### PR TITLE
GetUpdate returns a StatusUpdate instance instead of String

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -32,6 +32,8 @@ public class Index implements Serializable {
 	@ToString.Exclude
 	Documents documents;
 
+	Gson gson = new Gson();
+
 	/**
 	 * Set the Meilisearch configuration for the index
 	 *
@@ -124,8 +126,11 @@ public class Index implements Serializable {
 	 * @return Meilisearch API response
 	 * @throws Exception If something goes wrong
 	 */
-	public String getUpdate(int updateId) throws Exception {
-		return this.documents.getUpdate(this.uid, updateId);
+	public UpdateStatus getUpdate(int updateId) throws Exception {
+		return this.gson.fromJson(
+			this.documents.getUpdate(this.uid, updateId),
+			UpdateStatus.class
+		);
 	}
 
 	/**
@@ -135,8 +140,10 @@ public class Index implements Serializable {
 	 * @throws Exception If something goes wrong
 	 */
 	public UpdateStatus[] getUpdates() throws Exception {
-		Gson gson = new Gson();
-		return gson.fromJson(this.documents.getUpdates(this.uid), UpdateStatus[].class);
+		return this.gson.fromJson(
+			this.documents.getUpdates(this.uid),
+			UpdateStatus[].class
+		);
 	}
 
 	/**
@@ -160,7 +167,6 @@ public class Index implements Serializable {
 	 * @throws Exception if timeout is reached
 	 */
 	public void waitForPendingUpdate(int updateId, int timeoutInMs, int intervalInMs) throws Exception {
-		Gson gson = new Gson();
 		UpdateStatus updateStatus;
 		String status = "";
 		long startTime = new Date().getTime();
@@ -170,10 +176,7 @@ public class Index implements Serializable {
 			if (elapsedTime >= timeoutInMs){
 				throw new Exception();
 			}
-			updateStatus = gson.fromJson(
-				this.getUpdate(updateId), 
-				UpdateStatus.class
-			);
+			updateStatus = this.getUpdate(updateId);
 			status = updateStatus.getStatus();
 			Thread.sleep(intervalInMs);
 			elapsedTime = new Date().getTime() - startTime;

--- a/src/test/java/com/meilisearch/integration/IndexesTest.java
+++ b/src/test/java/com/meilisearch/integration/IndexesTest.java
@@ -101,11 +101,8 @@ public class IndexesTest extends AbstractIT {
 
 		index.waitForPendingUpdate(updateInfo.getUpdateId());
 
-		UpdateStatus updateStatus = this.gson.fromJson(
-			index.getUpdate(updateInfo.getUpdateId()),
-			UpdateStatus.class
-		);
-
+		UpdateStatus updateStatus = index.getUpdate(updateInfo.getUpdateId());
+		
 		assertEquals("processed", updateStatus.getStatus());
 
 		client.deleteIndex(index.getUid());


### PR DESCRIPTION
In current implementation, `getUpdates()` returns an array of UpdateStatus, but `getUpdate()` returns a String containing the server response. This PR makes this behavior consistent, by returning an `UpdateStatus` instance when `getUpdate()` is called