### PR TITLE
implement ServiceTemplate 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ dependencies {
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.16'
-	annotationProcessor 'org.projectlombok:lombok:1.18.12'
-	testCompileOnly 'org.projectlombok:lombok:1.18.12'
-	testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+	annotationProcessor 'org.projectlombok:lombok:1.18.16'
+	testCompileOnly 'org.projectlombok:lombok:1.18.16'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
 }
 
 task buildJar(type: Jar) {

--- a/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
+++ b/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
@@ -1,0 +1,107 @@
+package com.meilisearch.sdk;
+
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.HttpClient;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.HttpResponse;
+import com.meilisearch.sdk.json.JsonHandler;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class GenericServiceTemplate implements ServiceTemplate {
+	private final AbstractHttpClient client;
+	private final JsonHandler processor;
+	private final RequestFactory requestFactory;
+
+	/**
+	 * @param client         a {@link HttpClient}
+	 * @param processor      a {@link JsonHandler}
+	 * @param requestFactory a {@link RequestFactory}
+	 */
+	public GenericServiceTemplate(AbstractHttpClient client, JsonHandler processor, RequestFactory requestFactory) {
+		this.client = client;
+		this.processor = processor;
+		this.requestFactory = requestFactory;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AbstractHttpClient getClient() {
+		return client;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public JsonHandler getProcessor() {
+		return processor;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public RequestFactory getRequestFactory() {
+		return requestFactory;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T execute(HttpRequest<?> request, Class<?> targetClass, Class<?>... parameter) throws RuntimeException {
+		try {
+			if (targetClass == null) {
+				return (T) makeRequest(request);
+			}
+			return (T) CompletableFuture
+				.completedFuture(makeRequest(request))
+				.thenApply(httpResponse -> decodeResponse(httpResponse.getContent(), targetClass, parameter))
+				.get();
+		} catch (InterruptedException | ExecutionException e) {
+			Thread.currentThread().interrupt();
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	private <T> T decodeResponse(Object o, Class<?> targetClass, Class<?>... parameters) {
+		try {
+			return processor.decode(o, targetClass, parameters);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	/**
+	 * Executes the given {@link HttpRequest}
+	 *
+	 * @param request the {@link HttpRequest}
+	 * @return the HttpResponse
+	 * @throws MeiliSearchRuntimeException in case there are Problems with the Request, including error codes
+	 */
+	private HttpResponse<?> makeRequest(HttpRequest<?> request) {
+		try {
+			switch (request.getMethod()) {
+				case GET:
+					return client.get(request);
+				case POST:
+					return client.post(request);
+				case PUT:
+					return client.put(request);
+				case DELETE:
+					return client.delete(request);
+				default:
+					throw new IllegalStateException("Unexpected value: " + request.getMethod());
+			}
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/ServiceTemplate.java
+++ b/src/main/java/com/meilisearch/sdk/ServiceTemplate.java
@@ -1,0 +1,40 @@
+package com.meilisearch.sdk;
+
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.json.JsonHandler;
+
+/**
+ * A ServiceTemplate combines the HttpClient implementation with the JsonProcessor implementation and specifies how both work together.
+ */
+public interface ServiceTemplate {
+
+	/**
+	 * @return the wrapped HttpClient implementation
+	 */
+	AbstractHttpClient getClient();
+
+	/**
+	 * @return the wrapped JsonProcessor implementation
+	 */
+	JsonHandler getProcessor();
+
+	/**
+	 * @return the wrapped JsonProcessor implementation
+	 */
+	RequestFactory getRequestFactory();
+
+	/**
+	 * Executes the given request and deserializes the response
+	 *
+	 * @param request     the HttpRequest to execute
+	 * @param targetClass the Type of Object to deserialize
+	 * @param parameter   in case targetClass is a generic, parameter contains the specific types for the generic
+	 * @param <T>         type of targetClass or {@link com.meilisearch.sdk.http.response.HttpResponse} when targetClass is null
+	 * @return the deserialized response of type targetClass or the {@link com.meilisearch.sdk.http.response.HttpResponse} if targetClass is null
+	 * @throws MeiliSearchRuntimeException as a wrapper of API or JSON exceptions
+	 */
+	<T> T execute(HttpRequest<?> request, Class<?> targetClass, Class<?>... parameter) throws MeiliSearchRuntimeException;
+}

--- a/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchRuntimeException.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchRuntimeException.java
@@ -1,0 +1,7 @@
+package com.meilisearch.sdk.exceptions;
+
+public class MeiliSearchRuntimeException extends RuntimeException {
+	public MeiliSearchRuntimeException(Exception e) {
+		super(e);
+	}
+}

--- a/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
+++ b/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
@@ -1,0 +1,221 @@
+package com.meilisearch.sdk;
+
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.json.JsonHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GenericServiceTemplateTest {
+
+	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
+	private final JsonHandler handler = mock(JsonHandler.class);
+	private final GenericServiceTemplate classToTest = new GenericServiceTemplate(client, handler, new BasicRequestFactory());
+
+	@Test
+	void getClient() {
+		assertEquals(client, classToTest.getClient());
+	}
+
+	@Test
+	void getProcessor() {
+		assertEquals(handler, classToTest.getProcessor());
+	}
+
+	@Test
+	void executeGet() throws Exception {
+		when(client.get(any(BasicHttpRequest.class))).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		});
+		BasicHttpRequest request = new BasicHttpRequest(HttpMethod.GET, "/path", Collections.emptyMap(), null);
+		MockHttpResponse response = classToTest.execute(request, null);
+		assertEquals(request.getPath(), response.getRequestPath());
+		assertEquals(request.getHeaders(), response.getHeaders());
+	}
+
+	@Test
+	void executePost() throws Exception {
+		when(client.post(any())).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		}).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		});
+		BasicHttpRequest fullRequest = new BasicHttpRequest(HttpMethod.POST, "/path", Collections.emptyMap(), "content");
+		MockHttpResponse response = classToTest.execute(fullRequest, null);
+		assertEquals(fullRequest.getPath(), response.getRequestPath());
+		assertEquals(fullRequest.getContent(), response.getContent());
+		assertEquals(fullRequest.getHeaders(), response.getHeaders());
+
+		MockHttpRequest contentlessRequest = new MockHttpRequest(HttpMethod.POST, "/path", Collections.emptyMap(), null);
+		response = classToTest.execute(contentlessRequest, null);
+		assertEquals(contentlessRequest.getPath(), response.getRequestPath());
+		assertNull(response.getContent());
+		assertEquals(contentlessRequest.getHeaders(), response.getHeaders());
+	}
+
+	@Test
+	void executePut() throws Exception {
+		when(client.put(any())).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		}).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		});
+		BasicHttpRequest fullRequest = new BasicHttpRequest(HttpMethod.PUT, "/path", Collections.emptyMap(), "content");
+		MockHttpResponse response = classToTest.execute(fullRequest, null);
+		assertEquals(fullRequest.getPath(), response.getRequestPath());
+		assertEquals(fullRequest.getContent(), response.getContent());
+		assertEquals(fullRequest.getHeaders(), response.getHeaders());
+
+		MockHttpRequest contentlessRequest = new MockHttpRequest(HttpMethod.PUT, "/path", Collections.emptyMap(), null);
+		response = classToTest.execute(contentlessRequest, null);
+		assertEquals(contentlessRequest.getPath(), response.getRequestPath());
+		assertNull(response.getContent());
+		assertEquals(contentlessRequest.getHeaders(), response.getHeaders());
+	}
+
+	@Test
+	void executeDelete() throws Exception {
+		when(client.delete(any())).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		}).thenAnswer(invocationOnMock -> {
+			BasicHttpRequest request = invocationOnMock.getArgument(0);
+			return new MockHttpResponse(request.getPath(), request.getHeaders(), request.getContent());
+		});
+		BasicHttpRequest fullRequest = new BasicHttpRequest(HttpMethod.DELETE, "/path", Collections.emptyMap(), "content");
+		MockHttpResponse response = classToTest.execute(fullRequest, null);
+		assertEquals(fullRequest.getPath(), response.getRequestPath());
+		assertNotNull(response.getContent());
+		assertEquals(fullRequest.getHeaders(), response.getHeaders());
+
+		MockHttpRequest contentlessRequest = new MockHttpRequest(HttpMethod.DELETE, "/path", Collections.emptyMap(), null);
+		response = classToTest.execute(contentlessRequest, null);
+		assertEquals(contentlessRequest.getPath(), response.getRequestPath());
+		assertNull(response.getContent());
+		assertEquals(contentlessRequest.getHeaders(), response.getHeaders());
+	}
+
+	@Test
+	void defaultBranch() {
+		assertThrows(MeiliSearchRuntimeException.class, () -> classToTest.execute(new MockHttpRequest(HttpMethod.HEAD, null, null, null), null));
+	}
+
+	public static class MockHttpRequest extends BasicHttpRequest {
+		private HttpMethod method;
+		private String path;
+
+		private Map<String, String> headers;
+		private String content;
+
+		public MockHttpRequest(HttpMethod method, String path, Map<String, String> headers, String content) {
+			this.method = method;
+			this.path = path;
+			this.headers = headers;
+			this.content = content;
+		}
+
+		@Override
+		public HttpMethod getMethod() {
+			return method;
+		}
+
+		@Override
+		public void setMethod(HttpMethod method) {
+			this.method = method;
+		}
+
+		@Override
+		public String getPath() {
+			return path;
+		}
+
+		@Override
+		public void setPath(String path) {
+			this.path = path;
+		}
+
+		@Override
+		public Map<String, String> getHeaders() {
+			return headers;
+		}
+
+		@Override
+		public void setHeaders(Map<String, String> headers) {
+			this.headers = headers;
+		}
+
+		@Override
+		public boolean hasContent() {
+			return this.content == null || "".equals(this.content);
+		}
+
+		@Override
+		public String getContent() {
+			return this.content;
+		}
+
+		@Override
+		public byte[] getContentAsBytes() {
+			return new byte[0];
+		}
+	}
+
+	public static class MockHttpResponse extends BasicHttpResponse {
+
+		private final String requestPath;
+		private final Map<String, String> requestHeaders;
+		private final String requestBody;
+
+		public MockHttpResponse(String requestPath, Map<String, String> requestHeaders, String requestBody) {
+			super(requestHeaders, 200, requestBody);
+			this.requestPath = requestPath;
+			this.requestHeaders = requestHeaders;
+			this.requestBody = requestBody;
+		}
+
+		@Override
+		public Map<String, String> getHeaders() {
+			return requestHeaders;
+		}
+
+		@Override
+		public int getStatusCode() {
+			return 0;
+		}
+
+		@Override
+		public boolean hasContent() {
+			return requestBody == null || "".equals(requestBody);
+		}
+
+		@Override
+		public String getContent() {
+			return requestBody;
+		}
+
+		@Override
+		public byte[] getContentAsBytes() {
+			return new byte[0];
+		}
+
+		public String getRequestPath() {
+			return requestPath;
+		}
+	}
+}


### PR DESCRIPTION
⚠️ contains the changes of #91 

This PR introduces the "ServiceTemplate". While the HttpClient wraps how http calls are done and the JsonHandler wraps the (de-)serialization logic, the ServiceTemplate defines how these two abstractions work together. 

The GenericServiceTemplate defines the default behaviour for our Implementations. 
Make the Request -> deserialize the response -> return Response