### PR TITLE
add package version to Jupiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.7.0'))
-	testImplementation('org.junit.jupiter:junit-jupiter')
+	testImplementation('org.junit.jupiter:junit-jupiter:5.7.0')
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation 'org.mockito:mockito-core:3.7.7'
 	testImplementation 'org.hamcrest:hamcrest:2.2'


### PR DESCRIPTION
that fixes the dependencies.dependency.version missing error when adding our package to a project