### PR TITLE
Remove getOrCreate method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -157,47 +157,6 @@ public class Client {
     }
 
     /**
-     * Gets single index by uid or if it does not exists, Create index
-     *
-     * @param uid Unique identifier for the index to create
-     * @param primaryKey The primary key of the documents in that index
-     * @return Index instance
-     * @throws Exception if an error occurs
-     */
-    public Index getOrCreateIndex(String uid, String primaryKey) throws Exception {
-        try {
-            return this.getIndex(uid);
-        } catch (MeiliSearchApiException e) {
-            if (e.getErrorCode().equals("index_not_found")) {
-                return this.createIndex(uid, primaryKey);
-            }
-            throw e;
-        }
-    }
-
-    /**
-     * Gets single index by uid or if it does not exists, Create index
-     *
-     * @param uid Unique identifier for the index to create
-     * @return Index instance
-     * @throws Exception if an error occurs
-     */
-    public Index getOrCreateIndex(String uid) throws Exception {
-        return getOrCreateIndex(uid, null);
-    }
-
-    /**
-     * Triggers the creation of a MeiliSearch dump. Refer
-     * https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
-     *
-     * @return Dump instance
-     * @throws Exception if an error occurs
-     */
-    public Dump createDump() throws Exception {
-        return this.dumpHandler.createDump();
-    }
-
-    /**
      * Gets the status of a MeiliSearch dump.
      * https://docs.meilisearch.com/reference/api/dump.html#get-dump-status
      *

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -54,42 +54,6 @@ public class ClientTest extends AbstractIT {
         client.deleteIndex(index.getUid());
     }
 
-    @Test
-    public void testCreateIndexWithPrimaryKeyIfIndexDoesNotExists() throws Exception {
-        String indexUid = "dummyIndexUid";
-        Index index = client.getOrCreateIndex(indexUid, this.primaryKey);
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
-        client.deleteIndex(index.getUid());
-    }
-
-    @Test
-    public void testGetIndexWithPrimaryKeyIfIndexAlreadyExists() throws Exception {
-        String indexUid = "dummyIndexUid";
-        Index createdIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
-        assertEquals(createdIndex.getUid(), indexUid);
-
-        Index retrievedIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
-        assertEquals(retrievedIndex.getUid(), indexUid);
-        assertEquals(createdIndex.getUid(), retrievedIndex.getUid());
-
-        client.deleteIndex(createdIndex.getUid());
-    }
-
-    @Test
-    public void testGetOrCreateIndexShouldNotThrowAnyException() throws Exception {
-        String indexUid = "dummyIndexUid";
-        Index createdIndex = null;
-        try {
-            createdIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
-            Index retrievedIndex = client.getOrCreateIndex(indexUid, this.primaryKey);
-        } catch (Exception e) {
-            client.deleteIndex(createdIndex.getUid());
-            fail("Should Not Throw Any Exception");
-        }
-        client.deleteIndex(createdIndex.getUid());
-    }
-
     /** Test Index creation error: already exists */
     @Test
     public void testCreateIndexAlreadyExists() throws Exception {


### PR DESCRIPTION
### Breaking Changes
All the actions on indexes are now asynchronous, so the methods `get_or_create` is now useless. 