### PR TITLE
abstract away everything related to http 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ java {
 repositories {
 	// Use jcenter for resolving dependencies.
 	// You can declare any Maven/Ivy/file repository here.
-	jcenter()
 	mavenCentral()  // Required for Lombok dependency
+	jcenter()
 }
 
 dependencies {
@@ -37,6 +37,11 @@ dependencies {
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.7.0'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
+	// https://mvnrepository.com/artifact/org.mockito/mockito-core
+	testImplementation 'org.mockito:mockito-core:3.5.13'
+	testImplementation 'org.hamcrest:hamcrest:2.2'
+	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
+	testCompile group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0.2'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.12'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,8 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.8.6'
 	implementation 'org.json:json:20200518'
 	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-	compileOnly group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0.2'
+	compileOnly group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0.3'
+	compileOnly 'com.squareup.okhttp3:okhttp:4.9.0'
 
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.7.0'))

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 	jcenter()
 }
 
+configurations {
+	testCompile.extendsFrom compileOnly
+}
+
 dependencies {
 	// This dependency is used internally, and not exposed to consumers on their own compile classpath.
 	implementation 'com.google.guava:guava:29.0-jre'
@@ -40,8 +44,6 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation 'org.mockito:mockito-core:3.5.13'
 	testImplementation 'org.hamcrest:hamcrest:2.2'
-	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-	testCompile group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0.2'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.12'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation 'com.google.guava:guava:29.0-jre'
 	implementation 'com.google.code.gson:gson:2.8.6'
 	implementation 'org.json:json:20200518'
+	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
+	compileOnly group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0.2'
+
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.7.0'))
 	testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/com/meilisearch/sdk/Config.java
+++ b/src/main/java/com/meilisearch/sdk/Config.java
@@ -26,4 +26,12 @@ public class Config {
 		this.hostUrl = hostUrl;
 		this.apiKey = apiKey;
 	}
+
+	public String getHostUrl() {
+		return hostUrl;
+	}
+
+	public String getApiKey() {
+		return apiKey;
+	}
 }

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -6,7 +6,6 @@ import com.meilisearch.sdk.http.request.BasicHttpRequest;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 class MeiliSearchHttpRequest {
@@ -25,27 +24,26 @@ class MeiliSearchHttpRequest {
 		return this.get(api, "");
 	}
 
-
 	String get(String api, String param) throws Exception {
 		HttpResponse<?> httpResponse = this.client.get(new BasicHttpRequest(HttpMethod.GET, api + param, Collections.emptyMap(), null));
-		return Arrays.toString(httpResponse.getContentAsBytes());
+		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String post(String api, String params) throws Exception {
 		HttpResponse<?> httpResponse = this.client.post(new BasicHttpRequest(HttpMethod.POST, api + params, Collections.emptyMap(), null));
-		return Arrays.toString(httpResponse.getContentAsBytes());
+		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String put(String api, String params) throws Exception {
 		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api + params, Collections.emptyMap(), null));
-		return Arrays.toString(httpResponse.getContentAsBytes());
+		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String delete(String api) throws Exception {
 		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api, Collections.emptyMap(), null));
-		return Arrays.toString(httpResponse.getContentAsBytes());
+		return new String(httpResponse.getContentAsBytes());
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -11,14 +11,14 @@ import java.util.Collections;
 
 class MeiliSearchHttpRequest {
 	private final AbstractHttpClient client;
-	private final RequestFactory<?> factory;
+	private final RequestFactory factory;
 
 	protected MeiliSearchHttpRequest(Config config) {
 		this.client = new DefaultHttpClient(config);
 		this.factory = new BasicRequestFactory();
 	}
 
-	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory<?> factory) {
+	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory factory) {
 		this.client = client;
 		this.factory = factory;
 	}
@@ -34,14 +34,14 @@ class MeiliSearchHttpRequest {
 	}
 
 
-	String post(String api, String params) throws Exception {
-		HttpResponse<?> httpResponse = this.client.post(factory.create(HttpMethod.POST, api + params, Collections.emptyMap(), null));
+	String post(String api, String body) throws Exception {
+		HttpResponse<?> httpResponse = this.client.post(factory.create(HttpMethod.POST, api, Collections.emptyMap(), body));
 		return new String(httpResponse.getContentAsBytes());
 	}
 
 
-	String put(String api, String params) throws Exception {
-		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.PUT, api + params, Collections.emptyMap(), null));
+	String put(String api, String body) throws Exception {
+		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.PUT, api, Collections.emptyMap(), body));
 		return new String(httpResponse.getContentAsBytes());
 	}
 

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -1,111 +1,51 @@
 package com.meilisearch.sdk;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.DefaultHttpClient;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.response.HttpResponse;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 class MeiliSearchHttpRequest {
-	private final Config config;
+	private final AbstractHttpClient client;
 
 	protected MeiliSearchHttpRequest(Config config) {
-		this.config = config;
+		this.client = new DefaultHttpClient(config);
 	}
 
-	/**
-	 * Create and get a validated HTTP connection to url with method and API key
-	 *
-	 * @param url    URL to connect to
-	 * @param method HTTP method to use for the connection
-	 * @param apiKey API Key to use for the connection
-	 * @return Validated connection (otherwise, will throw a {@link IOException})
-	 * @throws IOException If unable to establish connection
-	 */
-	private HttpURLConnection getConnection(final URL url, final String method, final String apiKey) throws IOException {
-		if (url == null || "".equals(method)) throw new IOException("Unable to open an HttpURLConnection with no URL or method");
-
-		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-		connection.setRequestMethod(method);
-		connection.setRequestProperty("Content-Type", "application/json");
-
-		// Use API key header only if one is provided
-		if (!"".equals(apiKey)) {
-			connection.setRequestProperty("X-Meili-API-Key", apiKey);
-		}
-
-		// Ensure connection is set
-		Optional<HttpURLConnection> connectionOptional = Optional.of(connection);
-		return connectionOptional.orElseThrow(IOException::new);
+	public MeiliSearchHttpRequest(AbstractHttpClient client) {
+		this.client = client;
 	}
 
 
-	private String parseConnectionResponse(HttpURLConnection connection) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
-		StringBuilder sb = new StringBuilder();
-		String responseLine;
-
-		while ((responseLine = br.readLine()) != null) {
-			sb.append(responseLine);
-		}
-
-		br.close();
-
-		return sb.toString();
-	}
-
-
-	String get(String api) throws Exception {
+	public String get(String api) throws Exception {
 		return this.get(api, "");
 	}
 
 
 	String get(String api, String param) throws Exception {
-		StringBuilder urlBuilder = new StringBuilder(config.hostUrl + api);
-		if (!param.equals("")) {
-			urlBuilder.append(param);
-		}
-
-		URL url = new URL(urlBuilder.toString());
-		HttpURLConnection connection = this.getConnection(url, "GET", this.config.apiKey);
-
-		return this.parseConnectionResponse(connection);
+		HttpResponse<?> httpResponse = this.client.get(new BasicHttpRequest(HttpMethod.GET, api + param, Collections.emptyMap(), null));
+		return Arrays.toString(httpResponse.getContentAsBytes());
 	}
 
 
-	String post(String api, String params) throws IOException {
-		URL url = new URL(config.hostUrl + api);
-
-		HttpURLConnection connection = this.getConnection(url, "POST", config.apiKey);
-		connection.setDoOutput(true);
-		connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-		connection.setRequestProperty("Content-Length", String.valueOf(params.length()));
-		connection.getOutputStream().write(params.getBytes(StandardCharsets.UTF_8));
-		connection.connect();
-
-		return this.parseConnectionResponse(connection);
+	String post(String api, String params) throws Exception {
+		HttpResponse<?> httpResponse = this.client.post(new BasicHttpRequest(HttpMethod.POST, api + params, Collections.emptyMap(), null));
+		return Arrays.toString(httpResponse.getContentAsBytes());
 	}
 
 
 	String put(String api, String params) throws Exception {
-		URL url = new URL(config.hostUrl + api);
-
-		HttpURLConnection connection = this.getConnection(url, "PUT", config.apiKey);
-		connection.setDoOutput(true);
-		connection.getOutputStream().write(params.getBytes());
-		connection.connect();
-
-		return this.parseConnectionResponse(connection);
+		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api + params, Collections.emptyMap(), null));
+		return Arrays.toString(httpResponse.getContentAsBytes());
 	}
 
 
 	String delete(String api) throws Exception {
-		URL url = new URL(config.hostUrl + api);
-
-		HttpURLConnection connection = this.getConnection(url, "DELETE", config.apiKey);
-		connection.connect();
-		return this.parseConnectionResponse(connection);
+		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api, Collections.emptyMap(), null));
+		return Arrays.toString(httpResponse.getContentAsBytes());
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -2,7 +2,8 @@ package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.DefaultHttpClient;
-import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
 
@@ -10,13 +11,16 @@ import java.util.Collections;
 
 class MeiliSearchHttpRequest {
 	private final AbstractHttpClient client;
+	private final RequestFactory<?> factory;
 
 	protected MeiliSearchHttpRequest(Config config) {
 		this.client = new DefaultHttpClient(config);
+		this.factory = new BasicRequestFactory();
 	}
 
-	public MeiliSearchHttpRequest(AbstractHttpClient client) {
+	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory<?> factory) {
 		this.client = client;
+		this.factory = factory;
 	}
 
 
@@ -25,25 +29,25 @@ class MeiliSearchHttpRequest {
 	}
 
 	String get(String api, String param) throws Exception {
-		HttpResponse<?> httpResponse = this.client.get(new BasicHttpRequest(HttpMethod.GET, api + param, Collections.emptyMap(), null));
+		HttpResponse<?> httpResponse = this.client.get(factory.create(HttpMethod.GET, api + param, Collections.emptyMap(), null));
 		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String post(String api, String params) throws Exception {
-		HttpResponse<?> httpResponse = this.client.post(new BasicHttpRequest(HttpMethod.POST, api + params, Collections.emptyMap(), null));
+		HttpResponse<?> httpResponse = this.client.post(factory.create(HttpMethod.POST, api + params, Collections.emptyMap(), null));
 		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String put(String api, String params) throws Exception {
-		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api + params, Collections.emptyMap(), null));
+		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.PUT, api + params, Collections.emptyMap(), null));
 		return new String(httpResponse.getContentAsBytes());
 	}
 
 
 	String delete(String api) throws Exception {
-		HttpResponse<?> httpResponse = this.client.put(new BasicHttpRequest(HttpMethod.PUT, api, Collections.emptyMap(), null));
+		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.DELETE, api, Collections.emptyMap(), null));
 		return new String(httpResponse.getContentAsBytes());
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/AbstractHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/AbstractHttpClient.java
@@ -1,0 +1,8 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.HttpResponse;
+
+@SuppressWarnings("java:S1610")
+public abstract class AbstractHttpClient implements HttpClient<HttpRequest<?>, HttpResponse<?>> {
+}

