### PR TITLE
rewrite client to use ServiceTemplate based API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ java {
 
 repositories {
 	mavenCentral() // Required for Lombok dependency
-	jcenter()
 }
 
 configurations {

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -5,8 +5,9 @@ package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.api.documents.DocumentHandler;
 import com.meilisearch.sdk.api.index.IndexHandler;
+import com.meilisearch.sdk.api.instance.InstanceHandler;
+import com.meilisearch.sdk.api.keys.KeysHandler;
 
-import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -15,12 +16,16 @@ import java.util.stream.Collectors;
  */
 public class Client {
 	private final IndexHandler indexHandler;
+	private final InstanceHandler instanceHandler;
+	private final KeysHandler keysHandler;
 	private final Map<String, DocumentHandler<?>> handlerMap;
 	private final ServiceTemplate serviceTemplate;
 
 	Client(Config config, ServiceTemplate serviceTemplate) {
 		this.serviceTemplate = serviceTemplate;
 		this.indexHandler = new IndexHandler(serviceTemplate, serviceTemplate.getRequestFactory());
+		this.instanceHandler = new InstanceHandler(serviceTemplate, serviceTemplate.getRequestFactory());
+		this.keysHandler = new KeysHandler(serviceTemplate, serviceTemplate.getRequestFactory());
 		this.handlerMap = config.getModelMapping()
 			.entrySet()
 			.stream()
@@ -41,12 +46,10 @@ public class Client {
 		return (DocumentHandler<T>) this.handlerMap.get(uid);
 	}
 
-	@SuppressWarnings("unchecked")
 	public <T> DocumentHandler<T> documents(String uid, Class<T> model) {
 		DocumentHandler<T> handler = documents(uid);
 		if (handler != null) {
-			Class<T> handlerType = (Class<T>) ((ParameterizedType) handler.getClass().getGenericSuperclass()).getActualTypeArguments()[0];
-			if (handlerType == model) {
+			if (handler.getIndexModel() == model) {
 				return handler;
 			}
 		}
@@ -56,4 +59,11 @@ public class Client {
 		return handler;
 	}
 
+	public InstanceHandler instance() {
+		return instanceHandler;
+	}
+
+	public KeysHandler keys() {
+		return keysHandler;
+	}
 }

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -3,178 +3,57 @@
  */
 package com.meilisearch.sdk;
 
-import com.google.gson.Gson;
+import com.meilisearch.sdk.api.documents.DocumentHandler;
+import com.meilisearch.sdk.api.index.IndexHandler;
 
-import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * MeiliSearch client
  */
 public class Client {
-	public Config config;
-	public IndexesHandler indexesHandler;
-	public Gson gson;
-	public DumpHandler dumpHandler;
+	private final IndexHandler indexHandler;
+	private final Map<String, DocumentHandler<?>> handlerMap;
+	private final ServiceTemplate serviceTemplate;
 
-	/**
-	 * Calls instance for MeiliSearch client
-	 *
-	 * @param config Configuration to connect to MeiliSearch instance
-	 */
-	public Client(Config config) {
-		this.config = config;
-		this.gson = new Gson();
-		this.indexesHandler = new IndexesHandler(config);
-		this.dumpHandler = new DumpHandler(config);
+	Client(Config config, ServiceTemplate serviceTemplate) {
+		this.serviceTemplate = serviceTemplate;
+		this.indexHandler = new IndexHandler(serviceTemplate, serviceTemplate.getRequestFactory());
+		this.handlerMap = config.getModelMapping()
+			.entrySet()
+			.stream()
+			.collect(
+				Collectors.toMap(
+					Map.Entry::getKey,
+					entry -> new DocumentHandler<>(serviceTemplate, serviceTemplate.getRequestFactory(), entry.getKey(), entry.getValue())
+				)
+			);
 	}
 
-	/**
-	 * Creates index
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#create-an-index
-	 *
-	 * @param uid Unique identifier for the index to create
-	 * @return MeiliSearch API response
-	 * @throws Exception if an error occurs
-	 */
-	public Index createIndex(String uid) throws Exception {
-		return this.createIndex(uid, null);
+	public IndexHandler index() {
+		return this.indexHandler;
 	}
 
-	/**
-	 * Creates index
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#create-an-index
-	 *
-	 * @param uid Unique identifier for the index to create
-	 * @param primaryKey The primary key of the documents in that index
-	 * @return MeiliSearch API response
-	 * @throws Exception if an error occurs
-	 */
-	public Index createIndex(String uid, String primaryKey) throws Exception {
-		Index index = gson.fromJson(this.indexesHandler.create(uid, primaryKey), Index.class);
-		index.setConfig(this.config);
-		return index;
+	@SuppressWarnings("unchecked")
+	public <T> DocumentHandler<T> documents(String uid) {
+		return (DocumentHandler<T>) this.handlerMap.get(uid);
 	}
 
-	/**
-	 * Gets all indexes
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
-	 *
-	 * @return list of indexes in the MeiliSearch client
-	 * @throws Exception if an error occurs
-	 */
-	public Index[] getIndexList() throws Exception {
-		Index[] meiliSearchIndexList = gson.fromJson(this.indexesHandler.getAll(), Index[].class);
-		for (Index indexes : meiliSearchIndexList) {
-			indexes.setConfig(this.config);
-		}
-		return meiliSearchIndexList;
-	}
-
-	/**
-	 * Creates a local reference to an index identified by `uid`, without doing an HTTP call.
-	 * Calling this method doesn't create an index by itself, but grants access to all the other methods in the Index class.
-	 *
-	 * @param uid Unique identifier of the index
-	 * @return Index instance
-	 * @throws Exception if an error occurs
-	 */
-	public Index index(String uid) throws Exception {
-		Index index = new Index();
-		index.uid = uid;
-		index.setConfig(this.config);
-		return index;
-	}
-
-	/**
-	 * Gets single index by uid
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#get-one-index
-	 *
-	 * @param uid Unique identifier of the index to get
-	 * @return MeiliSearch API response
-	 * @throws Exception if an error occurs
-	 */
-	public Index getIndex(String uid) throws Exception {
-		Index indexes = gson.fromJson(this.indexesHandler.get(uid), Index.class);
-		indexes.setConfig(this.config);
-		return indexes;
-	}
-
-	/**
-	 * Updates single index by uid
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#update-an-index
-	 *
-	 * @param uid Unique identifier of the index to update
-	 * @param primaryKey Primary key of the documents in the index
-	 * @return MeiliSearch API response
-	 * @throws Exception if an error occurs
-	 */
-	public Index updateIndex(String uid, String primaryKey) throws Exception {
-		Index index = gson.fromJson(this.indexesHandler.updatePrimaryKey(uid, primaryKey), Index.class);
-		index.setConfig(this.config);
-		return index;
-	}
-
-	/**
-	 * Deletes single index by uid
-	 * Refer https://docs.meilisearch.com/reference/api/indexes.html#get-one-index
-	 *
-	 * @param uid Unique identifier of the index to delete
-	 * @return MeiliSearch API response
-	 * @throws Exception if an error occurs
-	 */
-	public String deleteIndex(String uid) throws Exception {
-		return this.indexesHandler.delete(uid);
-	}
-
-	/**
-	 * Gets single index by uid or if it does not exists, Create index
-	 *
-	 * @param uid Unique identifier for the index to create
-	 * @param primaryKey The primary key of the documents in that index
-	 * @return Index instance
-	 * @throws Exception if an error occurs
-	 */
-	public Index getOrCreateIndex(String uid, String primaryKey) throws Exception {
-		try {
-			return this.getIndex(uid);
-		} catch (MeiliSearchApiException e) {
-			if (e.getErrorCode().equals("index_not_found")) {
-				return this.createIndex(uid, primaryKey);
+	@SuppressWarnings("unchecked")
+	public <T> DocumentHandler<T> documents(String uid, Class<T> model) {
+		DocumentHandler<T> handler = documents(uid);
+		if (handler != null) {
+			Class<T> handlerType = (Class<T>) ((ParameterizedType) handler.getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+			if (handlerType == model) {
+				return handler;
 			}
-			throw e;
 		}
+		handler = new DocumentHandler<>(serviceTemplate, serviceTemplate.getRequestFactory(), uid, model);
+		handlerMap.put(uid, handler);
+
+		return handler;
 	}
 
-	/**
-	 * Gets single index by uid or if it does not exists, Create index
-	 *
-	 * @param uid Unique identifier for the index to create
-	 * @return Index instance
-	 * @throws Exception if an error occurs
-	 */
-	public Index getOrCreateIndex(String uid) throws Exception {
-		return getOrCreateIndex(uid, null);
-	}
-
-	/**
-	 * Triggers the creation of a MeiliSearch dump.
-	 * Refer https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
-	 *
-	 * @throws Exception if an error occurs
-	 */
-	public Dump createDump() throws Exception {
-		return this.dumpHandler.createDump();
-	}
-
-	/**
-	 * Gets the status of a MeiliSearch dump.
-	 * https://docs.meilisearch.com/reference/api/dump.html#get-dump-status
-	 *
-	 * @param uid Unique identifier for correspondent dump
-	 * @return String with dump status
-	 * @throws Exception if an error occurs
-	 */
-	public String getDumpStatus(String uid) throws Exception {
-		return this.dumpHandler.getDumpStatus(uid);
-	}
 }

--- a/src/main/java/com/meilisearch/sdk/ClientBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/ClientBuilder.java
@@ -1,0 +1,105 @@
+package com.meilisearch.sdk;
+
+import com.meilisearch.sdk.http.AbstractHttpClient;
+import com.meilisearch.sdk.http.ApacheHttpClient;
+import com.meilisearch.sdk.http.CustomOkHttpClient;
+import com.meilisearch.sdk.http.DefaultHttpClient;
+import com.meilisearch.sdk.http.factory.BasicRequestFactory;
+import com.meilisearch.sdk.http.factory.RequestFactory;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import com.meilisearch.sdk.json.JsonHandler;
+import com.meilisearch.sdk.json.JsonbJsonHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientBuilder {
+	private static final Logger log = LoggerFactory.getLogger(ClientBuilder.class);
+	private final Config config;
+	private ServiceTemplate serviceTemplate;
+	private AbstractHttpClient httpClient;
+	private JsonHandler jsonHandler;
+	private RequestFactory requestFactory;
+
+	private ClientBuilder(Config config) {
+		this.config = config;
+	}
+
+	public static ClientBuilder withConfig(Config config) {
+		return new ClientBuilder(config);
+	}
+
+	public ClientBuilder withServiceTemplate(ServiceTemplate serviceTemplate) {
+		this.serviceTemplate = serviceTemplate;
+		return this;
+	}
+
+	public ClientBuilder withAutodetectHttpClient() {
+		try {
+			Class.forName("com.google.gson.Gson", false, null);
+			this.httpClient = new ApacheHttpClient(config);
+			return this;
+		} catch (ClassNotFoundException e) {/* noop */}
+		try {
+			Class.forName("com.fasterxml.jackson.databind.ObjectMapper", false, null);
+			this.httpClient = new CustomOkHttpClient(config);
+			return this;
+		} catch (ClassNotFoundException e) {/* noop */}
+		this.httpClient = new DefaultHttpClient(config);
+		return this;
+	}
+
+	public ClientBuilder withHttpClient(AbstractHttpClient httpClient) {
+		this.httpClient = httpClient;
+		return this;
+	}
+
+	public ClientBuilder withAutodetectJsonHandler() {
+		try {
+			Class.forName("com.google.gson.Gson", false, null);
+			this.jsonHandler = new GsonJsonHandler();
+			return this;
+		} catch (ClassNotFoundException e) {/* noop */}
+		try {
+			Class.forName("com.fasterxml.jackson.databind.ObjectMapper", false, null);
+			this.jsonHandler = new JacksonJsonHandler();
+			return this;
+		} catch (ClassNotFoundException e) {/* noop */}
+		try {
+			Class.forName("javax.json.bind.Jsonb", false, null);
+			this.jsonHandler = new JsonbJsonHandler();
+			return this;
+		} catch (ClassNotFoundException e) {/* noop */}
+		throw new RuntimeException("No suitable json library found in classpath");
+	}
+
+	public ClientBuilder withJsonHandler(JsonHandler jsonHandler) {
+		this.jsonHandler = jsonHandler;
+		return this;
+	}
+
+	public ClientBuilder withRequestFactory(RequestFactory requestFactory) {
+		this.requestFactory = requestFactory;
+		return this;
+	}
+
+	public Client build() {
+		if (serviceTemplate != null && (jsonHandler != null || httpClient != null)) {
+			log.error("A ServiceTemplate is set while a JsonHandler and/or a HttpClient is set too. JsonHandler and HttpClient will be ignored!");
+		}
+		if (this.jsonHandler == null) {
+			this.withAutodetectJsonHandler();
+		}
+		if (this.httpClient == null) {
+			this.withAutodetectHttpClient();
+		}
+		if (this.requestFactory == null) {
+			this.requestFactory = new BasicRequestFactory(this.jsonHandler);
+		}
+		if (serviceTemplate == null) {
+			this.serviceTemplate = new GenericServiceTemplate(this.httpClient, this.jsonHandler, this.requestFactory);
+		}
+
+		return new Client(this.config, this.serviceTemplate);
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/ClientBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/ClientBuilder.java
@@ -94,7 +94,7 @@ public class ClientBuilder {
 			this.withAutodetectHttpClient();
 		}
 		if (this.requestFactory == null) {
-			this.requestFactory = new BasicRequestFactory(this.jsonHandler);
+			this.requestFactory = new BasicRequestFactory(this.jsonHandler, config);
 		}
 		if (serviceTemplate == null) {
 			this.serviceTemplate = new GenericServiceTemplate(this.httpClient, this.jsonHandler, this.requestFactory);

--- a/src/main/java/com/meilisearch/sdk/ClientBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/ClientBuilder.java
@@ -36,12 +36,12 @@ public class ClientBuilder {
 
 	public ClientBuilder withAutodetectHttpClient() {
 		try {
-			Class.forName("com.google.gson.Gson", false, null);
+			Class.forName("org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient", false, null);
 			this.httpClient = new ApacheHttpClient(config);
 			return this;
 		} catch (ClassNotFoundException e) {/* noop */}
 		try {
-			Class.forName("com.fasterxml.jackson.databind.ObjectMapper", false, null);
+			Class.forName("okhttp3.OkHttpClient", false, null);
 			this.httpClient = new CustomOkHttpClient(config);
 			return this;
 		} catch (ClassNotFoundException e) {/* noop */}
@@ -94,7 +94,7 @@ public class ClientBuilder {
 			this.withAutodetectHttpClient();
 		}
 		if (this.requestFactory == null) {
-			this.requestFactory = new BasicRequestFactory(this.jsonHandler);
+			this.requestFactory = new BasicRequestFactory(this.jsonHandler,this.config);
 		}
 		if (serviceTemplate == null) {
 			this.serviceTemplate = new GenericServiceTemplate(this.httpClient, this.jsonHandler, this.requestFactory);

--- a/src/main/java/com/meilisearch/sdk/ClientBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/ClientBuilder.java
@@ -94,7 +94,7 @@ public class ClientBuilder {
 			this.withAutodetectHttpClient();
 		}
 		if (this.requestFactory == null) {
-			this.requestFactory = new BasicRequestFactory(this.jsonHandler, config);
+			this.requestFactory = new BasicRequestFactory(this.jsonHandler);
 		}
 		if (serviceTemplate == null) {
 			this.serviceTemplate = new GenericServiceTemplate(this.httpClient, this.jsonHandler, this.requestFactory);

--- a/src/main/java/com/meilisearch/sdk/Config.java
+++ b/src/main/java/com/meilisearch/sdk/Config.java
@@ -1,11 +1,15 @@
 package com.meilisearch.sdk;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * MeiliSearch configuration
  */
 public class Config {
-	String hostUrl;
-	String apiKey;
+	private final String hostUrl;
+	private final String apiKey;
+	private Map<String, Class<?>> modelMapping;
 
 	/**
 	 * Creates a configuration without an API key
@@ -28,7 +32,21 @@ public class Config {
 	}
 
 	/**
+	 * Create a configuration with an API key
+	 *
+	 * @param hostUrl      URL of the Meilisearch instance
+	 * @param apiKey       API key to pass to the header of requests sent to Meilisearch
+	 * @param modelMapping Mapping of indexname to class
+	 */
+	public Config(String hostUrl, String apiKey, Map<String, Class<?>> modelMapping) {
+		this.hostUrl = hostUrl;
+		this.apiKey = apiKey;
+		this.modelMapping = Collections.unmodifiableMap(modelMapping);
+	}
+
+	/**
 	 * Method for returning the hostUrl
+	 *
 	 * @return host URL string of the MeiliSearch instance
 	 */
 	public String getHostUrl() {
@@ -37,9 +55,14 @@ public class Config {
 
 	/**
 	 * Method for returning the apiKey
+	 *
 	 * @return API key String
 	 */
 	public String getApiKey() {
 		return apiKey;
+	}
+
+	public Map<String, Class<?>> getModelMapping() {
+		return modelMapping;
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -28,7 +28,7 @@ class MeiliSearchHttpRequest {
 	protected MeiliSearchHttpRequest(Config config) {
 		this.client = new DefaultHttpClient(config);
 		this.jsonHandler = new GsonJsonHandler();
-		this.factory = new BasicRequestFactory(jsonHandler);
+		this.factory = new BasicRequestFactory(jsonHandler, config);
 	}
 
 	/**

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -189,6 +189,7 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * @param data a list of model to delete
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */
@@ -201,6 +202,8 @@ public class DocumentHandler<T> {
 	}
 
 	/**
+	 * @param data a list of model to delete
+	 * @param uidResolverFunc a function to resolve the id
 	 * @return an Update object with the updateId
 	 * @throws MeiliSearchRuntimeException in case something went wrong (http error, json exceptions, etc)
 	 */

--- a/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/DocumentHandler.java
@@ -8,6 +8,9 @@ import com.meilisearch.sdk.http.request.HttpMethod;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class DocumentHandler<T> {
 	private final ServiceTemplate serviceTemplate;

--- a/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
@@ -4,15 +4,15 @@ import java.util.Collections;
 import java.util.List;
 
 public class SearchRequest {
-	private final String q;
-	private final int offset;
-	private final int limit;
-	private final String filters;
-	private final List<String> attributesToRetrieve;
-	private final List<String> attributesToCrop;
-	private final int cropLength;
-	private final List<String> attributesToHighlight;
-	private final boolean matches;
+	private String q;
+	private int offset;
+	private int limit;
+	private String filters;
+	private List<String> attributesToRetrieve;
+	private List<String> attributesToCrop;
+	private int cropLength;
+	private List<String> attributesToHighlight;
+	private boolean matches;
 
 	public SearchRequest(String q) {
 		this(q, 0);
@@ -84,5 +84,50 @@ public class SearchRequest {
 
 	public boolean isMatches() {
 		return matches;
+	}
+
+	public SearchRequest setQ(String q) {
+		this.q = q;
+		return this;
+	}
+
+	public SearchRequest setOffset(int offset) {
+		this.offset = offset;
+		return this;
+	}
+
+	public SearchRequest setLimit(int limit) {
+		this.limit = limit;
+		return this;
+	}
+
+	public SearchRequest setFilters(String filters) {
+		this.filters = filters;
+		return this;
+	}
+
+	public SearchRequest setAttributesToRetrieve(List<String> attributesToRetrieve) {
+		this.attributesToRetrieve = attributesToRetrieve;
+		return this;
+	}
+
+	public SearchRequest setAttributesToCrop(List<String> attributesToCrop) {
+		this.attributesToCrop = attributesToCrop;
+		return this;
+	}
+
+	public SearchRequest setCropLength(int cropLength) {
+		this.cropLength = cropLength;
+		return this;
+	}
+
+	public SearchRequest setAttributesToHighlight(List<String> attributesToHighlight) {
+		this.attributesToHighlight = attributesToHighlight;
+		return this;
+	}
+
+	public SearchRequest setMatches(boolean matches) {
+		this.matches = matches;
+		return this;
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
@@ -2,6 +2,7 @@ package com.meilisearch.sdk.api.index;
 
 import com.meilisearch.sdk.ServiceTemplate;
 import com.meilisearch.sdk.api.documents.Update;
+import com.meilisearch.sdk.api.instance.IndexStats;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 import com.meilisearch.sdk.http.factory.RequestFactory;
 import com.meilisearch.sdk.http.request.HttpMethod;
@@ -128,5 +129,21 @@ public class IndexHandler {
 	 */
 	public Update resetSettings(String index) throws MeiliSearchRuntimeException {
 		return settingsHandler.resetSettings(index);
+	}
+
+
+	/**
+	 * Get Index Stats
+	 * Refer https://docs.meilisearch.com/reference/api/stats.html#get-stat-of-an-index
+	 *
+	 * @return Index Stats
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public IndexStats getStats(String index) {
+		String requestQuery = "/indexes/" + index + "/stats";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			IndexStats.class
+		);
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk.api.index;
 
 import com.meilisearch.sdk.ServiceTemplate;
+import com.meilisearch.sdk.UpdateStatus;
 import com.meilisearch.sdk.api.documents.Update;
 import com.meilisearch.sdk.api.instance.IndexStats;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
@@ -9,7 +10,9 @@ import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.concurrent.TimeoutException;
 
 public class IndexHandler {
 	private final ServiceTemplate serviceTemplate;
@@ -145,5 +148,21 @@ public class IndexHandler {
 			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
 			IndexStats.class
 		);
+	}
+
+	/**
+	 * Gets single index by uid or if it does not exists, Create index
+	 *
+	 * @param uid        Unique identifier for the index to create
+	 * @param primaryKey The primary key of the documents in that index
+	 * @return Index instance
+	 * @throws MeiliSearchRuntimeException if an error occurs
+	 */
+	public Index getOrCreateIndex(String uid, String primaryKey) {
+		try {
+			return this.getIndex(uid);
+		} catch (MeiliSearchRuntimeException e) {
+			return this.createIndex(uid, primaryKey);
+		}
 	}
 }

--- a/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/IndexHandler.java
@@ -1,7 +1,6 @@
 package com.meilisearch.sdk.api.index;
 
 import com.meilisearch.sdk.ServiceTemplate;
-import com.meilisearch.sdk.UpdateStatus;
 import com.meilisearch.sdk.api.documents.Update;
 import com.meilisearch.sdk.api.instance.IndexStats;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
@@ -10,9 +9,7 @@ import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.response.HttpResponse;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.concurrent.TimeoutException;
 
 public class IndexHandler {
 	private final ServiceTemplate serviceTemplate;
@@ -139,6 +136,7 @@ public class IndexHandler {
 	 * Get Index Stats
 	 * Refer https://docs.meilisearch.com/reference/api/stats.html#get-stat-of-an-index
 	 *
+	 * @param index the index name
 	 * @return Index Stats
 	 * @throws MeiliSearchRuntimeException if something goes wrong
 	 */

--- a/src/main/java/com/meilisearch/sdk/api/index/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/Settings.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * Refer https://docs.meilisearch.com/references/settings.html
  */
 public class Settings {
-	private HashMap<String, String[]> synonyms;
+	private HashMap<String, String[]> synonyms = new HashMap<>();
 	private String[] stopWords;
 	private String[] rankingRules;
 	private String[] attributesForFaceting;

--- a/src/main/java/com/meilisearch/sdk/api/index/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/api/index/Settings.java
@@ -1,7 +1,5 @@
 package com.meilisearch.sdk.api.index;
 
-import com.meilisearch.sdk.Index;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/com/meilisearch/sdk/api/instance/Dump.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/Dump.java
@@ -1,0 +1,22 @@
+package com.meilisearch.sdk.api.instance;
+
+public class Dump {
+	private String status;
+	private String uid;
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getUid() {
+		return uid;
+	}
+
+	public void setUid(String uid) {
+		this.uid = uid;
+	}
+}

--- a/src/main/java/com/meilisearch/sdk/api/instance/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/IndexStats.java
@@ -24,11 +24,11 @@ public class IndexStats {
 		this.numberOfDocuments = numberOfDocuments;
 	}
 
-	public boolean isIndexing() {
+	public boolean getIsIndexing() {
 		return isIndexing;
 	}
 
-	public void setIndexing(boolean indexing) {
+	public void setIsIndexing(boolean indexing) {
 		isIndexing = indexing;
 	}
 

--- a/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
@@ -19,6 +19,8 @@ public class InstanceHandler {
 	}
 
 	/**
+	 * Refer https://docs.meilisearch.com/reference/api/health.html
+	 *
 	 * @return true if everything is ok, false if meilisearch is in maintenance mode
 	 */
 	public boolean isHealthy() {
@@ -31,6 +33,8 @@ public class InstanceHandler {
 	}
 
 	/**
+	 * Refer https://docs.meilisearch.com/reference/api/stats.html
+	 *
 	 * @return a map with version information of meilisearch
 	 */
 	public Map<String, String> getVersion() {
@@ -46,20 +50,49 @@ public class InstanceHandler {
 		}
 	}
 
-
-	public IndexStats getStats(String index) {
-		String requestQuery = index + "/stats";
-		return serviceTemplate.execute(
-			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
-			IndexStats.class
-		);
-	}
-
+	/**
+	 * Get Stats
+	 * Refer https://docs.meilisearch.com/reference/api/stats.html
+	 *
+	 * @return Instance Stats
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
 	public Stats getStats() {
 		String requestQuery = "/stats";
 		return serviceTemplate.execute(
 			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
 			Stats.class
+		);
+	}
+
+	/**
+	 * Creates a dump
+	 * Refer https://docs.meilisearch.com/references/dump.html#create-a-dump
+	 *
+	 * @return Dump status
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Dump createDump() {
+		String requestQuery = "/dumps";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), null),
+			Dump.class
+		);
+	}
+
+	/**
+	 * Gets dump status
+	 * Refer https://docs.meilisearch.com/references/dump.html#get-dump-status
+	 *
+	 * @param uid Unique identifier for correspondent dump
+	 * @return dump status
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Dump getDumpStatus(String uid) {
+		String requestQuery = "/dumps/" + uid + "/status";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Dump.class
 		);
 	}
 

--- a/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
@@ -50,49 +50,20 @@ public class InstanceHandler {
 		}
 	}
 
-	/**
-	 * Get Stats
-	 * Refer https://docs.meilisearch.com/reference/api/stats.html
-	 *
-	 * @return Instance Stats
-	 * @throws MeiliSearchRuntimeException if something goes wrong
-	 */
+
+	public IndexStats getStats(String index) {
+		String requestQuery = index + "/stats";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			IndexStats.class
+		);
+	}
+
 	public Stats getStats() {
 		String requestQuery = "/stats";
 		return serviceTemplate.execute(
 			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
 			Stats.class
-		);
-	}
-
-	/**
-	 * Creates a dump
-	 * Refer https://docs.meilisearch.com/references/dump.html#create-a-dump
-	 *
-	 * @return Dump status
-	 * @throws MeiliSearchRuntimeException if something goes wrong
-	 */
-	public Dump createDump() {
-		String requestQuery = "/dumps";
-		return serviceTemplate.execute(
-			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), null),
-			Dump.class
-		);
-	}
-
-	/**
-	 * Gets dump status
-	 * Refer https://docs.meilisearch.com/references/dump.html#get-dump-status
-	 *
-	 * @param uid Unique identifier for correspondent dump
-	 * @return dump status
-	 * @throws MeiliSearchRuntimeException if something goes wrong
-	 */
-	public Dump getDumpStatus(String uid) {
-		String requestQuery = "/dumps/" + uid + "/status";
-		return serviceTemplate.execute(
-			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
-			Dump.class
 		);
 	}
 

--- a/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/api/instance/InstanceHandler.java
@@ -67,4 +67,35 @@ public class InstanceHandler {
 		);
 	}
 
+
+	/**
+	 * Creates a dump
+	 * Refer https://docs.meilisearch.com/references/dump.html#create-a-dump
+	 *
+	 * @return Dump status
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Dump createDump() {
+		String requestQuery = "/dumps";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.POST, requestQuery, Collections.emptyMap(), null),
+			Dump.class
+		);
+	}
+
+	/**
+	 * Gets dump status
+	 * Refer https://docs.meilisearch.com/references/dump.html#get-dump-status
+	 *
+	 * @param uid Unique identifier for correspondent dump
+	 * @return dump status
+	 * @throws MeiliSearchRuntimeException if something goes wrong
+	 */
+	public Dump getDumpStatus(String uid) {
+		String requestQuery = "/dumps/" + uid + "/status";
+		return serviceTemplate.execute(
+			requestFactory.create(HttpMethod.GET, requestQuery, Collections.emptyMap(), null),
+			Dump.class
+		);
+	}
 }

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -9,6 +9,7 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -34,9 +35,11 @@ public class ApacheHttpClient extends AbstractHttpClient {
 			.setSoTimeout(Timeout.ofSeconds(5))
 			.build();
 
-		this.client = HttpAsyncClients.custom()
+		CloseableHttpAsyncClient build = HttpAsyncClients.custom()
 			.setIOReactorConfig(ioReactorConfig)
 			.build();
+		build.start();
+		this.client = build;
 	}
 
 	public ApacheHttpClient(Config config, HttpAsyncClient client) {

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.http.factory;
 
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 import com.meilisearch.sdk.http.request.BasicHttpRequest;
 import com.meilisearch.sdk.http.request.HttpMethod;
@@ -10,15 +11,17 @@ import java.util.Map;
 
 public class BasicRequestFactory implements RequestFactory {
 	private final JsonHandler jsonHandler;
+	private final Config config;
 
-	public BasicRequestFactory(JsonHandler jsonHandler) {
+	public BasicRequestFactory(JsonHandler jsonHandler, Config config) {
 		this.jsonHandler = jsonHandler;
+		this.config = config;
 	}
 
 	@Override
 	public <T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content) {
 		try {
-			return new BasicHttpRequest(method, path, headers, content == null ? null : this.jsonHandler.encode(content));
+			return new BasicHttpRequest(method, config.getHostUrl() + path, headers, this.jsonHandler.encode(content));
 		} catch (Exception e) {
 			throw new MeiliSearchRuntimeException(e);
 		}

--- a/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
+++ b/src/main/java/com/meilisearch/sdk/http/factory/BasicRequestFactory.java
@@ -21,7 +21,7 @@ public class BasicRequestFactory implements RequestFactory {
 	@Override
 	public <T> HttpRequest<?> create(HttpMethod method, String path, Map<String, String> headers, T content) {
 		try {
-			return new BasicHttpRequest(method, config.getHostUrl() + path, headers, this.jsonHandler.encode(content));
+			return new BasicHttpRequest(method, config.getHostUrl() + path, headers, content == null ? null : this.jsonHandler.encode(content));
 		} catch (Exception e) {
 			throw new MeiliSearchRuntimeException(e);
 		}

--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -2,6 +2,7 @@ package com.meilisearch.sdk.json;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 
 public class GsonJsonHandler implements JsonHandler {
 	private final Gson gson;
@@ -16,14 +17,14 @@ public class GsonJsonHandler implements JsonHandler {
 
 	@Override
 	public String encode(Object o) throws Exception {
-		if (o.getClass() == String.class) {
+		if (o != null && o.getClass() == String.class) {
 			return (String) o;
 		}
 		try {
 			return gson.toJson(o);
 		} catch (Exception e) {
 			// todo: use dedicated exception
-			throw new RuntimeException("Error while serializing: ", e);
+			throw new MeiliSearchRuntimeException(e);
 		}
 	}
 
@@ -32,7 +33,7 @@ public class GsonJsonHandler implements JsonHandler {
 	public <T> T decode(Object o, Class<?> targetClass, Class<?>... parameters) throws Exception {
 		if (o == null) {
 			// todo: use dedicated exception
-			throw new RuntimeException("String to deserialize is null");
+			throw new MeiliSearchRuntimeException();
 		}
 		if (targetClass == String.class) {
 			return (T) o;
@@ -46,7 +47,7 @@ public class GsonJsonHandler implements JsonHandler {
 			}
 		} catch (Exception e) {
 			// todo: use dedicated exception
-			throw new RuntimeException("Error while deserializing: ", e);
+			throw new MeiliSearchRuntimeException(e);
 		}
 	}
 }

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -2,8 +2,8 @@ package com.meilisearch.integration;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
-import com.meilisearch.sdk.Dump;
-import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.api.index.Index;
+import com.meilisearch.sdk.api.instance.Dump;
 import com.meilisearch.sdk.utils.Movie;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +14,7 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 
 @Tag("integration")
 public class ClientTest extends AbstractIT {
@@ -40,10 +40,10 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testCreateIndexWithoutPrimaryKey() throws Exception {
 		String indexUid = "CreateIndexWithoutPrimaryKey";
-		Index index = client.createIndex(indexUid);
+		Index index = client.index().createIndex(indexUid);
 		assertEquals(index.getUid(), indexUid);
 		assertNull(index.getPrimaryKey());
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	/**
@@ -52,32 +52,32 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testCreateIndexWithPrimaryKey() throws Exception {
 		String indexUid = "CreateIndexWithPrimaryKey";
-		Index index = client.createIndex(indexUid, this.primaryKey);
+		Index index = client.index().createIndex(indexUid, this.primaryKey);
 		assertEquals(index.getUid(), indexUid);
 		assertEquals(index.getPrimaryKey(), this.primaryKey);
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	@Test
 	public void testCreateIndexWithPrimaryKeyIfIndexDoesNotExists() throws Exception {
 		String indexUid = "dummyIndexUid";
-		Index index = client.getOrCreateIndex(indexUid, this.primaryKey);
+		Index index = client.index().getOrCreateIndex(indexUid, this.primaryKey);
 		assertEquals(index.getUid(), indexUid);
 		assertEquals(index.getPrimaryKey(), this.primaryKey);
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	@Test
 	public void testGetIndexWithPrimaryKeyIfIndexAlreadyExists() throws Exception {
 		String indexUid = "dummyIndexUid";
-		Index createdIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
+		Index createdIndex = client.index().getOrCreateIndex(indexUid, this.primaryKey);
 		assertEquals(createdIndex.getUid(), indexUid);
 
-		Index retrievedIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
+		Index retrievedIndex = client.index().getOrCreateIndex(indexUid, this.primaryKey);
 		assertEquals(retrievedIndex.getUid(), indexUid);
 		assertEquals(createdIndex.getUid(), retrievedIndex.getUid());
 
-		client.deleteIndex(createdIndex.getUid());
+		client.index().deleteIndex(createdIndex.getUid());
 	}
 
 	@Test
@@ -85,13 +85,13 @@ public class ClientTest extends AbstractIT {
 		String indexUid = "dummyIndexUid";
 		Index createdIndex = null;
 		try {
-			createdIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
-			Index retrievedIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
+			createdIndex = client.index().getOrCreateIndex(indexUid, this.primaryKey);
+			Index retrievedIndex = client.index().getOrCreateIndex(indexUid, this.primaryKey);
 		} catch (Exception e) {
-			client.deleteIndex(createdIndex.getUid());
+			client.index().deleteIndex(createdIndex.getUid());
 			fail("Should Not Throw Any Exception");
 		}
-		client.deleteIndex(createdIndex.getUid());
+		client.index().deleteIndex(createdIndex.getUid());
 	}
 
 	/**
@@ -100,14 +100,14 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testCreateIndexAlreadyExists() throws Exception {
 		String indexUid = "CreateIndexAlreadyExists";
-		Index index = client.createIndex(indexUid, this.primaryKey);
+		Index index = client.index().createIndex(indexUid, this.primaryKey);
 		assertEquals(index.getUid(), indexUid);
 		assertEquals(index.getPrimaryKey(), this.primaryKey);
 		assertThrows(
-			MeiliSearchApiException.class,
-			() -> client.createIndex(indexUid, this.primaryKey)
+			MeiliSearchRuntimeException.class,
+			() -> client.index().createIndex(indexUid, this.primaryKey)
 		);
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	/**
@@ -116,14 +116,14 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testUpdateIndexPrimaryKey() throws Exception {
 		String indexUid = "UpdateIndexPrimaryKey";
-		Index index = client.createIndex(indexUid);
+		Index index = client.index().createIndex(indexUid);
 		assertEquals(index.getUid(), indexUid);
 		assertNull(index.getPrimaryKey());
-		index = client.updateIndex(indexUid, this.primaryKey);
+		index = client.index().updateIndex(indexUid, this.primaryKey);
 		assertTrue(index instanceof Index);
 		assertEquals(index.getUid(), indexUid);
 		assertEquals(index.getPrimaryKey(), this.primaryKey);
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	/**
@@ -132,11 +132,11 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testGetIndex() throws Exception {
 		String indexUid = "GetIndex";
-		Index index = client.createIndex(indexUid);
-		Index getIndex = client.getIndex(indexUid);
+		Index index = client.index().createIndex(indexUid);
+		Index getIndex = client.index().getIndex(indexUid);
 		assertEquals(index.getUid(), getIndex.getUid());
 		assertEquals(index.getPrimaryKey(), getIndex.getPrimaryKey());
-		client.deleteIndex(index.getUid());
+		client.index().deleteIndex(index.getUid());
 	}
 
 	/**
@@ -145,14 +145,14 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testGetIndexList() throws Exception {
 		String[] indexUids = {"GetIndexList", "GetIndexList2"};
-		Index index1 = client.createIndex(indexUids[0]);
-		Index index2 = client.createIndex(indexUids[1], this.primaryKey);
-		Index[] indexes = client.getIndexList();
+		Index index1 = client.index().createIndex(indexUids[0]);
+		Index index2 = client.index().createIndex(indexUids[1], this.primaryKey);
+		Index[] indexes = client.index().getAllIndexes();
 		assertEquals(2, indexes.length);
 		assert (Arrays.asList(indexUids).contains(indexUids[0]));
 		assert (Arrays.asList(indexUids).contains(indexUids[1]));
-		client.deleteIndex(indexUids[0]);
-		client.deleteIndex(indexUids[1]);
+		client.index().deleteIndex(indexUids[0]);
+		client.index().deleteIndex(indexUids[1]);
 	}
 
 	/**
@@ -161,11 +161,11 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testDeleteIndex() throws Exception {
 		String indexUid = "DeleteIndex";
-		Index index = client.createIndex(indexUid);
-		client.deleteIndex(index.getUid());
+		Index index = client.index().createIndex(indexUid);
+		client.index().deleteIndex(index.getUid());
 		assertThrows(
-			MeiliSearchApiException.class,
-			() -> client.getIndex(indexUid)
+			MeiliSearchRuntimeException.class,
+			() -> client.index().getIndex(indexUid)
 		);
 	}
 
@@ -175,11 +175,9 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testIndexMethodCallInexistentIndex() throws Exception {
 		String indexUid = "IndexMethodCallInexistentIndex";
-		Index index = client.index(indexUid);
-		assertEquals(indexUid, index.getUid());
 		assertThrows(
-			MeiliSearchApiException.class,
-			() -> client.getIndex(indexUid)
+			MeiliSearchRuntimeException.class,
+			() -> client.index().getIndex(indexUid)
 		);
 	}
 
@@ -189,8 +187,8 @@ public class ClientTest extends AbstractIT {
 	@Test
 	public void testIndexMethodCallExistingIndex() throws Exception {
 		String indexUid = "IndexMethodCallExistingIndex";
-		Index createdIndex = client.createIndex(indexUid);
-		Index index = client.index(indexUid);
+		Index createdIndex = client.index().createIndex(indexUid);
+		Index index = client.index().getIndex(indexUid);
 		assertEquals(createdIndex.getUid(), index.getUid());
 		assertEquals(null, index.getPrimaryKey());
 	}
@@ -202,11 +200,9 @@ public class ClientTest extends AbstractIT {
 	public void testIndexMethodCallExistingIndexWithPrimaryKey() throws Exception {
 		String indexUid = "IndexMethodCallExistingIndexWithPrimaryKey";
 		String primaryKey = "PrimaryKey";
-		Index createdIndex = client.createIndex(indexUid, primaryKey);
-		Index index = client.index(indexUid);
+		Index createdIndex = client.index().createIndex(indexUid, primaryKey);
+		Index index = client.index().getIndex(indexUid);
 		assertEquals(createdIndex.getUid(), index.getUid());
-		assertEquals(null, index.getPrimaryKey());
-		index.fetchPrimaryKey();
 		assertEquals(primaryKey, index.getPrimaryKey());
 	}
 
@@ -215,7 +211,7 @@ public class ClientTest extends AbstractIT {
 	 */
 	@Test
 	public void testCreateDump() throws Exception {
-		Dump dump = client.createDump();
+		Dump dump = client.instance().createDump();
 		String status = dump.getStatus();
 		assertEquals(status, "in_progress");
 	}
@@ -225,9 +221,9 @@ public class ClientTest extends AbstractIT {
 	 */
 	@Test
 	public void testGetDumpStatus() throws Exception {
-		Dump dump = client.createDump();
+		Dump dump = client.instance().createDump();
 		String uid = dump.getUid();
-		String status = client.getDumpStatus(uid);
+		Dump status = client.instance().getDumpStatus(uid);
 		assertNotNull(status);
 		assertNotNull(uid);
 	}

--- a/src/test/java/com/meilisearch/integration/DocumentsTest.java
+++ b/src/test/java/com/meilisearch/integration/DocumentsTest.java
@@ -46,7 +46,7 @@ public class DocumentsTest extends AbstractIT {
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		Movie singleDocument = testData.getData().get(0);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(Collections.singletonList(singleDocument));
+		Update update = movieHandler.addDocuments(Collections.singletonList(singleDocument));
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
 
@@ -74,7 +74,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
@@ -94,7 +94,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
 		Movie toUpdate = movies[0];
@@ -119,7 +119,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
 		List<Movie> toUpdate = new ArrayList<>();
@@ -151,7 +151,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie movie = movieHandler.getDocument(testData.getData().get(0).getId());
 		assertEquals(movie.getTitle(), testData.getData().get(0).getTitle());
@@ -168,7 +168,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
 		assertEquals(20, movies.length);
@@ -195,7 +195,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 		Movie[] movies = movieHandler.getDocuments(limit).toArray(new Movie[0]);
 		assertEquals(limit, movies.length);
@@ -215,7 +215,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
@@ -243,7 +243,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);
@@ -288,7 +288,7 @@ public class DocumentsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movieHandler = client.documents("movies");
-		Update update = movieHandler.addDocument(testData.getData());
+		Update update = movieHandler.addDocuments(testData.getData());
 		movieHandler.waitForPendingUpdate(update.getUpdateId());
 
 		Movie[] movies = movieHandler.getDocuments().toArray(new Movie[0]);

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -1,16 +1,21 @@
 package com.meilisearch.integration;
 
 import com.meilisearch.integration.classes.AbstractIT;
-import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.api.index.Index;
 import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
-import org.junit.jupiter.api.*;
+import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("integration")
 public class ExceptionsTest extends AbstractIT {
-	
+
 
 	@BeforeEach
 	public void initialize() {
@@ -32,7 +37,7 @@ public class ExceptionsTest extends AbstractIT {
 		String errorType = "authentication_error";
 		String errorLink = "https://docs.meilisearch.com/errors#missing_authorization_header";
 		try {
-			throw new MeiliSearchApiException(new APIError(errorMessage,errorCode,errorType,errorLink));
+			throw new MeiliSearchApiException(new APIError(errorMessage, errorCode, errorType, errorLink));
 		} catch (MeiliSearchApiException e) {
 			assertEquals(errorMessage, e.getMessage());
 			assertEquals(errorCode, e.getErrorCode());
@@ -45,17 +50,19 @@ public class ExceptionsTest extends AbstractIT {
 	 * Test MeiliSearchApiException is thrown on MeiliSearch bad request
 	 */
 	@Test
-	public void testMeiliSearchApiExceptionBadRequest () throws Exception {
+	public void testMeiliSearchApiExceptionBadRequest() throws Exception {
 		String indexUid = "MeiliSearchApiExceptionBadRequest";
-		Index index = client.createIndex(indexUid);
+		Index index = client.index().createIndex(indexUid);
 		assertThrows(
-			MeiliSearchApiException.class,
-			() -> client.createIndex(indexUid)
+			MeiliSearchRuntimeException.class,
+			() -> client.index().createIndex(indexUid)
 		);
 		try {
-			client.createIndex(indexUid);
-		} catch (MeiliSearchApiException e) {
-			assertEquals("index_already_exists", e.getErrorCode());
+			client.index().createIndex(indexUid);
+		} catch (MeiliSearchRuntimeException e) {
+			if (e.getCause().getClass() == MeiliSearchApiException.class) {
+				assertEquals("index_already_exists", ((MeiliSearchApiException) e.getCause()).getErrorCode());
+			}
 		}
 	}
 }

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -28,17 +28,6 @@ public class SearchTest extends AbstractIT {
 
 	private TestData<Movie> testData;
 
-	final class Results {
-		Movie[] hits;
-		int offset;
-		int limit;
-		int nbHits;
-		boolean exhaustiveNbHits;
-		int processingTimeMs;
-		String query;
-	}
-
-
 	@BeforeEach
 	public void initialize() {
 		this.setUp();
@@ -64,7 +53,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchResponse<Movie> res = movies.search("batman");
@@ -88,7 +77,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("a").setOffset(20);
@@ -108,7 +97,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("a").setLimit(2);
@@ -128,7 +117,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("a")
@@ -155,7 +144,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("and")
@@ -177,7 +166,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("and")
@@ -199,7 +188,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("and")
@@ -221,7 +210,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("and")
@@ -243,7 +232,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchRequest searchRequest = new SearchRequest("and")
@@ -270,7 +259,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchResponse<Movie> emptySearch = movies.search("");
@@ -290,7 +279,7 @@ public class SearchTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		SearchResponse<Movie> search = movies.search(new SearchRequest(null).setLimit(10));

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -45,7 +45,7 @@ public class SettingsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		Settings settings = client.index().getSettings(indexUid);
@@ -64,7 +64,7 @@ public class SettingsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		Settings settings = new Settings();
@@ -95,7 +95,7 @@ public class SettingsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		Settings settings = new Settings();
@@ -123,7 +123,7 @@ public class SettingsTest extends AbstractIT {
 
 		TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		Settings initialSettings = new Settings();

--- a/src/test/java/com/meilisearch/integration/UpdatesTest.java
+++ b/src/test/java/com/meilisearch/integration/UpdatesTest.java
@@ -67,7 +67,7 @@ public class UpdatesTest extends AbstractIT {
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		List<Update> updates = movies.getUpdates();
-		assertEquals(3, updates.size());
+		assertEquals(4, updates.size());
 	}
 
 	/**

--- a/src/test/java/com/meilisearch/integration/UpdatesTest.java
+++ b/src/test/java/com/meilisearch/integration/UpdatesTest.java
@@ -41,7 +41,7 @@ public class UpdatesTest extends AbstractIT {
 		Index index = client.index().getOrCreateIndex(indexUid, "");
 
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		update = movies.getUpdate(update.getUpdateId());
@@ -59,11 +59,11 @@ public class UpdatesTest extends AbstractIT {
 		Index index = client.index().getOrCreateIndex(indexUid, "");
 
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
-		update = movies.addDocument(testData.getData());
+		update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
-		update = movies.addDocument(testData.getData());
+		update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 
 		List<Update> updates = movies.getUpdates();
@@ -79,7 +79,7 @@ public class UpdatesTest extends AbstractIT {
 		Index index = client.index().getOrCreateIndex(indexUid, "");
 
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 		movies.waitForPendingUpdate(update.getUpdateId());
 		update = movies.getUpdate(update.getUpdateId());
 
@@ -97,7 +97,7 @@ public class UpdatesTest extends AbstractIT {
 		Index index = client.index().getOrCreateIndex(indexUid, "");
 
 		DocumentHandler<Movie> movies = client.documents("movies", Movie.class);
-		Update update = movies.addDocument(testData.getData());
+		Update update = movies.addDocuments(testData.getData());
 
 		assertThrows(
 			Exception.class,

--- a/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
+++ b/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
@@ -4,12 +4,16 @@ package com.meilisearch.integration.classes;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.ClientBuilder;
 import com.meilisearch.sdk.Config;
-import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.api.index.Index;
+import com.meilisearch.sdk.http.ApacheHttpClient;
+import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.utils.Movie;
 
 import java.io.*;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +36,13 @@ public abstract class AbstractIT {
 	}
 
 	public void setUp() {
-		if (client == null)
-			client = new Client(new Config("http://localhost:7700", "masterKey"));
+		if (client == null) {
+			Map<String, Class<?>> modelMapping = Collections.singletonMap("movies", Movie.class);
+			Config config = new Config("http://localhost:7700", "masterKey", modelMapping);
+			ApacheHttpClient httpClient = new ApacheHttpClient(config);
+			GsonJsonHandler handler = new GsonJsonHandler();
+			client = ClientBuilder.withConfig(config).withHttpClient(httpClient).withJsonHandler(handler).build();
+		}
 	}
 
 
@@ -56,10 +65,15 @@ public abstract class AbstractIT {
 
 	static public void deleteAllIndexes() {
 		try {
-			Client ms = new Client(new Config("http://localhost:7700", "masterKey"));
-			Index[] indexes = ms.getIndexList();
+			Map<String, Class<?>> modelMapping = Collections.singletonMap("movies", Movie.class);
+			Config config = new Config("http://localhost:7700", "masterKey", modelMapping);
+			ApacheHttpClient httpClient = new ApacheHttpClient(config);
+			GsonJsonHandler handler = new GsonJsonHandler();
+			Client ms = ClientBuilder.withConfig(config).withHttpClient(httpClient).withJsonHandler(handler).build();
+
+			Index[] indexes = ms.index().getAllIndexes();
 			for (Index index : indexes) {
-				ms.deleteIndex(index.getUid());
+				ms.index().deleteIndex(index.getUid());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
+++ b/src/test/java/com/meilisearch/sdk/GenericServiceTemplateTest.java
@@ -20,8 +20,9 @@ import static org.mockito.Mockito.when;
 class GenericServiceTemplateTest {
 
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
+	private final Config config = new Config("http://localhost:7700","masterKey");
 	private final JsonHandler handler = mock(JsonHandler.class);
-	private final GenericServiceTemplate classToTest = new GenericServiceTemplate(client, handler, new BasicRequestFactory(handler));
+	private final GenericServiceTemplate classToTest = new GenericServiceTemplate(client, handler, new BasicRequestFactory(handler, config));
 
 	@Test
 	void getClient() {

--- a/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/documents/DocumentHandlerTest.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk.api.documents;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.GenericServiceTemplate;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 import com.meilisearch.sdk.http.AbstractHttpClient;
@@ -23,7 +24,8 @@ class DocumentHandlerTest {
 
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
 	private final JsonHandler jsonHandler = new JacksonJsonHandler(new ObjectMapper());
-	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler);
+	private final Config config = new Config("http://localhost:7700","masterKey");
+	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler, config);
 	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, jsonHandler, requestFactory);
 	private final DocumentHandler<Movie> classToTest = new DocumentHandler<Movie>(serviceTemplate, requestFactory, "movies", Movie.class);
 

--- a/src/test/java/com/meilisearch/sdk/api/index/IndexHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/index/IndexHandlerTest.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk.api.index;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.GenericServiceTemplate;
 import com.meilisearch.sdk.api.documents.Update;
 import com.meilisearch.sdk.api.instance.IndexStats;
@@ -30,7 +31,8 @@ class IndexHandlerTest {
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
 	private final JsonHandler jsonHandler = new JacksonJsonHandler(new ObjectMapper());
 	private final SettingsHandler settingsService = mock(SettingsHandler.class);
-	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler);
+	private final Config config = new Config("http://localhost:7700","masterKey");
+	private final RequestFactory requestFactory = new BasicRequestFactory(jsonHandler, config);
 	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, jsonHandler, requestFactory);
 	private final IndexHandler classToTest = new IndexHandler(serviceTemplate, requestFactory, settingsService);
 

--- a/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
@@ -63,24 +63,10 @@ class InstanceHandlerTest {
 		assertThat(stats.getIndexes().keySet(), hasItems("movies", "rangemovies"));
 		IndexStats movies = stats.getIndexes().get("movies");
 		assertThat(movies.getNumberOfDocuments(), is(19654));
-		assertThat(movies.isIndexing(), is(false));
+		assertThat(movies.getIsIndexing(), is(false));
 		assertThat(movies.getFieldsDistribution().keySet(), hasItems("overview", "id", "title"));
 		assertThat(movies.getFieldsDistribution().get("overview"), is(19654));
 		assertThat(movies.getFieldsDistribution().get("id"), is(19654));
 		assertThat(movies.getFieldsDistribution().get("title"), is(19654));
-	}
-
-	@Test
-	void singleStats() throws Exception {
-		when(client.get(any(HttpRequest.class)))
-			.thenAnswer(invocation -> new BasicHttpResponse(null, 200, "{\"numberOfDocuments\": 19654,\"isIndexing\": false,\"fieldsDistribution\": {\"poster\": 19654,\"release_date\": 19654,\"title\": 19654,\"id\": 19654,\"overview\": 19654}}"))
-			.thenThrow(MeiliSearchRuntimeException.class);
-		IndexStats stats = classToTest.getStats("index");
-		assertThat(stats.getNumberOfDocuments(), is(19654));
-		assertThat(stats.isIndexing(), is(false));
-		assertThat(stats.getFieldsDistribution().keySet(), hasItems("overview", "id", "title", "release_date", "poster"));
-		assertThat(stats.getFieldsDistribution().get("overview"), is(19654));
-		assertThat(stats.getFieldsDistribution().get("id"), is(19654));
-		assertThat(stats.getFieldsDistribution().get("title"), is(19654));
 	}
 }

--- a/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/instance/InstanceHandlerTest.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.api.instance;
 
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.GenericServiceTemplate;
 import com.meilisearch.sdk.exceptions.MeiliSearchRuntimeException;
 import com.meilisearch.sdk.http.AbstractHttpClient;
@@ -23,7 +24,8 @@ class InstanceHandlerTest {
 
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
 	private final JsonHandler handler = new JacksonJsonHandler();
-	private final RequestFactory requestFactory = new BasicRequestFactory(handler);
+	private final Config config = new Config("http://localhost:7700","masterKey");
+	private final RequestFactory requestFactory = new BasicRequestFactory(handler, config);
 	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, handler, requestFactory);
 	InstanceHandler classToTest = new InstanceHandler(serviceTemplate, requestFactory);
 

--- a/src/test/java/com/meilisearch/sdk/api/keys/KeysHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/api/keys/KeysHandlerTest.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk.api.keys;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.GenericServiceTemplate;
 import com.meilisearch.sdk.http.AbstractHttpClient;
 import com.meilisearch.sdk.http.factory.BasicRequestFactory;
@@ -21,7 +22,8 @@ import static org.mockito.Mockito.*;
 class KeysHandlerTest {
 	private final AbstractHttpClient client = mock(AbstractHttpClient.class);
 	private final JsonHandler processor = new JacksonJsonHandler(new ObjectMapper());
-	private final RequestFactory requestFactory = new BasicRequestFactory(processor);
+	private final Config config = new Config("http://localhost:7700","masterKey");
+	private final RequestFactory requestFactory = new BasicRequestFactory(processor, config);
 	private final GenericServiceTemplate serviceTemplate = new GenericServiceTemplate(client, processor, requestFactory);
 	private final KeysHandler classToTest = new KeysHandler(serviceTemplate, requestFactory);
 

--- a/src/test/java/com/meilisearch/sdk/http/factory/BasicRequestFactoryTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/factory/BasicRequestFactoryTest.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.http.factory;
 
+import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.http.request.HttpMethod;
 import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.json.GsonJsonHandler;
@@ -13,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 class BasicRequestFactoryTest {
 
-	private final RequestFactory factory = new BasicRequestFactory(new GsonJsonHandler());
+	private final RequestFactory factory = new BasicRequestFactory(new GsonJsonHandler(),new Config(""));
 
 	@Test
 	void basicUseCase() {

--- a/src/test/resources/movies.json
+++ b/src/test/resources/movies.json
@@ -28,7 +28,7 @@
 	   "id":454626,
 	   "title":"Sonic the Hedgehog",
 	   "poster":"https://image.tmdb.org/t/p/original/aQvJ5WPzZgYVDrxLX4R6cLJCEaQ.jpg",
-	   "overview":"Based on the global blockbuster videogame franchise from Sega, Sonic the Hedgehog tells the story of the world\u2019s speediest hedgehog as he embraces his new home on Earth. In this live-action adventure comedy, Sonic and his new best friend team up to defend the planet from the evil genius Dr. Robotnik and his plans for world domination.",
+	   "overview":"Based on the global blockbuster videogame franchise from Sega, Sonic the Hedgehog tells the story of the world's speediest hedgehog as he embraces his new home on Earth. In this live-action adventure comedy, Sonic and his new best friend team up to defend the planet from the evil genius Dr. Robotnik and his plans for world domination.",
 	   "release_date":"2020-02-12",
 	   "language":"en",
 	   "genres":[
@@ -42,7 +42,7 @@
 	   "id":338762,
 	   "title":"Bloodshot",
 	   "poster":"https://image.tmdb.org/t/p/original/8WUVHemHFH2ZIP6NWkwlHWsyrEL.jpg",
-	   "overview":"After he and his wife are murdered, marine Ray Garrison is resurrected by a team of scientists. Enhanced with nanotechnology, he becomes a superhuman, biotech killing machine\u2014'Bloodshot'. As Ray first trains with fellow super-soldiers, he cannot recall anything from his former life. But when his memories flood back and he remembers the man that killed both him and his wife, he breaks out of the facility to get revenge, only to discover that there's more to the conspiracy than he thought.",
+	   "overview":"After he and his wife are murdered, marine Ray Garrison is resurrected by a team of scientists. Enhanced with nanotechnology, he becomes a superhuman, biotech killing machine - 'Bloodshot'. As Ray first trains with fellow super-soldiers, he cannot recall anything from his former life. But when his memories flood back and he remembers the man that killed both him and his wife, he breaks out of the facility to get revenge, only to discover that there's more to the conspiracy than he thought.",
 	   "release_date":"2020-03-05",
 	   "language":"en",
 	   "genres":[
@@ -67,7 +67,7 @@
 	   "id":514847,
 	   "title":"The Hunt",
 	   "poster":"https://image.tmdb.org/t/p/original/wxPhn4ef1EAo5njxwBkAEVrlJJG.jpg",
-	   "overview":"Twelve strangers wake up in a clearing. They don't know where they are\u2014or how they got there. In the shadow of a dark internet conspiracy theory, ruthless elitists gather at a remote location to hunt humans for sport. But their master plan is about to be derailed when one of the hunted turns the tables on her pursuers.",
+	   "overview":"Twelve strangers wake up in a clearing. They don't know where they are - or how they got there. In the shadow of a dark internet conspiracy theory, ruthless elitists gather at a remote location to hunt humans for sport. But their master plan is about to be derailed when one of the hunted turns the tables on her pursuers.",
 	   "release_date":"2020-03-11",
 	   "language":"en",
 	   "genres":[
@@ -150,7 +150,7 @@
 	   "id":385103,
 	   "title":"Scoob!",
 	   "poster":"https://image.tmdb.org/t/p/original/jHo2M1OiH9Re33jYtUQdfzPeUkx.jpg",
-	   "overview":"In Scooby-Doo\u2019s greatest adventure yet, see the never-before told story of how lifelong friends Scooby and Shaggy first met and how they joined forces with young detectives Fred, Velma, and Daphne to form the famous Mystery Inc. Now, with hundreds of cases solved, Scooby and the gang face their biggest, toughest mystery ever: an evil plot to unleash the ghost dog Cerberus upon the world. As they race to stop this global \u201cdogpocalypse,\u201d the gang discovers that Scooby has a secret legacy and an epic destiny greater than anyone ever imagined.",
+	   "overview":"In Scooby-Doo's greatest adventure yet, see the never-before told story of how lifelong friends Scooby and Shaggy first met and how they joined forces with young detectives Fred, Velma, and Daphne to form the famous Mystery Inc. Now, with hundreds of cases solved, Scooby and the gang face their biggest, toughest mystery ever: an evil plot to unleash the ghost dog Cerberus upon the world. As they race to stop this global  'dogpocalypse, ' the gang discovers that Scooby has a secret legacy and an epic destiny greater than anyone ever imagined.",
 	   "release_date":"2020-05-15",
 	   "language":"en",
 	   "genres":[
@@ -204,7 +204,7 @@
 	   "id":522627,
 	   "title":"The Gentlemen",
 	   "poster":"https://image.tmdb.org/t/p/original/jtrhTYB7xSrJxR1vusu99nvnZ1g.jpg",
-	   "overview":"American expat Mickey Pearson has built a highly profitable marijuana empire in London. When word gets out that he\u2019s looking to cash out of the business forever it triggers plots, schemes, bribery and blackmail in an attempt to steal his domain out from under him.",
+	   "overview":"American expat Mickey Pearson has built a highly profitable marijuana empire in London. When word gets out that he's looking to cash out of the business forever it triggers plots, schemes, bribery and blackmail in an attempt to steal his domain out from under him.",
 	   "release_date":"2019-12-03",
 	   "language":"en",
 	   "genres":[
@@ -323,7 +323,7 @@
 	   "id":545609,
 	   "title":"Extraction",
 	   "poster":"https://image.tmdb.org/t/p/original/wlfDxbGEsW58vGhFljKkcR5IxDj.jpg",
-	   "overview":"Tyler Rake, a fearless mercenary who offers his services on the black market, embarks on a dangerous mission when he is hired to rescue the kidnapped son of a Mumbai crime lord\u2026",
+	   "overview":"Tyler Rake, a fearless mercenary who offers his services on the black market, embarks on a dangerous mission when he is hired to rescue the kidnapped son of a Mumbai crime lord ...",
 	   "release_date":"2020-04-24",
 	   "language":"en",
 	   "genres":[


### PR DESCRIPTION
❌⚠️ This PR is a major breaking change! ⚠️❌

This is a rewrite of the Client and Config classes.

I added a modelMapping to the Config class. This way we are able to specify which index should be mapped to what Java Class. 

The Client class now has accessors for the specific apis.
`client.index()` returns the IndexHandler, 
`client.documents("indexname")` returns the DocumentHandler for the specified index.
`client.documents("indexname", Movie.class)` returns a DocumentHandler for the specified index with `Movie` as the desired Java Type, even if there is no mapping in the config for it.
`client.instance()` returns the InstanceHandler
`client.keys()` returns the KeysHandler
This way we dont have one uber-class that implements everything.

To make this easier, i created a ClientBuilder class. It allows the user to set every part of the ServiceTemplate classes (HttpClient, JsonHandler, RequestFactory, ServiceTempalte). If nothing gets specified, the ClientBuilder autodetects classes in the Classpath and loads the apropriate Implementation.