### PR TITLE
fix lombok version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ dependencies {
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.16'
-	annotationProcessor 'org.projectlombok:lombok:1.18.12'
-	testCompileOnly 'org.projectlombok:lombok:1.18.12'
-	testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+	annotationProcessor 'org.projectlombok:lombok:1.18.16'
+	testCompileOnly 'org.projectlombok:lombok:1.18.16'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
 }
 
 task buildJar(type: Jar) {


### PR DESCRIPTION
had some problems to get lombok running with intellij 2020.3 due to the version mismatch.