### PR TITLE
Refactor update index method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -106,8 +106,10 @@ public class Client {
 	 * @return Meilisearch API response
 	 * @throws Exception If an error occurs
 	 */
-	public String updateIndex(String uid, String primaryKey) throws Exception {
-		return this.indexesHandler.updatePrimaryKey(uid, primaryKey);
+	public Index updateIndex(String uid, String primaryKey) throws Exception {
+		Index index = gson.fromJson(this.indexesHandler.updatePrimaryKey(uid, primaryKey), Index.class);
+		index.setConfig(this.config);
+		return index;
 	}
 
 	/**

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -118,8 +118,8 @@ public class ClientTest extends AbstractIT {
 		Index index = client.createIndex(indexUid);
 		assertEquals(index.getUid(), indexUid);
 		assertNull(index.getPrimaryKey());
-		client.updateIndex(indexUid, this.primaryKey);
-		index = client.getIndex(indexUid);
+		index = client.updateIndex(indexUid, this.primaryKey);
+		assertTrue(index instanceof Index);
 		assertEquals(index.getUid(), indexUid);
 		assertEquals(index.getPrimaryKey(), this.primaryKey);
 		client.deleteIndex(index.getUid());


### PR DESCRIPTION
Closes #83 .
Now `updateIndex` returns an instance of Index, and `testUpdateIndexPrimaryKey()` makes sure that this happens.

I was also thinking in including `testUpdateIndexPrimaryKeyIfIndexDoesNotExists()` this test. But I think it's worth having a discussion about it first.
@eskombro and I agree that it should throw a `MeiliSearchApiException`, but what should `updatePrimaryKey` should return when the exception is thrown? Maybe It's worth returning an Optional<Index> for this method?