### PR TITLE
Automatize the package publishment

### DIFF
--- a/.github/workflows/ossrh-publish.yml
+++ b/.github/workflows/ossrh-publish.yml
@@ -1,0 +1,34 @@
+name: OSSRH
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Decode secring.gpg
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+      - name: Publish
+        run: ./gradlew publish -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+      - name: Close and release Nexus Repository
+        run: ./gradlew closeAndReleaseRepository
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ atlassian-ide-plugin.xml
 .vscode
 
 *.gpg
+secring*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,15 +177,15 @@ Once the changes are merged on `main`, you can publish the current draft release
 
 #### Sign your files and upload to Maven Repository manually <!-- omit in TOC -->
 
-1. Prepare the environment by filling the environment variables needed with all the credentials:
+1. Set the environment variables listed below with the required credentials:
 
-```
-OSSRH_USERNAME=<maven-username>
-OSSRH_PASSWORD=<maven-password>
+```bash
+export OSSRH_USERNAME=<maven-username>
+export OSSRH_PASSWORD=<maven-password>
 
-SIGNINT_KEY_ID=<id-associated-to-the-gpg-key>
-SIGNING_PASSWORD=<passphrase-associated-to-the-gpg-key>
-SIGNING_SECRET_KEY_RING_FILE=<gpg-key-encoded-in-base64>
+export SIGNINT_KEY_ID=<id-associated-to-the-gpg-key>
+export SIGNING_PASSWORD=<passphrase-associated-to-the-gpg-key>
+export SIGNING_SECRET_KEY_RING_FILE=<gpg-key-encoded-in-base64>
 ```
 
 2. Decode the gpg key

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the following code to the `<dependencies>` section of your project:
 <dependency>
   <groupId>com.meilisearch.sdk</groupId>
   <artifactId>meilisearch-java</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -62,7 +62,7 @@ Add the following code to the `<dependencies>` section of your project:
 Add the following line to the `dependencies` section of your `build.gradle`:
 
 ```groovy
-implementation 'com.meilisearch.sdk:meilisearch-java:0.2.0'
+implementation 'com.meilisearch.sdk:meilisearch-java:0.3.0'
 ```
 
 ## 🚀 Getting Started

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the following code to the `<dependencies>` section of your project:
 <dependency>
   <groupId>com.meilisearch.sdk</groupId>
   <artifactId>meilisearch-java</artifactId>
-  <version>0.3.0</version>
+  <version>0.2.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -62,7 +62,7 @@ Add the following code to the `<dependencies>` section of your project:
 Add the following line to the `dependencies` section of your `build.gradle`:
 
 ```groovy
