### PR TITLE
improve ErrorHandling

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk;
 
+import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.DefaultHttpClient;
 import com.meilisearch.sdk.http.factory.BasicRequestFactory;
@@ -7,6 +8,7 @@ import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
 import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
+import com.meilisearch.sdk.json.GsonJsonHandler;
 
 import java.util.Collections;
 
@@ -16,6 +18,7 @@ import java.util.Collections;
 class MeiliSearchHttpRequest {
 	private final AbstractHttpClient client;
 	private final RequestFactory factory;
+	private final GsonJsonHandler jsonHandler;
 
 	/**
 	 * Constructor for the MeiliSearchHttpRequest
@@ -25,6 +28,7 @@ class MeiliSearchHttpRequest {
 	protected MeiliSearchHttpRequest(Config config) {
 		this.client = new DefaultHttpClient(config);
 		this.factory = new BasicRequestFactory();
+		this.jsonHandler = new GsonJsonHandler();
 	}
 
 	/**
@@ -36,6 +40,7 @@ class MeiliSearchHttpRequest {
 	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory factory) {
 		this.client = client;
 		this.factory = factory;
+		this.jsonHandler = new GsonJsonHandler();
 	}
 
 
@@ -63,7 +68,7 @@ class MeiliSearchHttpRequest {
 	String get(String api, String param) throws Exception, MeiliSearchApiException {
 		HttpResponse<?> httpResponse = this.client.get(factory.create(HttpMethod.GET, api + param, Collections.emptyMap(), null));
 		if (httpResponse.getStatusCode() >= 400) {
-			throw new MeiliSearchApiException(httpResponse.getContent().toString());
+			throw new MeiliSearchApiException(jsonHandler.decode(httpResponse.getContent(), APIError.class));
 		}
 		return new String(httpResponse.getContentAsBytes());
 	}
@@ -80,7 +85,7 @@ class MeiliSearchHttpRequest {
 	String post(String api, String body) throws Exception, MeiliSearchApiException {
 		HttpResponse<?> httpResponse = this.client.post(factory.create(HttpMethod.POST, api, Collections.emptyMap(), body));
 		if (httpResponse.getStatusCode() >= 400) {
-			throw new MeiliSearchApiException(httpResponse.getContent().toString());
+			throw new MeiliSearchApiException(jsonHandler.decode(httpResponse.getContent(), APIError.class));
 		}
 		return new String(httpResponse.getContentAsBytes());
 	}
@@ -97,7 +102,7 @@ class MeiliSearchHttpRequest {
 	String put(String api, String body) throws Exception, MeiliSearchApiException {
 		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.PUT, api, Collections.emptyMap(), body));
 		if (httpResponse.getStatusCode() >= 400) {
-			throw new MeiliSearchApiException(httpResponse.getContent().toString());
+			throw new MeiliSearchApiException(jsonHandler.decode(httpResponse.getContent(), APIError.class));
 		}
 		return new String(httpResponse.getContentAsBytes());
 	}
@@ -114,7 +119,7 @@ class MeiliSearchHttpRequest {
 	String delete(String api) throws Exception, MeiliSearchApiException {
 		HttpResponse<?> httpResponse = this.client.put(factory.create(HttpMethod.DELETE, api, Collections.emptyMap(), null));
 		if (httpResponse.getStatusCode() >= 400) {
-			throw new MeiliSearchApiException(httpResponse.getContent().toString());
+			throw new MeiliSearchApiException(jsonHandler.decode(httpResponse.getContent(), APIError.class));
 		}
 		return new String(httpResponse.getContentAsBytes());
 	}

--- a/src/main/java/com/meilisearch/sdk/exceptions/APIError.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/APIError.java
@@ -1,0 +1,48 @@
+package com.meilisearch.sdk.exceptions;
+
+import java.io.Serializable;
+
+/**
+ * This is class wraps errors sent by MeiliSearch API
+ */
+public class APIError implements Serializable {
+	private static final long serialVersionUID = 900737636809105793L;
+
+	private final String message;
+	private final String errorCode;
+	private final String errorType;
+	private final String errorLink;
+
+	public APIError(String message, String errorCode, String errorType, String errorLink) {
+		this.message = message;
+		this.errorCode = errorCode;
+		this.errorType = errorType;
+		this.errorLink = errorLink;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	public String getErrorType() {
+		return errorType;
+	}
+
+	public String getErrorLink() {
+		return errorLink;
+	}
+
+	@Override
+	public String toString() {
+		return "APIError{" +
+			"message='" + message + '\'' +
+			", errorCode='" + errorCode + '\'' +
+			", errorType='" + errorType + '\'' +
+			", errorLink='" + errorLink + '\'' +
+			'}';
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchApiException.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchApiException.java
@@ -1,40 +1,34 @@
 package com.meilisearch.sdk.exceptions;
 
-import com.meilisearch.sdk.json.GsonJsonHandler;
+public class MeiliSearchApiException extends MeiliSearchRuntimeException {
 
-public class MeiliSearchApiException extends MeiliSearchException {
+	private final APIError error;
 
-	/**
-	 * This is class wraps errors sent by MeiliSearch API
-	 */
-
-	private GsonJsonHandler gson = new GsonJsonHandler();
-
-	private class ApiError {
-		public String message;
-		public String errorCode;
-		public String errorType;
-		public String errorLink;
-	}
-	
-	public MeiliSearchApiException (String errorMessage) throws Exception {
-		super(errorMessage);
-		ApiError error = this.gson.decode(
-			errorMessage,
-			ApiError.class
-		);
-		this.setErrorMessage(error.message);
-		this.setErrorCode(error.errorCode);
-		this.setErrorType(error.errorType);
-		this.setErrorLink(error.errorLink);
+	public MeiliSearchApiException(APIError error) {
+		super();
+		this.error = error;
 	}
 
+	public String getMessage() {
+		return error.getMessage();
+	}
+
+	public String getErrorCode() {
+		return error.getErrorCode();
+	}
+
+	public String getErrorType() {
+		return error.getErrorType();
+	}
+
+	public String getErrorLink() {
+		return error.getErrorLink();
+	}
+
+	@Override
 	public String toString() {
-		return this.getClass().getName() 
-			+ ". Error message: " + this.errorMessage
-			+ ". Error code: " + this.errorCode
-			+ ". Error documentation: " + this.errorLink
-			+ ". Error type: " + this.errorType
-			+ ".";
+		return "MeiliSearchApiException{" +
+			"error=" + error +
+			'}';
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchRuntimeException.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchRuntimeException.java
@@ -1,7 +1,14 @@
 package com.meilisearch.sdk.exceptions;
 
 public class MeiliSearchRuntimeException extends RuntimeException {
+	public MeiliSearchRuntimeException() {
+	}
+
 	public MeiliSearchRuntimeException(Exception e) {
 		super(e);
+	}
+
+	public MeiliSearchRuntimeException(Throwable cause) {
+		super(cause);
 	}
 }

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -2,12 +2,9 @@ package com.meilisearch.integration;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.Index;
-import com.meilisearch.sdk.exceptions.MeiliSearchException;
+import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,19 +26,13 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException serialization and getters
 	 */
 	@Test
-	public void testErrorSerializeAndGetters() throws Exception {
+	public void testErrorSerializeAndGetters() {
 		String errorMessage = "You must have an authorization token";
 		String errorCode = "missing_authorization_header";
 		String errorType = "authentication_error";
 		String errorLink = "https://docs.meilisearch.com/errors#missing_authorization_header";
 		try {
-			throw new MeiliSearchApiException(
-				"{"
-				+ "\"message\":\"" + errorMessage + "\","
-				+ "\"errorCode\":\"" + errorCode + "\","
-				+ "\"errorType\":\"" + errorType + "\","
-				+ "\"errorLink\":\"" + errorLink + "\""
-				+ "}");
+			throw new MeiliSearchApiException(new APIError(errorMessage,errorCode,errorType,errorLink));
 		} catch (MeiliSearchApiException e) {
 			assertEquals(errorMessage, e.getMessage());
 			assertEquals(errorCode, e.getErrorCode());
@@ -54,11 +45,12 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException is thrown on MeiliSearch bad request
 	 */
 	@Test
+	@Disabled
 	public void testMeiliSearchApiExceptionBadRequest () throws Exception {
 		String indexUid = "MeiliSearchApiExceptionBadRequest";
 		Index index = client.createIndex(indexUid);
 		assertThrows(
-			MeiliSearchException.class,
+			MeiliSearchApiException.class,
 			() -> client.createIndex(indexUid)
 		);
 		try {

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -45,7 +45,6 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException is thrown on MeiliSearch bad request
 	 */
 	@Test
-	@Disabled
 	public void testMeiliSearchApiExceptionBadRequest () throws Exception {
 		String indexUid = "MeiliSearchApiExceptionBadRequest";
 		Index index = client.createIndex(indexUid);


### PR DESCRIPTION
This PR improves the ErrorHandling of the GenericServiceTemplate. Instead of ignoring an error, we throw it as an RuntimeException. This way the user can decide if he wants to handle it or just ignore it. 

