### PR TITLE
Rename addDocument method to addDocuments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ atlassian-ide-plugin.xml
 # oh-my-zsh gradle plugin
 .gradletasknamecache
 
+.vscode

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ public class TestApp {
         jsonArray.add(jsonObject);
 
         // add new document "[{"1111": "alice in wonderland"}]"
-        String response = book.addDocument(jsonObject.toString());
+        String response = book.addDocuments(jsonObject.toString());
 
         // response : "{ "updateId": 0 }"
     }

--- a/src/main/java/meilisearch/Documents.java
+++ b/src/main/java/meilisearch/Documents.java
@@ -25,7 +25,7 @@ class Documents {
 		return meilisearchHttpRequest.get(requestQuery);
 	}
 
-	String addDocument(String uid, String document) throws Exception {
+	String addDocuments(String uid, String document) throws Exception {
 		String requestQuery = "/indexes/" + uid + "/documents";
 		return meilisearchHttpRequest.post(requestQuery, document);
 	}

--- a/src/main/java/meilisearch/Index.java
+++ b/src/main/java/meilisearch/Index.java
@@ -80,8 +80,8 @@ public class Index implements Serializable {
 	 * @return Meilisearch API response
 	 * @throws Exception If something goes wrong
 	 */
-	public String addDocument(String document) throws Exception {
-		return this.documents.addDocument(this.uid, document);
+	public String addDocuments(String document) throws Exception {
+		return this.documents.addDocuments(this.uid, document);
 	}
 
 	/**


### PR DESCRIPTION
The HTTP API for indexing documents takes always a JSON array of documents as a parameter, either if you want to index a single document or a batch. In which case we should probably expose just a single method for both, and rename it in its plural way as `addDocuments(...)` :)

Closes #26 