### PR TITLE
Rename errorCode, errorLink, errorType and errorMessage.

### DIFF
--- a/src/main/java/com/meilisearch/sdk/exceptions/APIError.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/APIError.java
@@ -7,15 +7,15 @@ public class APIError implements Serializable {
     private static final long serialVersionUID = 900737636809105793L;
 
     private final String message;
-    private final String errorCode;
-    private final String errorType;
-    private final String errorLink;
+    private final String code;
+    private final String type;
+    private final String link;
 
-    public APIError(String message, String errorCode, String errorType, String errorLink) {
+    public APIError(String message, String code, String type, String link) {
         this.message = message;
-        this.errorCode = errorCode;
-        this.errorType = errorType;
-        this.errorLink = errorLink;
+        this.code = code;
+        this.type = type;
+        this.link = link;
     }
 
     public String getMessage() {
@@ -23,15 +23,15 @@ public class APIError implements Serializable {
     }
 
     public String getErrorCode() {
-        return errorCode;
+        return code;
     }
 
     public String getErrorType() {
-        return errorType;
+        return type;
     }
 
     public String getErrorLink() {
-        return errorLink;
+        return link;
     }
 
     @Override
@@ -40,14 +40,14 @@ public class APIError implements Serializable {
                 + "message='"
                 + message
                 + '\''
-                + ", errorCode='"
-                + errorCode
+                + ", code='"
+                + code
                 + '\''
-                + ", errorType='"
-                + errorType
+                + ", type='"
+                + type
                 + '\''
-                + ", errorLink='"
-                + errorLink
+                + ", link='"
+                + link
                 + '\''
                 + '}';
     }

--- a/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchException.java
+++ b/src/main/java/com/meilisearch/sdk/exceptions/MeiliSearchException.java
@@ -3,50 +3,50 @@ package com.meilisearch.sdk.exceptions;
 public class MeiliSearchException extends Exception {
 
     /** This is a generic class for MeiliSearch Exception handling */
-    String errorMessage;
+    String message;
 
-    String errorType;
-    String errorCode;
-    String errorLink;
+    String type;
+    String code;
+    String link;
 
-    public MeiliSearchException(String errorMessage) {
-        super(errorMessage);
-        this.setErrorMessage(errorMessage);
+    public MeiliSearchException(String message) {
+        super(message);
+        this.setErrorMessage(message);
     }
 
     public String getMessage() {
-        return this.errorMessage;
+        return this.message;
     }
 
     public String getErrorType() {
-        return this.errorType;
+        return this.type;
     }
 
     public String getErrorCode() {
-        return this.errorCode;
+        return this.code;
     }
 
     public String getErrorLink() {
-        return this.errorLink;
+        return this.link;
     }
 
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
+    public void setErrorMessage(String message) {
+        this.message = message;
     }
 
-    public void setErrorType(String errorType) {
-        this.errorType = errorType;
+    public void setErrorType(String type) {
+        this.type = type;
     }
 
-    public void setErrorCode(String errorCode) {
-        this.errorCode = errorCode;
+    public void setErrorCode(String code) {
+        this.code = code;
     }
 
-    public void setErrorLink(String errorLink) {
-        this.errorLink = errorLink;
+    public void setErrorLink(String link) {
+        this.link = link;
     }
 
     public String toString() {
-        return this.getClass().getName() + ". Error message: " + this.errorMessage + ".";
+        return this.getClass().getName() + ". Error message: " + this.message + ".";
     }
 }

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -3,7 +3,6 @@ package com.meilisearch.integration;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.meilisearch.integration.classes.AbstractIT;
-import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
 import org.junit.jupiter.api.*;
@@ -24,18 +23,17 @@ public class ExceptionsTest extends AbstractIT {
     /** Test MeiliSearchApiException serialization and getters */
     @Test
     public void testErrorSerializeAndGetters() {
-        String errorMessage = "You must have an authorization token";
-        String errorCode = "missing_authorization_header";
-        String errorType = "authentication_error";
-        String errorLink = "https://docs.meilisearch.com/errors#missing_authorization_header";
+        String message = "You must have an authorization token";
+        String code = "missing_authorization_header";
+        String type = "authentication_error";
+        String link = "https://docs.meilisearch.com/errors#missing_authorization_header";
         try {
-            throw new MeiliSearchApiException(
-                    new APIError(errorMessage, errorCode, errorType, errorLink));
+            throw new MeiliSearchApiException(new APIError(message, code, type, link));
         } catch (MeiliSearchApiException e) {
-            assertEquals(errorMessage, e.getMessage());
-            assertEquals(errorCode, e.getErrorCode());
-            assertEquals(errorType, e.getErrorType());
-            assertEquals(errorLink, e.getErrorLink());
+            assertEquals(message, e.getMessage());
+            assertEquals(code, e.getErrorCode());
+            assertEquals(type, e.getErrorType());
+            assertEquals(link, e.getErrorLink());
         }
     }
 
@@ -43,7 +41,7 @@ public class ExceptionsTest extends AbstractIT {
     @Test
     public void testMeiliSearchApiExceptionBadRequest() throws Exception {
         String indexUid = "MeiliSearchApiExceptionBadRequest";
-        Index index = client.createIndex(indexUid);
+        client.createIndex(indexUid);
         assertThrows(MeiliSearchApiException.class, () -> client.createIndex(indexUid));
         try {
             client.createIndex(indexUid);


### PR DESCRIPTION
Renamed error Fields:
- errorCode to code
- errorLink to link
- errorType to type
- errorMessage to message

The name of these fields has not been renamed in `UpdateStatus` class because `type` is already used to retrieve the type of the update.
