### PR TITLE
Remove warnings from Json Handling classes

### DIFF
--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -30,7 +30,7 @@ class GsonJsonHandlerTest {
 	@Test
 	void deserialize() {
 		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class));
-		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, null));
+		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, (Class<?>[]) null));
 		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, new Class[0]));
 	}
 
@@ -48,7 +48,7 @@ class GsonJsonHandlerTest {
 	@Test
 	@SuppressWarnings({"RedundantArrayCreation", "ConfusingArgumentToVarargsMethod"})
 	void deserializeWithParametersEmpty() throws Exception {
-		assertNotNull(classToTest.decode("{}", Movie.class, null));
+		assertNotNull(classToTest.decode("{}", Movie.class, (Class<?> []) null));
 		assertNotNull(classToTest.decode("{}", Movie.class, new Class[0]));
 	}
 

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -30,7 +30,7 @@ class JacksonJsonHandlerTest {
 	@Test
 	void deserialize() {
 		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class));
-		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, null));
+		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, (Class<?> []) null));
 		assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class, new Class[0]));
 	}
 
@@ -48,7 +48,7 @@ class JacksonJsonHandlerTest {
 	@Test
 	@SuppressWarnings({"RedundantArrayCreation", "ConfusingArgumentToVarargsMethod"})
 	void deserializeWithParametersEmpty() throws Exception {
-		assertNotNull(classToTest.decode("{}", Movie.class, null));
+		assertNotNull(classToTest.decode("{}", Movie.class, (Class<?> []) null));
 		assertNotNull(classToTest.decode("{}", Movie.class, new Class[0]));
 	}
 


### PR DESCRIPTION
Closes #72.

In order to remove the warnings from the classes `GsonJsonHandlerTest` and `JacksonJsonHandlerTest`. I implemented a cast in the `.decode()`  methods last parameter (null) to Class<?>[], this is because the method `.decode()` can return a generic, and in that case, the last argument is expecting a list of types to use with a generic.

TBH I don't know if this is the best approach, so in case it's not please let me know.