--- a/src/main/java/com/meilisearch/sdk/http/AbstractHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/AbstractHttpClient.java
@@ -1,8 +1,13 @@
 package com.meilisearch.sdk.http;
 
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.http.response.HttpResponse;
 
-@SuppressWarnings("java:S1610")
 public abstract class AbstractHttpClient implements HttpClient<HttpRequest<?>, HttpResponse<?>> {
+	protected final Config config;
+
+	public AbstractHttpClient(Config config) {
+		this.config = config;
+	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.http;
 
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.http.response.BasicHttpResponse;
 import com.meilisearch.sdk.http.response.HttpResponse;
@@ -25,18 +26,21 @@ import java.util.stream.Collectors;
 public class ApacheHttpClient extends AbstractHttpClient {
 
 	private final HttpAsyncClient client;
+	private final Config config;
 
-	public ApacheHttpClient() {
+	public ApacheHttpClient(Config config) {
 		final IOReactorConfig ioReactorConfig = IOReactorConfig.custom()
 			.setSoTimeout(Timeout.ofSeconds(5))
 			.build();
 
-		client = HttpAsyncClients.custom()
+		this.client = HttpAsyncClients.custom()
 			.setIOReactorConfig(ioReactorConfig)
 			.build();
+		this.config = config;
 	}
 
-	public ApacheHttpClient(HttpAsyncClient client) {
+	public ApacheHttpClient(Config config, HttpAsyncClient client) {
+		this.config = config;
 		this.client = client;
 	}
 
@@ -76,6 +80,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
 	private SimpleHttpRequest mapRequest(HttpRequest<?> request) {
 		SimpleHttpRequest httpRequest = new SimpleHttpRequest(request.getMethod().name(), request.getPath());
 		httpRequest.setBody(request.getContentAsBytes(), ContentType.APPLICATION_JSON);
+		httpRequest.addHeader("X-Meili-API-Key", this.config.getApiKey());
 		return httpRequest;
 	}
 

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -27,9 +27,9 @@ import java.util.stream.Collectors;
 public class ApacheHttpClient extends AbstractHttpClient {
 
 	private final HttpAsyncClient client;
-	private final Config config;
 
 	public ApacheHttpClient(Config config) {
+		super(config);
 		final IOReactorConfig ioReactorConfig = IOReactorConfig.custom()
 			.setSoTimeout(Timeout.ofSeconds(5))
 			.build();
@@ -37,11 +37,10 @@ public class ApacheHttpClient extends AbstractHttpClient {
 		this.client = HttpAsyncClients.custom()
 			.setIOReactorConfig(ioReactorConfig)
 			.build();
-		this.config = config;
 	}
 
 	public ApacheHttpClient(Config config, HttpAsyncClient client) {
-		this.config = config;
+		super(config);
 		this.client = client;
 	}
 

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -1,11 +1,15 @@
 package com.meilisearch.sdk.http;
 
-import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.http.response.HttpResponse;
+import org.apache.hc.client5.http.async.HttpAsyncClient;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.NameValuePair;
@@ -17,9 +21,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-public class ApacheHttpClient implements HttpClient<BasicHttpRequest, BasicHttpResponse> {
 
-	private final CloseableHttpAsyncClient client;
+public class ApacheHttpClient extends AbstractHttpClient {
+
+	private final HttpAsyncClient client;
 
 	public ApacheHttpClient() {
 		final IOReactorConfig ioReactorConfig = IOReactorConfig.custom()
@@ -31,44 +36,50 @@ public class ApacheHttpClient implements HttpClient<BasicHttpRequest, BasicHttpR
 			.build();
 	}
 
-	public ApacheHttpClient(CloseableHttpAsyncClient client) {
+	public ApacheHttpClient(HttpAsyncClient client) {
 		this.client = client;
 	}
 
 
-	private BasicHttpResponse execute(BasicHttpRequest request) throws ExecutionException, InterruptedException {
+	private HttpResponse<?> execute(HttpRequest<?> request) throws ExecutionException, InterruptedException {
 		CompletableFuture<SimpleHttpResponse> response = new CompletableFuture<>();
-		client.execute(mapRequest(request), getCallback(response));
+		client.execute(
+			SimpleRequestProducer.create(mapRequest(request)),
+			SimpleResponseConsumer.create(),
+			null,
+			HttpClientContext.create(),
+			getCallback(response)
+		);
 		return response.thenApply(this::mapResponse).get();
 	}
 
 	@Override
-	public BasicHttpResponse get(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> get(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse post(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> post(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse put(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> put(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse delete(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
-	private SimpleHttpRequest mapRequest(BasicHttpRequest request) {
+	private SimpleHttpRequest mapRequest(HttpRequest<?> request) {
 		SimpleHttpRequest httpRequest = new SimpleHttpRequest(request.getMethod().name(), request.getPath());
-		httpRequest.setBody(request.getContent(), ContentType.APPLICATION_JSON);
+		httpRequest.setBody(request.getContentAsBytes(), ContentType.APPLICATION_JSON);
 		return httpRequest;
 	}
 
-	private BasicHttpResponse mapResponse(SimpleHttpResponse response) {
+	private HttpResponse<?> mapResponse(SimpleHttpResponse response) {
 		return new BasicHttpResponse(
 			Arrays.stream(response.getHeaders()).collect(Collectors.toConcurrentMap(NameValuePair::getName, NameValuePair::getValue)),
 			response.getCode(),

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -99,7 +99,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
 	}
 
 	private FutureCallback<SimpleHttpResponse> getCallback(CompletableFuture<SimpleHttpResponse> completableFuture) {
-		return new FutureCallback<>() {
+		return new FutureCallback<SimpleHttpResponse>() {
 			@Override
 			public void completed(SimpleHttpResponse result) {
 				completableFuture.complete(result);

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -1,0 +1,97 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.util.Timeout;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+public class ApacheHttpClient implements HttpClient<BasicHttpRequest, BasicHttpResponse> {
+
+	private final CloseableHttpAsyncClient client;
+
+	public ApacheHttpClient() {
+		final IOReactorConfig ioReactorConfig = IOReactorConfig.custom()
+			.setSoTimeout(Timeout.ofSeconds(5))
+			.build();
+
+		client = HttpAsyncClients.custom()
+			.setIOReactorConfig(ioReactorConfig)
+			.build();
+	}
+
+	public ApacheHttpClient(CloseableHttpAsyncClient client) {
+		this.client = client;
+	}
+
+
+	private BasicHttpResponse execute(BasicHttpRequest request) throws ExecutionException, InterruptedException {
+		CompletableFuture<SimpleHttpResponse> response = new CompletableFuture<>();
+		client.execute(mapRequest(request), getCallback(response));
+		return response.thenApply(this::mapResponse).get();
+	}
+
+	@Override
+	public BasicHttpResponse get(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse post(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse put(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse delete(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	private SimpleHttpRequest mapRequest(BasicHttpRequest request) {
+		SimpleHttpRequest httpRequest = new SimpleHttpRequest(request.getMethod().name(), request.getPath());
+		httpRequest.setBody(request.getContent(), ContentType.APPLICATION_JSON);
+		return httpRequest;
+	}
+
+	private BasicHttpResponse mapResponse(SimpleHttpResponse response) {
+		return new BasicHttpResponse(
+			Arrays.stream(response.getHeaders()).collect(Collectors.toConcurrentMap(NameValuePair::getName, NameValuePair::getValue)),
+			response.getCode(),
+			response.getBodyText()
+		);
+	}
+
+	private FutureCallback<SimpleHttpResponse> getCallback(CompletableFuture<SimpleHttpResponse> completableFuture) {
+		return new FutureCallback<>() {
+			@Override
+			public void completed(SimpleHttpResponse result) {
+				completableFuture.complete(result);
+			}
+
+			@Override
+			public void failed(Exception ex) {
+				completableFuture.completeExceptionally(ex);
+			}
+
+			@Override
+			public void cancelled() {
+				completableFuture.cancel(true);
+			}
+		};
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -13,17 +13,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class OkHttpHttpClient extends AbstractHttpClient {
+public class CustomOkHttpClient extends AbstractHttpClient {
 	private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 	private static final RequestBody EMPTY_REQUEST_BODY = RequestBody.create("".getBytes());
 	private final OkHttpClient client;
 
-	public OkHttpHttpClient(Config config, OkHttpClient client) {
+	public CustomOkHttpClient(Config config, OkHttpClient client) {
 		super(config);
 		this.client = client;
 	}
 
-	public OkHttpHttpClient(Config config) {
+	public CustomOkHttpClient(Config config) {
 		super(config);
 		this.client = new OkHttpClient();
 	}

--- a/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
@@ -16,10 +16,8 @@ import java.util.stream.Collectors;
 
 public class DefaultHttpClient extends AbstractHttpClient {
 
-	private final Config config;
-
 	public DefaultHttpClient(Config config) {
-		this.config = config;
+		super(config);
 	}
 
 	/**

--- a/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
@@ -1,0 +1,80 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class DefaultHttpClient implements HttpClient<BasicHttpRequest, BasicHttpResponse> {
+
+	private final Config config;
+
+	public DefaultHttpClient(Config config) {
+		this.config = config;
+	}
+
+	/**
+	 * Create and get a validated HTTP connection to url with method and API key
+	 *
+	 * @param url    URL to connect to
+	 * @param method HTTP method to use for the connection
+	 * @param apiKey API Key to use for the connection
+	 * @return Validated connection (otherwise, will throw a {@link IOException})
+	 * @throws IOException If unable to establish connection
+	 */
+	private HttpURLConnection getConnection(final URL url, final String method, final String apiKey) throws IOException {
+		if (url == null || "".equals(method)) throw new IOException("Unable to open an HttpURLConnection with no URL or method");
+
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		connection.setRequestMethod(method);
+		connection.setRequestProperty("Content-Type", "application/json");
+
+		// Use API key header only if one is provided
+		if (!"".equals(apiKey)) {
+			connection.setRequestProperty("X-Meili-API-Key", apiKey);
+		}
+
+		// Ensure connection is set
+		Optional<HttpURLConnection> connectionOptional = Optional.of(connection);
+		return connectionOptional.orElseThrow(IOException::new);
+	}
+
+	private BasicHttpResponse execute(BasicHttpRequest request) throws IOException {
+		URL url = new URL(this.config.getHostUrl() + request.getPath());
+		HttpURLConnection connection = this.getConnection(url, request.getMethod().name(), this.config.getApiKey());
+
+		return new BasicHttpResponse(
+			Collections.emptyMap(),
+			connection.getResponseCode(),
+			new BufferedReader(new InputStreamReader(connection.getInputStream())).lines().collect(Collectors.joining("\n"))
+		);
+	}
+
+	@Override
+	public BasicHttpResponse get(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse post(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse put(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+
+	@Override
+	public BasicHttpResponse delete(BasicHttpRequest request) throws Exception {
+		return execute(request);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
@@ -1,8 +1,9 @@
 package com.meilisearch.sdk.http;
 
 import com.meilisearch.sdk.Config;
-import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.http.response.HttpResponse;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -13,7 +14,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class DefaultHttpClient implements HttpClient<BasicHttpRequest, BasicHttpResponse> {
+public class DefaultHttpClient extends AbstractHttpClient {
 
 	private final Config config;
 
@@ -47,7 +48,7 @@ public class DefaultHttpClient implements HttpClient<BasicHttpRequest, BasicHttp
 		return connectionOptional.orElseThrow(IOException::new);
 	}
 
-	private BasicHttpResponse execute(BasicHttpRequest request) throws IOException {
+	private HttpResponse<?> execute(HttpRequest<?> request) throws IOException {
 		URL url = new URL(this.config.getHostUrl() + request.getPath());
 		HttpURLConnection connection = this.getConnection(url, request.getMethod().name(), this.config.getApiKey());
 
@@ -59,22 +60,22 @@ public class DefaultHttpClient implements HttpClient<BasicHttpRequest, BasicHttp
 	}
 
 	@Override
-	public BasicHttpResponse get(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> get(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse post(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> post(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse put(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> put(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 
 	@Override
-	public BasicHttpResponse delete(BasicHttpRequest request) throws Exception {
+	public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
 		return execute(request);
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/HttpClient.java
@@ -1,0 +1,14 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.HttpResponse;
+
+public interface HttpClient<T extends HttpRequest<?>, R extends HttpResponse<?>> {
+	R get(T request) throws Exception;
+
+	R post(T request) throws Exception;
+
+	R put(T request) throws Exception;
+
+	R delete(T request) throws Exception;
+}

--- a/src/main/java/com/meilisearch/sdk/http/OkHttpHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/OkHttpHttpClient.java
@@ -1,0 +1,114 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.http.response.HttpResponse;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OkHttpHttpClient extends AbstractHttpClient {
+	private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+	private static final RequestBody EMPTY_REQUEST_BODY = RequestBody.create("".getBytes());
+	private final OkHttpClient client;
+
+	public OkHttpHttpClient(Config config, OkHttpClient client) {
+		super(config);
+		this.client = client;
+	}
+
+	public OkHttpHttpClient(Config config) {
+		super(config);
+		this.client = new OkHttpClient();
+	}
+
+	private RequestBody getBodyFromRequest(HttpRequest<?> request) {
+		if (request.hasContent())
+			return RequestBody.create(request.getContentAsBytes(), JSON);
+		return EMPTY_REQUEST_BODY;
+	}
+
+	private Request buildRequest(HttpRequest<?> request) throws MalformedURLException {
+		URL url = new URL(this.config.getHostUrl() + request.getPath());
+		Request.Builder builder = new Request.Builder();
+		builder.url(url);
+		if (this.config.getApiKey() != null)
+			builder.addHeader("X-Meili-API-Key", this.config.getApiKey());
+		switch (request.getMethod()) {
+			case GET:
+				builder.get();
+				break;
+			case POST:
+				builder.post(getBodyFromRequest(request));
+				break;
+			case PUT:
+				builder.put(getBodyFromRequest(request));
+				break;
+			case DELETE:
+				if (request.hasContent())
+					builder.delete(getBodyFromRequest(request));
+				else
+					builder.delete();
+				break;
+			default:
+				throw new IllegalStateException("Unexpected value: " + request.getMethod());
+		}
+
+		return builder.build();
+	}
+
+	private HttpResponse<?> buildResponse(Response response) throws IOException {
+		String body = null;
+		ResponseBody responseBody = response.body();
+		if (responseBody != null)
+			body = responseBody.string();
+
+		return new BasicHttpResponse(
+			parseHeaders(response.headers().toMultimap()),
+			response.code(),
+			body
+		);
+	}
+
+	private Map<String, String> parseHeaders(Map<String, List<String>> headers) {
+		HashMap<String, String> headerMap = new HashMap<>();
+		for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+			headerMap.put(entry.getKey(), String.join("; ", entry.getValue()));
+		}
+		return headerMap;
+	}
+
+	@Override
+	public HttpResponse<?> get(HttpRequest<?> request) throws Exception {
+		Request okRequest = buildRequest(request);
+		Response execute = client.newCall(okRequest).execute();
+		return buildResponse(execute);
+	}
+
+	@Override
+	public HttpResponse<?> post(HttpRequest<?> request) throws Exception {
+		Request okRequest = buildRequest(request);
+		Response execute = client.newCall(okRequest).execute();
+		return buildResponse(execute);
+	}
+
+	@Override
+	public HttpResponse<?> put(HttpRequest<?> request) throws Exception {
+		Request okRequest = buildRequest(request);
+		Response execute = client.newCall(okRequest).execute();
+		return buildResponse(execute);
+	}
+
+	@Override
+	public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
+		Request okRequest = buildRequest(request);
+		Response execute = client.newCall(okRequest).execute();
+		return buildResponse(execute);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -1,0 +1,14 @@
+package com.meilisearch.sdk.http.factory;
+
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.request.HttpRequest;
+
+import java.util.Map;
+
+public class BasicRequestFactory implements RequestFactory<String> {
+	@Override
+	public HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, String content) {
+		return new BasicHttpRequest(method,path,headers,content);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -6,9 +6,10 @@ import com.meilisearch.sdk.http.request.HttpRequest;
 
 import java.util.Map;
 
-public class BasicRequestFactory implements RequestFactory<String> {
+public class BasicRequestFactory implements RequestFactory {
 	@Override
-	public HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, String content) {
-		return new BasicHttpRequest(method,path,headers,content);
+	public <T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content) {
+		//todo integrate serializer for content
+		return new BasicHttpRequest(method, path, headers, (String) content);
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/factory/RequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/RequestFactory.java
@@ -1,0 +1,11 @@
+package com.meilisearch.sdk.http.factory;
+
+
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.request.HttpRequest;
+
+import java.util.Map;
+
+public interface RequestFactory<T> {
+	HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content);
+}

--- a/src/main/java/com/meilisearch/sdk/http/factory/RequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/RequestFactory.java
@@ -6,6 +6,6 @@ import com.meilisearch.sdk.http.request.HttpRequest;
 
 import java.util.Map;
 
-public interface RequestFactory<T> {
-	HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content);
+public interface RequestFactory {
+	<T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content);
 }

--- a/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
@@ -49,6 +49,11 @@ public class BasicHttpRequest implements HttpRequest<String> {
 	}
 
 	@Override
+	public boolean hasContent() {
+		return content != null;
+	}
+
+	@Override
 	public String getContent() {
 		return content;
 	}

--- a/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
@@ -1,0 +1,45 @@
+package com.meilisearch.sdk.http.request;
+
+import java.util.Map;
+
+public class BasicHttpRequest implements HttpRequest<String> {
+	private HttpMethod method;
+	private String path;
+	private Map<String, String> headers;
+	private String content;
+
+	@Override
+	public HttpMethod getMethod() {
+		return this.method;
+	}
+
+	@Override
+	public void setMethod(HttpMethod method) {
+		this.method = method;
+	}
+
+	@Override
+	public String getPath() {
+		return this.path;
+	}
+
+	@Override
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	@Override
+	public Map<String, String> getHeaders() {
+		return this.headers;
+	}
+
+	@Override
+	public void setHeaders(Map<String, String> headers) {
+		this.headers = headers;
+	}
+
+	@Override
+	public String getContent() {
+		return content;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/BasicHttpRequest.java
@@ -8,6 +8,16 @@ public class BasicHttpRequest implements HttpRequest<String> {
 	private Map<String, String> headers;
 	private String content;
 
+	public BasicHttpRequest() {
+	}
+
+	public BasicHttpRequest(HttpMethod method, String path, Map<String, String> headers, String content) {
+		this.method = method;
+		this.path = path;
+		this.headers = headers;
+		this.content = content;
+	}
+
 	@Override
 	public HttpMethod getMethod() {
 		return this.method;
@@ -41,5 +51,10 @@ public class BasicHttpRequest implements HttpRequest<String> {
 	@Override
 	public String getContent() {
 		return content;
+	}
+
+	@Override
+	public byte[] getContentAsBytes() {
+		return content.getBytes();
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
@@ -1,0 +1,5 @@
+package com.meilisearch.sdk.http.request;
+
+public enum HttpMethod {
+	HEAD, GET, POST, PUT, DELETE
+}

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
@@ -16,4 +16,6 @@ public interface HttpRequest<T> {
 	void setHeaders(Map<String, String> headers);
 
 	T getContent();
+
+	byte[] getContentAsBytes();
 }

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
@@ -15,6 +15,8 @@ public interface HttpRequest<T> {
 
 	void setHeaders(Map<String, String> headers);
 
+	boolean hasContent();
+
 	T getContent();
 
 	byte[] getContentAsBytes();

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpRequest.java
@@ -1,0 +1,19 @@
+package com.meilisearch.sdk.http.request;
+
+import java.util.Map;
+
+public interface HttpRequest<T> {
+	HttpMethod getMethod();
+
+	void setMethod(HttpMethod method);
+
+	String getPath();
+
+	void setPath(String path);
+
+	Map<String, String> getHeaders();
+
+	void setHeaders(Map<String, String> headers);
+
+	T getContent();
+}

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
@@ -24,6 +24,11 @@ public class BasicHttpResponse implements HttpResponse<String> {
 	}
 
 	@Override
+	public boolean hasContent() {
+		return content != null;
+	}
+
+	@Override
 	public String getContent() {
 		return content;
 	}

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
@@ -27,4 +27,9 @@ public class BasicHttpResponse implements HttpResponse<String> {
 	public String getContent() {
 		return content;
 	}
+
+	@Override
+	public byte[] getContentAsBytes() {
+		return content.getBytes();
+	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicHttpResponse.java
@@ -1,0 +1,30 @@
+package com.meilisearch.sdk.http.response;
+
+import java.util.Map;
+
+public class BasicHttpResponse implements HttpResponse<String> {
+	private final Map<String, String> headers;
+	private final int statusCode;
+	private final String content;
+
+	public BasicHttpResponse(Map<String, String> headers, int statusCode, String content) {
+		this.headers = headers;
+		this.statusCode = statusCode;
+		this.content = content;
+	}
+
+	@Override
+	public Map<String, String> getHeaders() {
+		return headers;
+	}
+
+	@Override
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	@Override
+	public String getContent() {
+		return content;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
@@ -1,0 +1,11 @@
+package com.meilisearch.sdk.http.response;
+
+import java.util.Map;
+
+public interface HttpResponse<B> {
+	Map<String, String> getHeaders();
+
+	int getStatusCode();
+
+	B getContent();
+}

--- a/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
@@ -7,6 +7,8 @@ public interface HttpResponse<B> {
 
 	int getStatusCode();
 
+	boolean hasContent();
+
 	B getContent();
 
 	byte[] getContentAsBytes();

--- a/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
@@ -8,4 +8,6 @@ public interface HttpResponse<B> {
 	int getStatusCode();
 
 	B getContent();
+
+	byte[] getContentAsBytes();
 }

--- a/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
@@ -1,0 +1,161 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import org.apache.hc.client5.http.async.HttpAsyncClient;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ApacheHttpClientTest {
+	private final Config config = new Config("http://localhost:7700", "masterKey");
+	private final HttpAsyncClient client = mock(HttpAsyncClient.class);
+	private final ApacheHttpClient classToTest = new ApacheHttpClient(config, client);
+
+	private final ArrayDeque<SimpleHttpRequest> requestQueue = new ArrayDeque<>();
+	private final ArrayDeque<SimpleHttpResponse> responseQueue = new ArrayDeque<>();
+
+	@BeforeEach
+	void setUp() {
+		when(client.execute(any(), any(), any(), any(), any())).then(invocation -> {
+			SimpleRequestProducer argument = invocation.getArgument(0);
+			Field requestField = BasicRequestProducer.class.getDeclaredField("request");
+			requestField.setAccessible(true);
+			SimpleHttpRequest request = (SimpleHttpRequest) requestField.get(argument);
+			requestQueue.push(request);
+			SimpleHttpResponse polledResponse = responseQueue.poll();
+			//noinspection unchecked
+			((FutureCallback<SimpleHttpResponse>) invocation.getArgument(4)).completed(polledResponse);
+			return CompletableFuture.completedFuture(polledResponse);
+		});
+	}
+
+	@AfterEach
+	void tearDown() {
+		requestQueue.clear();
+		responseQueue.clear();
+		reset(client);
+	}
+
+	@Test
+	void get() throws Exception {
+		SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(200, "some body", ContentType.APPLICATION_JSON);
+		responseQueue.push(expectedResponse);
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.GET, "/test", Collections.emptyMap(), "thisisabody");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.get(request);
+
+		assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
+		assertThat(response.getContentAsBytes(), equalTo(expectedResponse.getBodyBytes()));
+
+		SimpleHttpRequest expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.getBodyText(), equalTo(request.getContent()));
+		assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
+	}
+
+	@Test
+	void post() throws Exception {
+		SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(200, "some body", ContentType.APPLICATION_JSON);
+		responseQueue.push(expectedResponse);
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.POST, "/test", Collections.emptyMap(), "thisisabody");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.post(request);
+
+		assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
+		assertThat(response.getContentAsBytes(), equalTo(expectedResponse.getBodyBytes()));
+
+		SimpleHttpRequest expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.getBodyText(), equalTo(request.getContent()));
+		assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
+	}
+
+	@Test
+	void put() throws Exception {
+		SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(200, "some body", ContentType.APPLICATION_JSON);
+		responseQueue.push(expectedResponse);
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.PUT, "/test", Collections.emptyMap(), "thisisabody");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.put(request);
+
+		assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
+		assertThat(response.getContentAsBytes(), equalTo(expectedResponse.getBodyBytes()));
+
+		SimpleHttpRequest expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.getBodyText(), equalTo(request.getContent()));
+		assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
+	}
+
+	@Test
+	void delete() throws Exception {
+		SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(204);
+		responseQueue.push(expectedResponse);
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.DELETE, "/test", Collections.emptyMap(), null);
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.delete(request);
+
+		assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
+		assertThat(response.hasContent(), equalTo(false));
+
+		SimpleHttpRequest expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
+	}
+
+	@Test
+	void withCancelledRequest() {
+		reset(client);
+		when(client.execute(any(), any(), any(), any(), any())).then(invocation -> {
+			((FutureCallback<SimpleHttpResponse>) invocation.getArgument(4)).cancelled();
+			return CompletableFuture.completedFuture(null);
+		});
+
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.GET, "/test", Collections.emptyMap(), "thisisabody");
+		Exception exception = assertThrows(Exception.class, () -> classToTest.get(request),"");
+		assertThat(findRootCause(exception).getClass(), equalTo(CancellationException.class));
+	}
+
+	@Test
+	void withException() {
+		reset(client);
+		when(client.execute(any(), any(), any(), any(), any())).then(invocation -> {
+			((FutureCallback<SimpleHttpResponse>) invocation.getArgument(4)).failed(new Exception("BOOM!"));
+			return CompletableFuture.completedFuture(null);
+		});
+
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.GET, "/test", Collections.emptyMap(), "thisisabody");
+		Exception exception = assertThrows(Exception.class, () -> classToTest.get(request),"");
+		assertThat(findRootCause(exception).getClass(), equalTo(Exception.class));
+	}
+
+	public Throwable findRootCause(Throwable throwable) {
+		Throwable rootCause = throwable;
+		while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+			rootCause = rootCause.getCause();
+		}
+		return rootCause;
+	}
+}

--- a/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
@@ -1,0 +1,164 @@
+package com.meilisearch.sdk.http;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import okhttp3.*;
+import okhttp3.internal.connection.RealCall;
+import okio.Buffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CustomOkHttpClientTest {
+	private final Config config = new Config("http://localhost:7700", "masterKey");
+	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final CustomOkHttpClient classToTest = new CustomOkHttpClient(config, client);
+
+	private final ArrayDeque<Request> requestQueue = new ArrayDeque<>();
+	private final ArrayDeque<Response> responseQueue = new ArrayDeque<>();
+	private final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+	@BeforeEach
+	void setUp() {
+		RealCall mockCall = mock(RealCall.class);
+		when(client.newCall(any())).thenAnswer(invocation -> {
+			Request request = invocation.getArgument(0);
+			requestQueue.push(request);
+
+			Response ok = new Response.Builder()
+				.request(request)
+				.protocol(Protocol.HTTP_1_1)
+				.message("OK")
+				.code(200)
+				.headers(request.headers())
+				.body(ResponseBody.create(readBody(request.body()), JSON))
+				.build();
+
+			responseQueue.push(ok);
+
+			return mockCall;
+		});
+		when(mockCall.execute()).then(invocation -> responseQueue.poll());
+	}
+
+	@AfterEach
+	void tearDown() {
+		requestQueue.clear();
+		responseQueue.clear();
+		reset(client);
+	}
+
+	private String readBody(RequestBody body) {
+		if (body == null) {
+			return "";
+		}
+		Buffer buffer = new Buffer();
+		try {
+			body.writeTo(buffer);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return new BufferedReader(new InputStreamReader(buffer.inputStream())).lines().collect(Collectors.joining());
+	}
+
+	@Test
+	void get() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.GET, "/test", Collections.emptyMap(), "some body");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.get(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+	}
+
+	@Test
+	void post() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.POST, "/test", Collections.emptyMap(), "some body");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.post(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+		assertThat(response.getContent(), equalTo(request.getContent()));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(request.getContent(), equalTo(readBody(expectedRequest.body())));
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+
+	}
+
+	@Test
+	void postWithoutBody() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.POST, "/test", Collections.emptyMap(), null);
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.post(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+		assertThat(response.getContent(), equalTo(""));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(readBody(expectedRequest.body()), equalTo(""));
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+
+	}
+
+	@Test
+	void put() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.PUT, "/test", Collections.emptyMap(), "some body");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.put(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+		assertThat(response.getContent(), equalTo(request.getContent()));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(request.getContent(), equalTo(readBody(expectedRequest.body())));
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+	}
+
+	@Test
+	void delete() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.DELETE, "/test", Collections.emptyMap(), "some body");
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.delete(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+	}
+
+	@Test
+	void deleteWithoutBody() throws Exception {
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.DELETE, "/test", Collections.emptyMap(), null);
+		BasicHttpResponse response = (BasicHttpResponse) classToTest.delete(request);
+
+		assertThat(response.getStatusCode(), equalTo(200));
+
+		Request expectedRequest = requestQueue.poll();
+		assertThat(expectedRequest, notNullValue());
+		assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+		assertThat(expectedRequest.url().toString(), equalTo(this.config.getHostUrl() + request.getPath()));
+	}
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR abstracts away everything to do with http requests.
This way we can change the underlying http client without the need for a full rewrite.

Most of the former MeiliSearchHttpRequest class moved into the DefaultHttpClient, turning MeiliSearchHttpRequest into a wrapper to not break existing code.

ApacheHttpClient is a HttpClient basend on the Apache HttpComponents library. I added the Library as a compiletime dependency. This way it doesn't get bundled in the final jar.

RequestFactory is an abstraction to make the request creation more flexible, just in case some special use case needs to overwrite the BasicHttpRequest that is used as a default request class.

Everything combined, the user could change the whole http stack without changes to the sdk code. 

Currently only MeiliSearchHttpRequest uses it. Long term it would be better to create a single Instance in the Client that is used by all created handlers.

This is also a candidate for #7 