-implementation 'com.meilisearch.sdk:meilisearch-java:0.3.0'
+implementation 'com.meilisearch.sdk:meilisearch-java:0.2.0'
 ```
 
 ## 🚀 Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,13 @@
 plugins {
 	// Apply the java-library plugin to add support for Java Library
 	id 'java-library'
+	id 'maven-publish'
+	id 'signing'
 }
 
 group = 'com.meilisearch.sdk'
 archivesBaseName = 'meilisearch-java'
-version = '0.2.0'
-
-apply plugin: 'maven'
-apply plugin: 'signing'
+version = '0.3.0'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8
@@ -65,15 +64,15 @@ dependencies {
 }
 
 task buildJar(type: Jar) {
-	baseName = 'meilisearch-java'
+	archiveBaseName = 'meilisearch-java'
 	from {
 		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 	}
-		{
-			exclude 'META-INF/*.SF'
-			exclude 'META-INF/*.DSA'
-			exclude 'META-INF/*.RSA'
-		}
+	{
+		exclude 'META-INF/*.SF'
+		exclude 'META-INF/*.DSA'
+		exclude 'META-INF/*.RSA'
+	}
 	with jar
 }
 
@@ -96,74 +95,62 @@ task integrationTest(type: Test) {
 }
 
 task javadocJar(type: Jar) {
-		classifier = 'javadoc'
-		from javadoc
+	classifier = 'javadoc'
+	from javadoc
 }
 
 task sourcesJar(type: Jar) {
-		classifier = 'sources'
-		from sourceSets.main.allSource
+	classifier = 'sources'
+	from sourceSets.main.allSource
 }
 
 artifacts {
-		archives javadocJar, sourcesJar
+	archives javadocJar, sourcesJar
 }
 
-signing {
-	if (project.hasProperty('releaseSDK')){
-		useGpgCmd()
-		sign configurations.archives
-	}
-}
-
-uploadArchives {
-
-	def ossrhUsername = findProperty('ossrhUsername')
-	def ossrhPassword = findProperty('ossrhPassword')
-
-	repositories {
-		mavenDeployer {
-			project.logger.lifecycle('Trying to upload files to Maven repository...')
-			beforeDeployment {
-				MavenDeployment deployment -> signing.signPom(deployment)
-			}
-
-			repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-				authentication(userName: ossrhUsername, password: ossrhPassword)
-			}
-
-			snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-				authentication(userName: ossrhUsername, password: ossrhPassword)
-			}
-
-			pom.project {
-				name 'com.meilisearch.sdk:meilisearch-java'
-				packaging 'jar'
-				artifactId 'meilisearch-java'
-				description 'MeiliSearch is a powerful, fast, open-source, easy to use and deploy search engine.'
-				url 'https://github.com/meilisearch/meilisearch-java'
-
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+			artifactId = 'meilisearch-java'
+            from components.java
+			pom {
+				name = 'com.meilisearch.sdk:meilisearch-java'
+				packaging = 'jar'
+				artifactId = 'meilisearch-java'
+				description = 'MeiliSearch is a powerful, fast, open-source, easy to use and deploy search engine.'
+				url = 'https://github.com/meilisearch/meilisearch-java'
 				scm {
-					connection 'scm:git:git://github.com/meilisearch/meilisearch-java.git'
-					developerConnection 'scm:git:ssh://github.com:meilisearch/meilisearch-java.git'
-					url 'http://github.com/meilisearch/meilisearch-java'
+					connection = 'scm:git:git://github.com/meilisearch/meilisearch-java.git'
+					developerConnection = 'scm:git:ssh://github.com:meilisearch/meilisearch-java.git'
+					url = 'http://github.com/meilisearch/meilisearch-java'
 				}
-
 				licenses {
 					license {
-					name 'MIT License'
-					url 'http://www.opensource.org/licenses/mit-license.php'
+					name = 'MIT License'
+					url = 'http://www.opensource.org/licenses/mit-license.php'
 					}
 				}
-
 				developers {
 					developer {
-					id 'eskombro'
-					name 'Samuel Jimenez'
-					email 'samuel@meilisearch.com'
+					id = 'eskombro'
+					name = 'Samuel Jimenez'
+					email = 'samuel@meilisearch.com'
 					}
 				}
+			}
+        }
+    }
+	repositories {
+		maven {
+			url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+			credentials {
+				username ossrhUsername
+				password ossrhPassword
 			}
 		}
 	}
+}
+
+signing {
+    sign publishing.publications.mavenJava
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 
 group = 'com.meilisearch.sdk'
 archivesBaseName = 'meilisearch-java'
-version = '0.3.0'
+version = '0.2.0'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
 	id 'java-library'
 	id 'maven-publish'
 	id 'signing'
+	id 'io.codearte.nexus-staging' version '0.30.0'
 }
 
 group = 'com.meilisearch.sdk'
@@ -109,10 +110,10 @@ artifacts {
 }
 
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
+	publications {
+		mavenJava(MavenPublication) {
 			artifactId = 'meilisearch-java'
-            from components.java
+			from components.java
 			pom {
 				name = 'com.meilisearch.sdk:meilisearch-java'
 				packaging = 'jar'
@@ -126,31 +127,38 @@ publishing {
 				}
 				licenses {
 					license {
-					name = 'MIT License'
-					url = 'http://www.opensource.org/licenses/mit-license.php'
+						name = 'MIT License'
+						url = 'http://www.opensource.org/licenses/mit-license.php'
 					}
 				}
 				developers {
 					developer {
-					id = 'eskombro'
-					name = 'Samuel Jimenez'
-					email = 'samuel@meilisearch.com'
+						id = 'eskombro'
+						name = 'Samuel Jimenez'
+						email = 'samuel@meilisearch.com'
 					}
 				}
 			}
-        }
-    }
+		}
+	}
 	repositories {
 		maven {
 			url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 			credentials {
-				username ossrhUsername
-				password ossrhPassword
+				username System.getenv('OSSRH_USERNAME')
+				password System.getenv('OSSRH_PASSWORD')
 			}
 		}
 	}
 }
 
 signing {
-    sign publishing.publications.mavenJava
+	sign publishing.publications.mavenJava
+}
+
+nexusStaging {
+	packageGroup = "com.meilisearch"
+	serverUrl = "https://oss.sonatype.org/service/local/"
+	username System.getenv('OSSRH_USERNAME')
+	password System.getenv('OSSRH_PASSWORD')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,0 @@
-ossrhUsername=
-ossrhPassword=
-
-signing.keyId=
-signing.password=
-signing.secretKeyRingFile=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 ossrhUsername=
 ossrhPassword=
 
-signing.gnupg.executable=gpg
-signing.gnupg.keyName=
-signing.gnupg.passphrase=
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=


### PR DESCRIPTION
Closes #129 

In the build.gradle :
- Update from the deprecated plugin maven to maven-publish
- Signing is now linked to the Publishing task (variables have changed)
- Add nexusStaging task in order to automatize the closing and release in the nexus repository

Other :
- Add github action to publish the package on the Sonatype OSSRH on each release
- gradle.properties has been deleted and we now use environment variables
- Update CONTRIBUTING.md

@curquiza we will need to add the 'Check release validity'
@eskombro do we still need all the publishing steps in the CONTRIBUTING.md?

The last step of the  GitHub Action ossrh-publish.yml has not been tested  "Close and release Nexus Repository" as we don't want to publish a new version yet.
Also the Secrets need to be added.

:blush: