### PR TITLE
implement apis based on ServiceTemplate

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -1,13 +1,13 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.APIError;
+import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.DefaultHttpClient;
 import com.meilisearch.sdk.http.factory.BasicRequestFactory;
 import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
-import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 
 import java.util.Collections;
@@ -27,14 +27,14 @@ class MeiliSearchHttpRequest {
 	 */
 	protected MeiliSearchHttpRequest(Config config) {
 		this.client = new DefaultHttpClient(config);
-		this.factory = new BasicRequestFactory();
 		this.jsonHandler = new GsonJsonHandler();
+		this.factory = new BasicRequestFactory(jsonHandler);
 	}
 
 	/**
 	 * Constructor for the MeiliSearchHttpRequest
 	 *
-	 * @param client HttpClient for making calls to server
+	 * @param client  HttpClient for making calls to server
 	 * @param factory RequestFactory for generating calls to server
 	 */
 	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory factory) {
@@ -49,7 +49,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to document
 	 * @return document that was requested
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	public String get(String api) throws Exception, MeiliSearchApiException {
@@ -59,10 +59,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Gets a document at the specified path with a given parameter
 	 *
-	 * @param api Path to document
+	 * @param api   Path to document
 	 * @param param Parameter to be passed
 	 * @return document that was requested
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String get(String api, String param) throws Exception, MeiliSearchApiException {
@@ -76,10 +76,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Adds a document to the specified path
 	 *
-	 * @param api Path to server
+	 * @param api  Path to server
 	 * @param body Query for search
 	 * @return results of the search
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String post(String api, String body) throws Exception, MeiliSearchApiException {
@@ -93,10 +93,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Replaces the requested resource with new data
 	 *
-	 * @param api Path to the requested resource
+	 * @param api  Path to the requested resource
 	 * @param body Replacement data for the requested resource
 	 * @return updated resource
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String put(String api, String body) throws Exception, MeiliSearchApiException {
@@ -113,7 +113,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to the requested resource
 	 * @return deleted resource
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String delete(String api) throws Exception, MeiliSearchApiException {

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -1,13 +1,13 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.APIError;
-import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.DefaultHttpClient;
 import com.meilisearch.sdk.http.factory.BasicRequestFactory;
 import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
+import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 
 import java.util.Collections;
@@ -34,7 +34,7 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Constructor for the MeiliSearchHttpRequest
 	 *
-	 * @param client  HttpClient for making calls to server
+	 * @param client HttpClient for making calls to server
 	 * @param factory RequestFactory for generating calls to server
 	 */
 	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory factory) {
@@ -49,7 +49,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to document
 	 * @return document that was requested
-	 * @throws Exception               if the client has an error
+	 * @throws Exception if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	public String get(String api) throws Exception, MeiliSearchApiException {
@@ -59,10 +59,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Gets a document at the specified path with a given parameter
 	 *
-	 * @param api   Path to document
+	 * @param api Path to document
 	 * @param param Parameter to be passed
 	 * @return document that was requested
-	 * @throws Exception               if the client has an error
+	 * @throws Exception if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String get(String api, String param) throws Exception, MeiliSearchApiException {
@@ -76,10 +76,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Adds a document to the specified path
 	 *
-	 * @param api  Path to server
+	 * @param api Path to server
 	 * @param body Query for search
 	 * @return results of the search
-	 * @throws Exception               if the client has an error
+	 * @throws Exception if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String post(String api, String body) throws Exception, MeiliSearchApiException {
@@ -93,10 +93,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Replaces the requested resource with new data
 	 *
-	 * @param api  Path to the requested resource
+	 * @param api Path to the requested resource
 	 * @param body Replacement data for the requested resource
 	 * @return updated resource
-	 * @throws Exception               if the client has an error
+	 * @throws Exception if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String put(String api, String body) throws Exception, MeiliSearchApiException {
@@ -113,7 +113,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to the requested resource
 	 * @return deleted resource
-	 * @throws Exception               if the client has an error
+	 * @throws Exception if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String delete(String api) throws Exception, MeiliSearchApiException {

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -1,13 +1,13 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.APIError;
+import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.DefaultHttpClient;
 import com.meilisearch.sdk.http.factory.BasicRequestFactory;
 import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
-import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 
 import java.util.Collections;
@@ -34,7 +34,7 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Constructor for the MeiliSearchHttpRequest
 	 *
-	 * @param client HttpClient for making calls to server
+	 * @param client  HttpClient for making calls to server
 	 * @param factory RequestFactory for generating calls to server
 	 */
 	public MeiliSearchHttpRequest(AbstractHttpClient client, RequestFactory factory) {
@@ -49,7 +49,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to document
 	 * @return document that was requested
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	public String get(String api) throws Exception, MeiliSearchApiException {
@@ -59,10 +59,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Gets a document at the specified path with a given parameter
 	 *
-	 * @param api Path to document
+	 * @param api   Path to document
 	 * @param param Parameter to be passed
 	 * @return document that was requested
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String get(String api, String param) throws Exception, MeiliSearchApiException {
@@ -76,10 +76,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Adds a document to the specified path
 	 *
-	 * @param api Path to server
+	 * @param api  Path to server
 	 * @param body Query for search
 	 * @return results of the search
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String post(String api, String body) throws Exception, MeiliSearchApiException {
@@ -93,10 +93,10 @@ class MeiliSearchHttpRequest {
 	/**
 	 * Replaces the requested resource with new data
 	 *
-	 * @param api Path to the requested resource
+	 * @param api  Path to the requested resource
 	 * @param body Replacement data for the requested resource
 	 * @return updated resource
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String put(String api, String body) throws Exception, MeiliSearchApiException {
@@ -113,7 +113,7 @@ class MeiliSearchHttpRequest {
 	 *
 	 * @param api Path to the requested resource
 	 * @return deleted resource
-	 * @throws Exception if the client has an error
+	 * @throws Exception               if the client has an error
 	 * @throws MeiliSearchApiException if the response is an error
 	 */
 	String delete(String api) throws Exception, MeiliSearchApiException {

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -1,0 +1,209 @@
+package com.meilisearch.sdk.api.documents;
+
+import com.meilisearch.sdk.ServiceTemplate;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpMethod;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DocumentHandler<T> {
+	private final ServiceTemplate serviceTemplate;
+	private final RequestFactory requestFactory;
+	private final String indexName;
+	private final Class<?> indexModel;
+
+	public DocumentHandler(ServiceTemplate serviceTemplate, RequestFactory requestFactory, String indexName, Class<?> indexModel) {
+		this.serviceTemplate = serviceTemplate;
+		this.requestFactory = requestFactory;
+		this.indexName = indexName;
+		this.indexModel = indexModel;
+	}
+
+	/**
+	 * @param identifier the identifier of the document you are looking for
+	 * @return the Document as the
+	 * @throws com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public T getDocument(String identifier) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents/" + identifier;
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			indexModel
+		);
+	}
+
+	/**
+	 * @return a list of Documents from the index.
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public List<T> getDocuments() throws MeiliSearchRuntimeException {
+		return getDocuments(20);
+	}
+
+	/**
+	 * @param limit maximum number of documents to be returned
+	 * @return a list of Documents from the index.
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public List<T> getDocuments(int limit) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents?limit=" + limit;
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			List.class,
+			indexModel
+		);
+	}
+
+	/**
+	 * @param data an already serialized document
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update addDocument(String data) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), data),
+			Update.class
+		);
+	}
+
+	/**
+	 * @param data a list of document objects
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update addDocument(List<T> data) throws MeiliSearchRuntimeException {
+		try {
+			String dataString = serviceTemplate.getProcessor().encode(data);
+			return addDocument(dataString);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	/**
+	 * @param data the serialized document
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update replaceDocument(String data) throws MeiliSearchRuntimeException {
+		return addDocument(data);
+	}
+
+	/**
+	 * @param data a list of document objects
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update replaceDocument(List<T> data) throws MeiliSearchRuntimeException {
+		try {
+			String dataString = serviceTemplate.getProcessor().encode(data);
+			return replaceDocument(dataString);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	/**
+	 * @param data the serialized document
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update updateDocument(String data) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.PUT, requestQuery, Collections.emptyMap(), data),
+			Update.class
+		);
+	}
+
+	/**
+	 * @param identifier the id of the document
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update deleteDocument(String identifier) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents/" + identifier;
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.DELETE, requestQuery, Collections.emptyMap(), null),
+			Update.class
+		);
+	}
+
+	/**
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update deleteDocuments() throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/documents";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.DELETE, requestQuery, Collections.emptyMap(), null),
+			Update.class
+		);
+	}
+
+	/**
+	 * @param q the Querystring
+	 * @return a SearchResponse with the Hits represented by the mapped Class for this index
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public SearchResponse<T> search(String q) throws MeiliSearchRuntimeException {
+		try {
+			String requestQuery = "/indexes/" + indexName + "/search";
+			SearchRequest sr = new SearchRequest(q);
+			return serviceTemplate.execute(
+				requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), serviceTemplate.getProcessor().encode(sr)),
+				SearchResponse.class,
+				indexModel
+			);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	/**
+	 * @param sr SearchRequest
+	 * @return a SearchResponse with the Hits represented by the mapped Class for this index
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public SearchResponse<T> search(SearchRequest sr) throws MeiliSearchRuntimeException {
+		try {
+			String requestQuery = "/indexes/" + indexName + "/search";
+			return serviceTemplate.execute(
+				requestFactory.create(HttpMethod.POST, requestQuery,Collections.emptyMap(), serviceTemplate.getProcessor().encode(sr)),
+				SearchResponse.class,
+				indexModel
+			);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
+	}
+
+	/**
+	 * @param updateId the updateId
+	 * @return the update belonging to the updateID
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update getUpdate(int updateId) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/updates/" + updateId;
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Update.class
+		);
+	}
+
+	/**
+	 * @return a List of Updates
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public List<Update> getUpdates() throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + indexName + "/updates";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			List.class,
+			Update.class
+		);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -59,6 +59,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Add or replace a document
+	 *
 	 * @param data an already serialized document
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -105,6 +105,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Add or replace a batch of documents
+	 *
 	 * @param data a list of document objects
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -22,6 +22,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Retrieve a document with a specific identifier
+	 *
 	 * @param identifier the identifier of the document you are looking for
 	 * @return the Document as the
 	 * @throws com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -94,6 +94,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Add or replace a document
+	 *
 	 * @param data the serialized document
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -25,7 +25,7 @@ public class DocumentHandler<T> {
 	 * Retrieve a document with a specific identifier
 	 *
 	 * @param identifier the identifier of the document you are looking for
-	 * @return the Document as the
+	 * @return the document specified by the identifier
 	 * @throws com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
 	public T getDocument(String identifier) throws MeiliSearchRuntimeException {

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -120,6 +120,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Delete a document with a specific identifier
+	 *
 	 * @param identifier the id of the document
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -133,6 +133,7 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Delete a batch of documents
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -195,6 +195,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Retrieve a list containing all the updates
+	 *
 	 * @return a List of Updates
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -182,6 +182,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Retrieve an update with a specific updated
+	 *
 	 * @param updateId the updateId
 	 * @return the update belonging to the updateID
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -43,7 +43,7 @@ public class DocumentHandler<T> {
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
 	public List<T> getDocuments() throws MeiliSearchRuntimeException {
-		return getDocuments(20);
+		return getDocuments(0);
 	}
 
 	/**
@@ -54,7 +54,10 @@ public class DocumentHandler<T> {
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
 	public List<T> getDocuments(int limit) throws MeiliSearchRuntimeException {
-		String requestQuery = "/indexes/" + indexName + "/documents?limit=" + limit;
+		String requestQuery = "/indexes/" + indexName + "/documents";
+		if (limit > 0) {
+			requestQuery += "?limit=" + limit;
+		}
 		return serviceTemplate.execute(
 			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
 			List.class,
@@ -69,7 +72,7 @@ public class DocumentHandler<T> {
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
-	public Update addDocument(String data) throws MeiliSearchRuntimeException {
+	public Update addDocuments(String data) throws MeiliSearchRuntimeException {
 		String requestQuery = "/indexes/" + indexName + "/documents";
 		return serviceTemplate.execute(
 			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), data),
@@ -84,10 +87,10 @@ public class DocumentHandler<T> {
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
-	public Update addDocument(List<T> data) throws MeiliSearchRuntimeException {
+	public Update addDocuments(List<T> data) throws MeiliSearchRuntimeException {
 		try {
 			String dataString = serviceTemplate.getProcessor().encode(data);
-			return addDocument(dataString);
+			return addDocuments(dataString);
 		} catch (Exception e) {
 			throw new MeiliSearchRuntimeException(e);
 		}
@@ -100,8 +103,8 @@ public class DocumentHandler<T> {
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
-	public Update replaceDocument(String data) throws MeiliSearchRuntimeException {
-		return addDocument(data);
+	public Update replaceDocuments(String data) throws MeiliSearchRuntimeException {
+		return addDocuments(data);
 	}
 
 	/**
@@ -111,10 +114,10 @@ public class DocumentHandler<T> {
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
-	public Update replaceDocument(List<T> data) throws MeiliSearchRuntimeException {
+	public Update replaceDocuments(List<T> data) throws MeiliSearchRuntimeException {
 		try {
 			String dataString = serviceTemplate.getProcessor().encode(data);
-			return replaceDocument(dataString);
+			return replaceDocuments(dataString);
 		} catch (Exception e) {
 			throw new MeiliSearchRuntimeException(e);
 		}
@@ -127,12 +130,29 @@ public class DocumentHandler<T> {
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
-	public Update updateDocument(String data) throws MeiliSearchRuntimeException {
+	public Update updateDocuments(String data) throws MeiliSearchRuntimeException {
 		String requestQuery = "/indexes/" + indexName + "/documents";
 		return serviceTemplate.execute(
 			requestFactory.create(HttpMethod.PUT, requestQuery, Collections.emptyMap(), data),
 			Update.class
 		);
+	}
+
+
+	/**
+	 * Add or update a document
+	 *
+	 * @param data a list of document objects
+	 * @return an Update object with the updateId
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update updateDocuments(List<T> data) throws MeiliSearchRuntimeException {
+		try {
+			String dataString = serviceTemplate.getProcessor().encode(data);
+			return updateDocuments(dataString);
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
 	}
 
 	/**
@@ -152,6 +172,7 @@ public class DocumentHandler<T> {
 
 	/**
 	 * Delete a batch of documents
+	 *
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
@@ -191,7 +212,7 @@ public class DocumentHandler<T> {
 		try {
 			String requestQuery = "/indexes/" + indexName + "/search";
 			return serviceTemplate.execute(
-				requestFactory.create(HttpMethod.POST, requestQuery,Collections.emptyMap(), serviceTemplate.getProcessor().encode(sr)),
+				requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), serviceTemplate.getProcessor().encode(sr)),
 				SearchResponse.class,
 				indexModel
 			);

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -121,6 +121,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Add or update a document
+	 *
 	 * @param data the serialized document
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -78,6 +78,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Add or replace a batch of documents
+	 *
 	 * @param data a list of document objects
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -47,6 +47,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Retrieve a list of documents
+	 *
 	 * @param limit maximum number of documents to be returned
 	 * @return a list of Documents from the index.
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -37,6 +37,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * Retrieve a list of documents
+	 *
 	 * @return a list of Documents from the index.
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */

--- a/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
@@ -1,0 +1,88 @@
+package com.meilisearch.sdk.api.documents;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchRequest {
+	private final String q;
+	private final int offset;
+	private final int limit;
+	private final String filters;
+	private final List<String> attributesToRetrieve;
+	private final List<String> attributesToCrop;
+	private final int cropLength;
+	private final List<String> attributesToHighlight;
+	private final boolean matches;
+
+	public SearchRequest(String q) {
+		this(q, 0);
+	}
+
+	public SearchRequest(String q, int offset) {
+		this(q, offset, 20);
+	}
+
+	public SearchRequest(String q, int offset, int limit) {
+		this(q, offset, limit, Collections.singletonList("*"));
+	}
+
+	public SearchRequest(String q, int offset, int limit, List<String> attributesToRetrieve) {
+		this(q, offset, limit, attributesToRetrieve, null, 200, null, null, false);
+	}
+
+	public SearchRequest(String q,
+						 int offset,
+						 int limit,
+						 List<String> attributesToRetrieve,
+						 List<String> attributesToCrop,
+						 int cropLength,
+						 List<String> attributesToHighlight,
+						 String filters,
+						 boolean matches) {
+		this.q = q;
+		this.offset = offset;
+		this.limit = limit;
+		this.attributesToRetrieve = attributesToRetrieve;
+		this.attributesToCrop = attributesToCrop;
+		this.cropLength = cropLength;
+		this.attributesToHighlight = attributesToHighlight;
+		this.filters = filters;
+		this.matches = matches;
+	}
+
+	public String getQ() {
+		return q;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public List<String> getAttributesToRetrieve() {
+		return attributesToRetrieve;
+	}
+
+	public List<String> getAttributesToCrop() {
+		return attributesToCrop;
+	}
+
+	public int getCropLength() {
+		return cropLength;
+	}
+
+	public List<String> getAttributesToHighlight() {
+		return attributesToHighlight;
+	}
+
+	public String getFilters() {
+		return filters;
+	}
+
+	public boolean isMatches() {
+		return matches;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/documents/SearchResponse.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/SearchResponse.java
@@ -1,0 +1,41 @@
+package com.meilisearch.sdk.api.documents;
+
+import java.util.List;
+
+public class SearchResponse<T> {
+	private List<T> hits;
+	private int offset;
+	private int limit;
+	private int nbHits;
+	private boolean exhaustiveNbHits;
+	private int processingTimeMs;
+	private String query;
+
+	public List<T> getHits() {
+		return hits;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public int getNbHits() {
+		return nbHits;
+	}
+
+	public boolean isExhaustiveNbHits() {
+		return exhaustiveNbHits;
+	}
+
+	public int getProcessingTimeMs() {
+		return processingTimeMs;
+	}
+
+	public String getQuery() {
+		return query;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/documents/Type.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/Type.java
@@ -1,0 +1,23 @@
+package com.meilisearch.sdk.api.documents;
+
+public class Type {
+	private String name;
+
+	private int number;
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setNumber(int number) {
+		this.number = number;
+	}
+
+	public int getNumber() {
+		return this.number;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/documents/Update.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/Update.java
@@ -1,0 +1,64 @@
+package com.meilisearch.sdk.api.documents;
+
+public class Update {
+	private String status;
+
+	private int updateId;
+
+	private Type type;
+
+	private double duration;
+
+	private String enqueuedAt;
+
+	private String processedAt;
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getStatus() {
+		return this.status;
+	}
+
+	public void setUpdateId(int updateId) {
+		this.updateId = updateId;
+	}
+
+	public int getUpdateId() {
+		return this.updateId;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public Type getType() {
+		return this.type;
+	}
+
+	public void setDuration(double duration) {
+		this.duration = duration;
+	}
+
+	public double getDuration() {
+		return this.duration;
+	}
+
+	public void setEnqueuedAt(String enqueuedAt) {
+		this.enqueuedAt = enqueuedAt;
+	}
+
+	public String getEnqueuedAt() {
+		return this.enqueuedAt;
+	}
+
+	public void setProcessedAt(String processedAt) {
+		this.processedAt = processedAt;
+	}
+
+	public String getProcessedAt() {
+		return this.processedAt;
+	}
+
+}

--- a/src/main/java/com/meilisearch/sdk/api/index/Index.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/Index.java
@@ -1,0 +1,40 @@
+package com.meilisearch.sdk.api.index;
+
+public class Index {
+	private String uid;
+	private String primaryKey;
+	private String createdAt;
+	private String updatedAt;
+
+	public String getUid() {
+		return uid;
+	}
+
+	public void setUid(String uid) {
+		this.uid = uid;
+	}
+
+	public String getPrimaryKey() {
+		return primaryKey;
+	}
+
+	public void setPrimaryKey(String primaryKey) {
+		this.primaryKey = primaryKey;
+	}
+
+	public String getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(String createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public String getUpdatedAt() {
+		return updatedAt;
+	}
+
+	public void setUpdatedAt(String updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
@@ -1,0 +1,132 @@
+package com.meilisearch.sdk.api.index;
+
+import com.meilisearch.sdk.ServiceTemplate;
+import com.meilisearch.sdk.api.documents.Update;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.response.HttpResponse;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+public class IndexHandler {
+	private final ServiceTemplate serviceTemplate;
+	private final RequestFactory requestFactory;
+	private final SettingsHandler settingsHandler;
+
+	public IndexHandler(ServiceTemplate serviceTemplate, RequestFactory requestFactory, SettingsHandler settingsHandler) {
+		this.serviceTemplate = serviceTemplate;
+		this.requestFactory = requestFactory;
+		this.settingsHandler = settingsHandler;
+	}
+
+	public IndexHandler(ServiceTemplate serviceTemplate, RequestFactory requestFactory) throws MeiliSearchRuntimeException {
+		this(serviceTemplate, requestFactory, new SettingsHandler(serviceTemplate, requestFactory));
+	}
+
+	/**
+	 * @param uid the uid of the index to be created
+	 * @return an {@link Index} Object
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Index createIndex(String uid) throws MeiliSearchRuntimeException {
+		return this.createIndex(uid, null);
+	}
+
+	/**
+	 * @param uid        the indexname
+	 * @param primaryKey the primaryKey for that index
+	 * @return the newly created index
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Index createIndex(String uid, String primaryKey) throws MeiliSearchRuntimeException {
+		HashMap<String, String> body = new HashMap<>();
+		body.put("uid", uid);
+		if (primaryKey != null)
+			body.put("primaryKey", primaryKey);
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.POST, "/indexes", Collections.emptyMap(), body),
+			Index.class
+		);
+	}
+
+	/**
+	 * @param uid the indexname
+	 * @return the index
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Index getIndex(String uid) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid;
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Index.class
+		);
+	}
+
+	/**
+	 * @return an array of all indexes
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Index[] getAllIndexes() throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Index[].class
+		);
+	}
+
+	/**
+	 * @param uid        the indexname
+	 * @param primaryKey the primaryKey for that index
+	 * @return the updated index
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Index updateIndex(String uid, String primaryKey) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid;
+		HashMap<String, String> body = new HashMap<>();
+		body.put("primaryKey", primaryKey);
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.PUT, requestQuery, Collections.emptyMap(), body),
+			Index.class
+		);
+	}
+
+	/**
+	 * @param uid the indexname
+	 * @return true if the index was deleted, otherwise false
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public boolean deleteIndex(String uid) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid;
+		return ((HttpResponse<?>) serviceTemplate.execute(requestFactory.create(HttpMethod.DELETE, requestQuery, Collections.emptyMap(), null), null)).getStatusCode() == 204;
+	}
+
+	/**
+	 * @param index the indexname
+	 * @return the index settings
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Settings getSettings(String index) throws MeiliSearchRuntimeException {
+		return settingsHandler.getSettings(index);
+	}
+
+	/**
+	 * @param index    the indexname
+	 * @param settings the new Settings
+	 * @return the updated settings
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update updateSettings(String index, Settings settings) throws MeiliSearchRuntimeException {
+		return settingsHandler.updateSettings(index, settings);
+	}
+
+	/**
+	 * @param index the indexname
+	 * @return the settings
+	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
+	 */
+	public Update resetSettings(String index) throws MeiliSearchRuntimeException {
+		return settingsHandler.resetSettings(index);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/index/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/Settings.java
@@ -1,0 +1,83 @@
+package com.meilisearch.sdk.api.index;
+
+import com.meilisearch.sdk.Index;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Data Structure for the Settings in an {@link Index}
+ * <p>
+ * Refer https://docs.meilisearch.com/references/settings.html
+ */
+public class Settings {
+	private HashMap<String, String[]> synonyms;
+	private String[] stopWords;
+	private String[] rankingRules;
+	private String[] attributesForFaceting;
+	private String distinctAttribute;
+	private String[] searchableAttributes;
+	private String[] displayedAttributes;
+
+	/**
+	 * Empty SettingsRequest constructor
+	 */
+	public Settings() {
+	}
+
+	public Map<String, String[]> getSynonyms() {
+		return synonyms;
+	}
+
+	public void setSynonyms(Map<String, String[]> synonyms) {
+		this.synonyms = new HashMap<>(synonyms);
+	}
+
+	public String[] getStopWords() {
+		return stopWords;
+	}
+
+	public void setStopWords(String[] stopWords) {
+		this.stopWords = stopWords;
+	}
+
+	public String[] getRankingRules() {
+		return rankingRules;
+	}
+
+	public void setRankingRules(String[] rankingRules) {
+		this.rankingRules = rankingRules;
+	}
+
+	public String[] getAttributesForFaceting() {
+		return attributesForFaceting;
+	}
+
+	public void setAttributesForFaceting(String[] attributesForFaceting) {
+		this.attributesForFaceting = attributesForFaceting;
+	}
+
+	public String getDistinctAttribute() {
+		return distinctAttribute;
+	}
+
+	public void setDistinctAttribute(String distinctAttribute) {
+		this.distinctAttribute = distinctAttribute;
+	}
+
+	public String[] getSearchableAttributes() {
+		return searchableAttributes;
+	}
+
+	public void setSearchableAttributes(String[] searchableAttributes) {
+		this.searchableAttributes = searchableAttributes;
+	}
+
+	public String[] getDisplayedAttributes() {
+		return displayedAttributes;
+	}
+
+	public void setDisplayedAttributes(String[] displayedAttributes) {
+		this.displayedAttributes = displayedAttributes;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/index/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/SettingsHandler.java
@@ -1,0 +1,68 @@
+package com.meilisearch.sdk.api.index;
+
+import com.meilisearch.sdk.ServiceTemplate;
+import com.meilisearch.sdk.api.documents.Update;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpMethod;
+
+import java.util.Collections;
+
+public class SettingsHandler {
+	private final ServiceTemplate serviceTemplate;
+	private final RequestFactory requestFactory;
+
+	public SettingsHandler(ServiceTemplate serviceTemplate, RequestFactory requestFactory) {
+		this.serviceTemplate = serviceTemplate;
+		this.requestFactory = requestFactory;
+	}
+
+	/**
+	 * Gets the settings of a given index
+	 * Refer https://docs.meilisearch.com/references/settings.html#get-settings
+	 *
+	 * @param uid Index identifier
+	 * @return settings of a given uid as String
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Settings getSettings(String uid) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid + "/settings";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Settings.class
+		);
+	}
+
+	/**
+	 * Updates the settings of a given index
+	 * Refer https://docs.meilisearch.com/references/settings.html#update-settings
+	 *
+	 * @param uid      Index identifier
+	 * @param settings the data that contains the new settings
+	 * @return updateId is the id of the update
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Update updateSettings(String uid, Settings settings) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid + "/settings";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), settings),
+			Update.class
+		);
+	}
+
+	/**
+	 * Resets the settings of a given index
+	 * Refer https://docs.meilisearch.com/references/settings.html#reset-settings
+	 *
+	 * @param uid Index identifier
+	 * @return updateId is the id of the update
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Update resetSettings(String uid) throws MeiliSearchRuntimeException {
+		String requestQuery = "/indexes/" + uid + "/settings";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.DELETE, requestQuery, Collections.emptyMap(), null),
+			Update.class
+		);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/instance/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/IndexStats.java
@@ -1,0 +1,42 @@
+package com.meilisearch.sdk.api.instance;
+
+import java.util.Map;
+
+public class IndexStats {
+	private int numberOfDocuments;
+	private boolean isIndexing;
+	private Map<String,Integer> fieldsDistribution;
+
+	public IndexStats() {
+	}
+
+	public IndexStats(int numberOfDocuments, boolean isIndexing, Map<String, Integer> fieldsDistribution) {
+		this.numberOfDocuments = numberOfDocuments;
+		this.isIndexing = isIndexing;
+		this.fieldsDistribution = fieldsDistribution;
+	}
+
+	public int getNumberOfDocuments() {
+		return numberOfDocuments;
+	}
+
+	public void setNumberOfDocuments(int numberOfDocuments) {
+		this.numberOfDocuments = numberOfDocuments;
+	}
+
+	public boolean isIndexing() {
+		return isIndexing;
+	}
+
+	public void setIndexing(boolean indexing) {
+		isIndexing = indexing;
+	}
+
+	public Map<String, Integer> getFieldsDistribution() {
+		return fieldsDistribution;
+	}
+
+	public void setFieldsDistribution(Map<String, Integer> fieldsDistribution) {
+		this.fieldsDistribution = fieldsDistribution;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
@@ -1,0 +1,66 @@
+package com.meilisearch.sdk.api.instance;
+
+import com.meilisearch.sdk.ServiceTemplate;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpMethod;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InstanceHandler {
+	private final ServiceTemplate serviceTemplate;
+	private final RequestFactory requestFactory;
+
+	public InstanceHandler(ServiceTemplate serviceTemplate, RequestFactory requestFactory) {
+		this.serviceTemplate = serviceTemplate;
+		this.requestFactory = requestFactory;
+	}
+
+	/**
+	 * @return true if everything is ok, false if meilisearch is in maintenance mode
+	 */
+	public boolean isHealthy() {
+		try {
+			serviceTemplate.execute(requestFactory.create(HttpMethod.GET, "/health", Collections.emptyMap(), null), null);
+			return true;
+		} catch (MeiliSearchRuntimeException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * @return a map with version information of meilisearch
+	 */
+	public Map<String, String> getVersion() {
+		try {
+			return serviceTemplate.execute(
+				requestFactory.create(HttpMethod.GET, "/version", Collections.emptyMap(), null),
+				HashMap.class,
+				String.class,
+				String.class
+			);
+		} catch (MeiliSearchRuntimeException e) {
+			return Collections.emptyMap();
+		}
+	}
+
+
+	public IndexStats getStats(String index) {
+		String requestQuery = index + "/stats";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			IndexStats.class
+		);
+	}
+
+	public Stats getStats() {
+		String requestQuery = "/stats";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Stats.class
+		);
+	}
+
+}

--- a/src/main/java/com/meilisearch/sdk/api/instance/Stats.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/Stats.java
@@ -1,0 +1,43 @@
+package com.meilisearch.sdk.api.instance;
+
+import java.util.Date;
+import java.util.Map;
+
+public class Stats {
+	private int databaseSize;
+	private Date lastUpdate;
+	private Map<String, IndexStats> indexes;
+
+	public Stats() {
+	}
+
+	public Stats(int databaseSize, Date lastUpdate, Map<String, IndexStats> indexes) {
+		this.databaseSize = databaseSize;
+		this.lastUpdate = lastUpdate;
+		this.indexes = indexes;
+	}
+
+	public int getDatabaseSize() {
+		return databaseSize;
+	}
+
+	public void setDatabaseSize(int databaseSize) {
+		this.databaseSize = databaseSize;
+	}
+
+	public Date getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(Date lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	public Map<String, IndexStats> getIndexes() {
+		return indexes;
+	}
+
+	public void setIndexes(Map<String, IndexStats> indexes) {
+		this.indexes = indexes;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -1,15 +1,26 @@
 package com.meilisearch.sdk.http.factory;
 
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 import com.meilisearch.sdk.http.request.BasicHttpRequest;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.json.JsonHandler;
 
 import java.util.Map;
 
 public class BasicRequestFactory implements RequestFactory {
+	private final JsonHandler jsonHandler;
+
+	public BasicRequestFactory(JsonHandler jsonHandler) {
+		this.jsonHandler = jsonHandler;
+	}
+
 	@Override
 	public <T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content) {
-		//todo integrate serializer for content
-		return new BasicHttpRequest(method, path, headers, (String) content);
+		try {
+			return new BasicHttpRequest(method, path, headers, this.jsonHandler.encode(content));
+		} catch (Exception e) {
+			throw new MeiliSearchRuntimeException(e);
+		}
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -18,7 +18,7 @@ public class BasicRequestFactory implements RequestFactory {
 	@Override
 	public <T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content) {
 		try {
-			return new BasicHttpRequest(method, path, headers, this.jsonHandler.encode(content));
+			return new BasicHttpRequest(method, path, headers, content == null ? null : this.jsonHandler.encode(content));
 		} catch (Exception e) {
 			throw new MeiliSearchRuntimeException(e);
 		}

--- a/src/main/java/com/meilisearch/sdk/json/JacksonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/JacksonJsonHandler.java
@@ -30,7 +30,7 @@ public class JacksonJsonHandler implements JsonHandler {
 	 */
 	@Override
 	public String encode(Object o) throws Exception {
-		if (o.getClass() == String.class) {
+		if (o != null && o.getClass() == String.class) {
 			return (String) o;
 		}
 		try {

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -45,6 +45,7 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException is thrown on MeiliSearch bad request
 	 */
 	@Test
+	@Disabled
 	public void testMeiliSearchApiExceptionBadRequest () throws Exception {
 		String indexUid = "MeiliSearchApiExceptionBadRequest";
 		Index index = client.createIndex(indexUid);

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -45,7 +45,6 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException is thrown on MeiliSearch bad request
 	 */
 	@Test
-	@Disabled
 	public void testMeiliSearchApiExceptionBadRequest () throws Exception {
 		String indexUid = "MeiliSearchApiExceptionBadRequest";
 		Index index = client.createIndex(indexUid);

--- a/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
+++ b/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
@@ -21,7 +21,7 @@ class GenericServiceTemplateTest {
 
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
 	private final JsonHandler handler = mock(JsonHandler.class);
-	private final GenericServiceTemplate classToTest = new GenericServiceTemplate(client, handler, new BasicRequestFactory());
+	private final GenericServiceTemplate classToTest = new GenericServiceTemplate(client, handler, new BasicRequestFactory(handler));
 
 	@Test
 	void getClient() {

--- a/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
@@ -1,0 +1,152 @@
+package com.meilisearch.sdk.api.documents;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.GenericServiceTemplate;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import com.meilisearch.sdk.json.JsonHandler;
+import com.meilisearch.sdk.utils.Movie;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DocumentHandlerTest {
+
+	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
+	private final JsonHandler jsonHandler = new JacksonJsonHandler(new ObjectMapper());
+	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler);
+	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, jsonHandler, requestFactory);
+	private final DocumentHandler<Movie> classToTest = new DocumentHandler<Movie>(serviceTemplate, requestFactory, "movies", Movie.class);
+
+	@Test
+	void getDocument() throws Exception {
+		when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"id\":25684,\"title\":\"American Ninja 5\",\"poster\":\"https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg\",\"overview\":\"When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.\",\"release_date\":\"1993-01-01\"}"));
+		Movie movie = classToTest.getDocument("25684");
+		assertNotNull(movie);
+		assertEquals("25684", movie.getId());
+		assertEquals("American Ninja 5", movie.getTitle());
+		assertEquals("https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg", movie.getPoster());
+		assertEquals("When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.", movie.getOverview());
+		assertEquals("1993-01-01", movie.getRelease_date());
+	}
+
+	@Test
+	void getDocuments() throws Exception {
+		when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "[{\"id\":25684,\"release_date\":\"1993-01-01\",\"poster\":\"https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg\",\"title\":\"American Ninja 5\",\"overview\":\"When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.\"},{\"id\":468219,\"title\":\"Dead in a Week (Or Your Money Back)\",\"release_date\":\"2018-09-12\",\"poster\":\"https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg\",\"overview\":\"William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed.\"}]"));
+		List<Movie> movies = classToTest.getDocuments();
+		assertNotNull(movies);
+		assertEquals(2, movies.size());
+		Movie movie = movies.get(0);
+		assertEquals("25684", movie.getId());
+		assertEquals("American Ninja 5", movie.getTitle());
+		assertEquals("https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg", movie.getPoster());
+		assertEquals("When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.", movie.getOverview());
+		assertEquals("1993-01-01", movie.getRelease_date());
+	}
+
+	@Test
+	void addAndReplaceDocument() throws Exception {
+		when(client.post(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"updateId\":1}"));
+		Movie movie = new Movie(
+			"287947",
+			"Shazam",
+			"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg",
+			"A boy is given the ability to become an adult superhero in times of need with a single magic word.",
+			"2019-03-23", "English", "Action", "Comedy", "Fantasy"
+		);
+		Update update = classToTest.replaceDocument(Collections.singletonList(movie));
+		assertNotNull(update);
+		assertEquals(1, update.getUpdateId());
+	}
+
+	@Test
+	void addAndUpdateDocument() throws Exception {
+		when(client.put(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"updateId\":1}"));
+		Update update = classToTest.updateDocument("[{\"id\":287947,\"title\":\"Shazam\",\"poster\":\"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg\",\"overview\":\"A boy is given the ability to become an adult superhero in times of need with a single magic word.\",\"release_date\":\"2019-03-23\"}]");
+		assertNotNull(update);
+		assertEquals(1, update.getUpdateId());
+	}
+
+	@Test
+	void deleteDocument() throws Exception {
+		when(client.delete(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"updateId\": 1}"));
+		assertEquals(1, classToTest.deleteDocument("123").getUpdateId());
+		when(client.delete(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, null));
+		assertThrows(MeiliSearchRuntimeException.class, () -> classToTest.deleteDocument("123"));
+		when(client.delete(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, ""));
+		assertThrows(MeiliSearchRuntimeException.class, () -> classToTest.deleteDocument("123"));
+	}
+
+	@Test
+	void deleteDocuments() throws Exception {
+		when(client.delete(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"updateId\": 1}"));
+		assertEquals(1, classToTest.deleteDocuments().getUpdateId());
+	}
+
+	@Test
+	void search() throws Exception {
+		when(client.post(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"hits\":[{\"id\":\"2770\",\"title\":\"American Pie 2\",\"poster\":\"https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg\",\"overview\":\"The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...\",\"release_date\":997405200},{\"id\":\"190859\",\"title\":\"American Sniper\",\"poster\":\"https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg\",\"overview\":\"U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...\",\"release_date\":1418256000}],\"offset\":0,\"limit\":20,\"nbHits\":1,\"exhaustiveNbHits\":false,\"processingTimeMs\":2,\"query\":\"test120232\"}"));
+		SearchResponse<Movie> movieSearchResponse = classToTest.search("American Pie");
+		assertNotNull(movieSearchResponse);
+		assertNotNull(movieSearchResponse.getHits());
+		assertEquals(2, movieSearchResponse.getHits().size());
+		assertEquals("American Pie 2", movieSearchResponse.getHits().get(0).getTitle());
+		assertEquals("2770", movieSearchResponse.getHits().get(0).getId());
+		assertEquals("https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg", movieSearchResponse.getHits().get(0).getPoster());
+		assertEquals("997405200", movieSearchResponse.getHits().get(0).getRelease_date());
+	}
+
+	@Test
+	void testSearch() throws Exception {
+		when(client.post(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"hits\":[{\"id\":\"2770\",\"title\":\"American Pie 2\",\"poster\":\"https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg\",\"overview\":\"The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...\",\"release_date\":997405200},{\"id\":\"190859\",\"title\":\"American Sniper\",\"poster\":\"https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg\",\"overview\":\"U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...\",\"release_date\":1418256000}],\"offset\":0,\"limit\":20,\"nbHits\":1,\"exhaustiveNbHits\":false,\"processingTimeMs\":2,\"query\":\"test120232\"}"));
+		SearchResponse<Movie> movieSearchResponse = classToTest.search(new SearchRequest("american pie"));
+		assertNotNull(movieSearchResponse);
+		assertNotNull(movieSearchResponse.getHits());
+		assertEquals(2, movieSearchResponse.getHits().size());
+		assertEquals("American Pie 2", movieSearchResponse.getHits().get(0).getTitle());
+		assertEquals("2770", movieSearchResponse.getHits().get(0).getId());
+		assertEquals("https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg", movieSearchResponse.getHits().get(0).getPoster());
+		assertEquals("997405200", movieSearchResponse.getHits().get(0).getRelease_date());
+
+	}
+
+	@Test
+	void getUpdate() throws Exception {
+		when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"status\":\"processed\",\"updateId\":1,\"type\":{\"name\":\"DocumentsAddition\",\"number\":4},\"duration\":0.076980613,\"enqueuedAt\":\"2019-12-07T21:16:09.623944Z\",\"processedAt\":\"2019-12-07T21:16:09.703509Z\"}"));
+		Update update = classToTest.getUpdate(1);
+		assertNotNull(update);
+		assertEquals("processed", update.getStatus());
+		assertEquals(1, update.getUpdateId());
+		assertEquals("DocumentsAddition", update.getType().getName());
+		assertEquals(4, update.getType().getNumber());
+		assertEquals(0.076980613, update.getDuration());
+		assertEquals("2019-12-07T21:16:09.623944Z", update.getEnqueuedAt());
+		assertEquals("2019-12-07T21:16:09.703509Z", update.getProcessedAt());
+	}
+
+	@Test
+	void getUpdates() throws Exception {
+		when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "[{\"status\":\"processed\",\"updateId\":1,\"type\":{\"name\":\"DocumentsAddition\",\"number\":4},\"duration\":0.076980613,\"enqueuedAt\":\"2019-12-07T21:16:09.623944Z\",\"processedAt\":\"2019-12-07T21:16:09.703509Z\"}]"));
+		List<Update> updates = classToTest.getUpdates();
+		assertNotNull(updates);
+		assertEquals(1, updates.size());
+		Update update = updates.get(0);
+		assertEquals("processed", update.getStatus());
+		assertEquals(1, update.getUpdateId());
+		assertEquals("DocumentsAddition", update.getType().getName());
+		assertEquals(4, update.getType().getNumber());
+		assertEquals(0.076980613, update.getDuration());
+		assertEquals("2019-12-07T21:16:09.623944Z", update.getEnqueuedAt());
+		assertEquals("2019-12-07T21:16:09.703509Z", update.getProcessedAt());
+	}
+
+}

--- a/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
@@ -63,7 +63,7 @@ class DocumentHandlerTest {
 			"A boy is given the ability to become an adult superhero in times of need with a single magic word.",
 			"2019-03-23", "English", "Action", "Comedy", "Fantasy"
 		);
-		Update update = classToTest.replaceDocument(Collections.singletonList(movie));
+		Update update = classToTest.replaceDocuments(Collections.singletonList(movie));
 		assertNotNull(update);
 		assertEquals(1, update.getUpdateId());
 	}
@@ -71,7 +71,7 @@ class DocumentHandlerTest {
 	@Test
 	void addAndUpdateDocument() throws Exception {
 		when(client.put(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"updateId\":1}"));
-		Update update = classToTest.updateDocument("[{\"id\":287947,\"title\":\"Shazam\",\"poster\":\"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg\",\"overview\":\"A boy is given the ability to become an adult superhero in times of need with a single magic word.\",\"release_date\":\"2019-03-23\"}]");
+		Update update = classToTest.updateDocuments("[{\"id\":287947,\"title\":\"Shazam\",\"poster\":\"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg\",\"overview\":\"A boy is given the ability to become an adult superhero in times of need with a single magic word.\",\"release_date\":\"2019-03-23\"}]");
 		assertNotNull(update);
 		assertEquals(1, update.getUpdateId());
 	}

--- a/src/test/java/com/meilisearch/sdk/api/index/IndexHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/index/IndexHandlerTest.java
@@ -1,0 +1,107 @@
+package com.meilisearch.sdk.api.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.GenericServiceTemplate;
+import com.meilisearch.sdk.api.documents.Update;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.BasicHttpRequest;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import com.meilisearch.sdk.json.JsonHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+
+class IndexHandlerTest {
+
+	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
+	private final JsonHandler jsonHandler = new JacksonJsonHandler(new ObjectMapper());
+	private final SettingsHandler settingsService = mock(SettingsHandler.class);
+	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler);
+	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, jsonHandler, requestFactory);
+	private final IndexHandler classToTest = new IndexHandler(serviceTemplate, requestFactory, settingsService);
+
+	@Test
+	void create() throws Exception {
+		Mockito.when(client.post(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"uid\":\"movies\",\"primaryKey\":\"id\",\"createdAt\":\"2019-11-20T09:40:33.711476Z\",\"updatedAt\":\"2019-11-20T09:40:33.711476Z\"}"));
+		Index index = classToTest.createIndex("movies");
+		assertEquals("movies", index.getUid());
+		assertEquals("id", index.getPrimaryKey());
+	}
+
+	@Test
+	void createWithPrimaryKey() throws Exception {
+		Mockito.when(client.post(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"uid\":\"movies\",\"primaryKey\":\"movie_id\",\"createdAt\":\"2019-11-20T09:40:33.711476Z\",\"updatedAt\":\"2019-11-20T09:40:33.711476Z\"}"));
+		Index index = classToTest.createIndex("movies", "movie_id");
+		assertEquals("movies", index.getUid());
+		assertEquals("movie_id", index.getPrimaryKey());
+	}
+
+	@Test
+	void get() throws Exception {
+		Mockito.when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"uid\":\"movies\",\"primaryKey\":\"movie_id\",\"createdAt\":\"2019-11-20T09:40:33.711476Z\",\"updatedAt\":\"2019-11-20T09:40:33.711476Z\"}"));
+		Index index = classToTest.getIndex("movies");
+		assertEquals("movies", index.getUid());
+		assertEquals("movie_id", index.getPrimaryKey());
+	}
+
+	@Test
+	void getAll() throws Exception {
+		Mockito.when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "[{\"uid\":\"movies\",\"primaryKey\":\"movie_id\",\"createdAt\":\"2019-11-20T09:40:33.711476Z\",\"updatedAt\":\"2019-11-20T09:40:33.711476Z\"}]"));
+		Index[] index = classToTest.getAllIndexes();
+		assertEquals(1, index.length);
+		assertEquals("movies", index[0].getUid());
+		assertEquals("movie_id", index[0].getPrimaryKey());
+	}
+
+	@Test
+	void update() throws Exception {
+		Deque<BasicHttpRequest> deque = new ArrayDeque<>();
+		Mockito.when(client.put(any(HttpRequest.class))).then(invocationOnMock -> {
+			deque.add((BasicHttpRequest) invocationOnMock.getArguments()[0]);
+			return new BasicHttpResponse(null, 200, "{\"uid\":\"movies\",\"primaryKey\":\"movie_id\",\"createdAt\":\"2019-11-20T09:40:33.711476Z\",\"updatedAt\":\"2019-11-20T09:40:33.711476Z\"}");
+		});
+		Index index = classToTest.updateIndex("movies", "movie_id");
+		assertEquals("movies", index.getUid());
+		assertEquals("movie_id", index.getPrimaryKey());
+	}
+
+	@Test
+	void delete() throws Exception {
+		Mockito.when(client.delete(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 204, ""));
+		assertTrue(classToTest.deleteIndex("movies"));
+		Mockito.when(client.delete(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 404, ""));
+		assertFalse(classToTest.deleteIndex("movies"));
+		Mockito.when(client.delete(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 100, ""));
+		assertFalse(classToTest.deleteIndex("movies"));
+	}
+
+	@Test
+	void settings() {
+		Settings dummySettings = new Settings();
+		dummySettings.setDistinctAttribute("test");
+		Update dummyUpdate = new Update();
+		Mockito.when(settingsService.getSettings(any())).thenReturn(dummySettings);
+		Mockito.when(settingsService.resetSettings(any())).thenReturn(dummyUpdate);
+		Mockito.when(settingsService.updateSettings(any(), any())).thenReturn(dummyUpdate);
+
+		assertThat(classToTest.getSettings("test"), is(equalTo(dummySettings)));
+		assertThat(classToTest.resetSettings("test"), is(equalTo(dummyUpdate)));
+		assertThat(classToTest.updateSettings("test", dummySettings), is(equalTo(dummyUpdate)));
+	}
+}

--- a/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
@@ -1,0 +1,86 @@
+package com.meilisearch.sdk.api.instance;
+
+import com.meilisearch.sdk.GenericServiceTemplate;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.http.response.BasicHttpResponse;
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import com.meilisearch.sdk.json.JsonHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InstanceHandlerTest {
+
+	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
+	private final JsonHandler handler = new JacksonJsonHandler();
+	private final RequestFactory requestFactory = new BasicRequestFactory(handler);
+	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, handler, requestFactory);
+	InstanceHandler classToTest = new InstanceHandler(serviceTemplate, requestFactory);
+
+	@Test
+	void isHealthy() throws Exception {
+		when(client.get(any(HttpRequest.class))).thenAnswer(invocation -> new BasicHttpResponse(null, 200, "")).thenThrow(MeiliSearchRuntimeException.class);
+		assertTrue(classToTest.isHealthy());
+		assertFalse(classToTest.isHealthy());
+	}
+
+	@Test
+	void version() throws Exception {
+		when(client.get(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"buildDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}"))
+			.thenThrow(MeiliSearchRuntimeException.class);
+		Map<String, String> version = classToTest.getVersion();
+		assertNotNull(version);
+		assertTrue(version.containsKey("commitSha"));
+		assertEquals("b46889b5f0f2f8b91438a08a358ba8f05fc09fc1", version.get("commitSha"));
+		assertTrue(version.containsKey("buildDate"));
+		assertEquals("2019-11-15T09:51:54.278247+00:00", version.get("buildDate"));
+		assertTrue(version.containsKey("pkgVersion"));
+		assertEquals("0.1.1", version.get("pkgVersion"));
+		version = classToTest.getVersion();
+		assertNotNull(version);
+		assertEquals(0, version.size());
+	}
+
+	@Test
+	void fullStats() throws Exception {
+		when(client.get(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"databaseSize\": 447819776,\"lastUpdate\": \"2019-11-15T11:15:22.092896Z\",\"indexes\": {\"movies\": {\"numberOfDocuments\": 19654,\"isIndexing\": false,\"fieldsDistribution\": {\"poster\": 19654,\"overview\": 19654,\"title\": 19654,\"id\": 19654,\"release_date\": 19654}},\"rangemovies\": {\"numberOfDocuments\": 19654,\"isIndexing\": false,\"fieldsDistribution\": {\"overview\": 19654,\"id\": 19654,\"title\": 19654}}}}"))
+			.thenThrow(MeiliSearchRuntimeException.class);
+		Stats stats = classToTest.getStats();
+		assertThat(stats.getDatabaseSize(), is(447819776));
+		assertThat(stats.getLastUpdate().toString(), is("Fri Nov 15 12:15:22 CET 2019"));
+		assertThat(stats.getIndexes().keySet(), hasItems("movies", "rangemovies"));
+		IndexStats movies = stats.getIndexes().get("movies");
+		assertThat(movies.getNumberOfDocuments(), is(19654));
+		assertThat(movies.isIndexing(), is(false));
+		assertThat(movies.getFieldsDistribution().keySet(), hasItems("overview", "id", "title"));
+		assertThat(movies.getFieldsDistribution().get("overview"), is(19654));
+		assertThat(movies.getFieldsDistribution().get("id"), is(19654));
+		assertThat(movies.getFieldsDistribution().get("title"), is(19654));
+	}
+
+	@Test
+	void singleStats() throws Exception {
+		when(client.get(any(HttpRequest.class)))
+			.thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"numberOfDocuments\": 19654,\"isIndexing\": false,\"fieldsDistribution\": {\"poster\": 19654,\"release_date\": 19654,\"title\": 19654,\"id\": 19654,\"overview\": 19654}}"))
+			.thenThrow(MeiliSearchRuntimeException.class);
+		IndexStats stats = classToTest.getStats("index");
+		assertThat(stats.getNumberOfDocuments(), is(19654));
+		assertThat(stats.isIndexing(), is(false));
+		assertThat(stats.getFieldsDistribution().keySet(), hasItems("overview", "id", "title", "release_date", "poster"));
+		assertThat(stats.getFieldsDistribution().get("overview"), is(19654));
+		assertThat(stats.getFieldsDistribution().get("id"), is(19654));
+		assertThat(stats.getFieldsDistribution().get("title"), is(19654));
+	}
+}

--- a/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
@@ -59,7 +59,7 @@ class InstanceHandlerTest {
 			.thenThrow(MeiliSearchRuntimeException.class);
 		Stats stats = classToTest.getStats();
 		assertThat(stats.getDatabaseSize(), is(447819776));
-		assertThat(stats.getLastUpdate().toString(), is("Fri Nov 15 12:15:22 CET 2019"));
+		assertThat(stats.getLastUpdate().toInstant().toEpochMilli(), is(1573816522092L));
 		assertThat(stats.getIndexes().keySet(), hasItems("movies", "rangemovies"));
 		IndexStats movies = stats.getIndexes().get("movies");
 		assertThat(movies.getNumberOfDocuments(), is(19654));

--- a/src/test/java/com/meilisearch/sdk/http/factory/BasicRequestFactoryTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/factory/BasicRequestFactoryTest.java
@@ -1,0 +1,43 @@
+package com.meilisearch.sdk.http.factory;
+
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import com.meilisearch.sdk.utils.Movie;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class BasicRequestFactoryTest {
+
+	private final RequestFactory factory = new BasicRequestFactory(new GsonJsonHandler());
+
+	@Test
+	void basicUseCase() {
+		HttpRequest<?> httpRequest = factory.create(HttpMethod.GET, "/", Collections.emptyMap(), null);
+		assertThat(httpRequest.hasContent(), is(false));
+		assertThat(httpRequest.getPath(), is("/"));
+		assertThat(httpRequest.getMethod(), is(HttpMethod.GET));
+	}
+
+	@Test
+	void contentString() {
+		HttpRequest<?> httpRequest = factory.create(HttpMethod.GET, "/", Collections.emptyMap(), "thisisatest");
+		assertThat(httpRequest.hasContent(), is(true));
+		assertThat(httpRequest.getContent(), is("thisisatest"));
+		assertThat(httpRequest.getPath(), is("/"));
+		assertThat(httpRequest.getMethod(), is(HttpMethod.GET));
+	}
+
+	@Test
+	void contentClass() {
+		HttpRequest<?> httpRequest = factory.create(HttpMethod.GET, "/", Collections.emptyMap(), new Movie("thisisanid","thisisatitle"));
+		assertThat(httpRequest.hasContent(), is(true));
+		assertThat(httpRequest.getContent(), is("{\"id\":\"thisisanid\",\"title\":\"thisisatitle\"}"));
+		assertThat(httpRequest.getPath(), is("/"));
+		assertThat(httpRequest.getMethod(), is(HttpMethod.GET));
+	}
+}

--- a/src/test/java/com/meilisearch/sdk/utils/Movie.java
+++ b/src/test/java/com/meilisearch/sdk/utils/Movie.java
@@ -27,6 +27,16 @@ public class Movie {
 		this.title = title;
 	}
 
+	public Movie(String id, String title, String poster, String overview, String release_date, String language, String... genres) {
+		this.id = id;
+		this.title = title;
+		this.poster = poster;
+		this.overview = overview;
+		this.release_date = release_date;
+		this.language = language;
+		this.genres = genres;
+	}
+
 	public String getId() {
 		return id;
 	}


### PR DESCRIPTION
⚠️ This PR includes #120 

This PR contains the api implementations based on the ServiceTemplate. 
IndexHandler to handle Index and the Settings Endpoints
DocumentHandler to handle Document operations
InstanceHandler to handle Instance-wide endpoints like Stats

DocumentHandler is implemented as a generic to support a user-provided model class.
This way we dont have to return a String.