### PR TITLE
Remove `deleteIfExist` method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -146,15 +146,14 @@ public class Client {
     }
 
     /**
-     * Deletes single index if exists by uid Refer
-     * https://docs.meilisearch.com/reference/api/indexes.html#get-one-index
+     * Triggers the creation of a MeiliSearch dump. Refer
+     * https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
      *
-     * @param uid Unique identifier of the index to delete
-     * @return MeiliSearch API response
+     * @return Dump instance
      * @throws Exception if an error occurs
      */
-    public boolean deleteIndexIfExists(String uid) throws Exception {
-        return this.indexesHandler.deleteIfExists(uid);
+    public Dump createDump() throws Exception {
+        return this.dumpHandler.createDump();
     }
 
     /**

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -179,27 +179,6 @@ public class ClientTest extends AbstractIT {
         assertThrows(MeiliSearchApiException.class, () -> client.getIndex(indexUid));
     }
 
-    /** Test deleteIndexIfExists */
-    @Test
-    public void testDeleteIndexIfExistsDeleteIndex() throws Exception {
-        String indexUid = "DeleteIndex";
-        Index index = client.createIndex(indexUid);
-        client.deleteIndexIfExists(index.getUid());
-        assertThrows(MeiliSearchApiException.class, () -> client.getIndex(indexUid));
-    }
-
-    /** Test deleteIndexIfExists */
-    @Test
-    public void testDeleteIndexIfExistsDoesNotThrowException() throws Exception {
-        String indexUid = "DeleteIndex";
-        Index index = client.createIndex(indexUid);
-        client.deleteIndexIfExists(index.getUid());
-        assertDoesNotThrow(() -> client.deleteIndexIfExists(indexUid));
-
-        boolean response = client.deleteIndexIfExists(indexUid);
-        assertFalse(response);
-    }
-
     /** Test call to index method with an inexistent index */
     @Test
     public void testIndexMethodCallInexistentIndex() throws Exception {


### PR DESCRIPTION
### Breaking Changes
All the actions on indexes are now asynchronous, so the methods `delete_if_exist` is now useless. 

