### PR TITLE
Upgrade graddle wrapper to gradle 6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 23 20:24:56 JST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Solve compatibility issue:

Error: "Could not initialize class org.codehaus.groovy.runtime.InvokerHelper" on JDK 14

See:
- Gradle issue https://github.com/gradle/gradle/issues/12599
- https://stackoverflow.com/questions/35000729/android-studio-could-not-initialize-class-org-codehaus-groovy-runtime-invokerhel