### PR TITLE
Additions related to API Keys

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -234,6 +234,18 @@ public class Client {
     }
 
     /**
+     * Updates a key
+     *
+     * @param key String containing the key
+     * @param options String containing the options to update
+     * @return Key Instance
+     * @throws Exception if client request causes an error
+     */
+    public Key updateKey(String key, String options) throws Exception {
+        return this.keysHandler.updateKey(key, options);
+    }
+
+    /**
      * Deletes a key
      *
      * @param key String containing the key

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -10,6 +10,7 @@ public class Client {
     public Config config;
     public IndexesHandler indexesHandler;
     public TasksHandler tasksHandler;
+    public KeysHandler keysHandler;
     public Gson gson;
     public DumpHandler dumpHandler;
 
@@ -23,6 +24,7 @@ public class Client {
         this.gson = new Gson();
         this.indexesHandler = new IndexesHandler(config);
         this.tasksHandler = new TasksHandler(config);
+        this.keysHandler = new KeysHandler(config);
         this.dumpHandler = new DumpHandler(config);
     }
 
@@ -197,5 +199,48 @@ public class Client {
      */
     public void waitForTask(int uid) throws Exception {
         this.tasksHandler.waitForTask(uid);
+    }
+
+    /**
+     * Retrieves the key with the specified uid
+     *
+     * @param uid Identifier of the requested Key
+     * @return Key Instance
+     * @throws Exception if an error occurs
+     */
+    public Key getKey(String uid) throws Exception {
+        return this.keysHandler.getKey(uid);
+    }
+
+    /**
+     * Retrieves list of keys
+     *
+     * @return List of keys in the MeiliSearch client
+     * @throws Exception if an error occurs
+     */
+    public Key[] getKeys() throws Exception {
+        return this.keysHandler.getKeys();
+    }
+
+    /**
+     * Creates a key
+     *
+     * @param options String containing the options of the key
+     * @return Key Instance
+     * @throws Exception if an error occurs
+     */
+    public Key createKey(String options) throws Exception {
+        return this.keysHandler.createKey(options);
+    }
+
+    /**
+     * Deletes a key
+     *
+     * @param key String containing the key
+     * @return MeiliSearch API response
+     * @throws Exception if an error occurs
+     */
+    public String deleteKey(String key) throws Exception {
+        return this.keysHandler.deleteKey(key);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
+++ b/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
@@ -87,6 +87,8 @@ public class GenericServiceTemplate implements ServiceTemplate {
                     return client.post(request);
                 case PUT:
                     return client.put(request);
+                case PATCH:
+                    return client.patch(request);
                 case DELETE:
                     return client.delete(request);
                 default:

--- a/src/main/java/com/meilisearch/sdk/Key.java
+++ b/src/main/java/com/meilisearch/sdk/Key.java
@@ -1,0 +1,89 @@
+package com.meilisearch.sdk;
+
+import com.google.gson.Gson;
+
+/** MeiliSearch response for a Key */
+public class Key {
+    protected String description = "";
+    protected String key = "";
+    protected String[] actions = null;
+    protected String[] indexes = null;
+    protected String expiresAt = "";
+    protected String createdAt = "";
+    protected String updatedAt = "";
+
+    private static Gson gsonKey = new Gson();
+
+    /**
+     * Method to return the JSON String of the Key
+     *
+     * @return JSON string of the Key object
+     */
+    @Override
+    public String toString() {
+        return gsonKey.toJson(this);
+    }
+
+    /**
+     * Method to return the Key value
+     *
+     * @return String containing the value of the Key
+     */
+    public String getKey() {
+        return this.key;
+    }
+
+    /**
+     * Method to return the description of the Key
+     *
+     * @return String containing the description of the Key
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Method to return the actions authorized by the key
+     *
+     * @return String containing the actions authorized by the key
+     */
+    public String[] getActions() {
+        return this.actions;
+    }
+
+    /**
+     * Method to return the indexes accessible by the Key
+     *
+     * @return String value of the indexes accessible by the Key
+     */
+    public String[] getIndexes() {
+        return this.indexes;
+    }
+
+    /**
+     * Method to return the time that the Key will expire
+     *
+     * @return String value of the date and time of expiration date of the Key
+     */
+    public String getExpiresAt() {
+        return this.expiresAt;
+    }
+
+    /**
+     * Method to return the time that the Key was created at
+     *
+     * @return String value of the date and time of the Key when it was created
+     */
+    public String getCreatedAt() {
+        return this.createdAt;
+    }
+
+    /**
+     * Method to return the time that the Update was finished at
+     *
+     * @return String value of the date and time of the Update when it was finished
+     */
+    public String getUpdatedAt() {
+        return this.updatedAt;
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -62,6 +62,19 @@ public class KeysHandler {
     }
 
     /**
+     * Updates a key
+     *
+     * @param key String containing the key
+     * @param options String containing the options of the key
+     * @return Key Instance
+     * @throws Exception if client request causes an error
+     */
+    Key updateKey(String key, String options) throws Exception {
+        String urlPath = "/keys/" + key;
+        return this.gson.fromJson(this.meilisearchHttpRequest.patch(urlPath, options), Key.class);
+    }
+
+    /**
      * Deletes a key
      *
      * @param key String containing the key

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -1,0 +1,75 @@
+package com.meilisearch.sdk;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.meilisearch.sdk.exceptions.MeiliSearchApiException;
+
+/**
+ * Wrapper around MeilisearchHttpRequest class to use for MeiliSearch keys
+ *
+ * <p>Refer https://docs.meilisearch.com/reference/api/keys.html
+ */
+public class KeysHandler {
+    private final MeiliSearchHttpRequest meilisearchHttpRequest;
+    private final Gson gson = new Gson();
+
+    /**
+     * Creates and sets up an instance of Key to simplify MeiliSearch API calls to manage keys
+     *
+     * @param config MeiliSearch configuration
+     */
+    public KeysHandler(Config config) {
+        this.meilisearchHttpRequest = new MeiliSearchHttpRequest(config);
+    }
+
+    /**
+     * Retrieves the Key with the specified uid
+     *
+     * @param uid Identifier of the requested Key
+     * @return Key instance
+     * @throws Exception if client request causes an error
+     */
+    Key getKey(String uid) throws Exception, MeiliSearchApiException {
+        String urlPath = "/keys/" + uid;
+        return this.gson.fromJson(this.meilisearchHttpRequest.get(urlPath), Key.class);
+    }
+
+    /**
+     * Retrieves Keys from the client
+     *
+     * @return List of key instance
+     * @throws Exception if client request causes an error
+     */
+    Key[] getKeys() throws Exception {
+        String urlPath = "/keys";
+        Result<Key> result =
+                this.gson.fromJson(
+                        this.meilisearchHttpRequest.get(urlPath),
+                        new TypeToken<Result<Key>>() {}.getType());
+        return result.getResults();
+    }
+
+    /**
+     * Creates a key
+     *
+     * @param options String containing the options of the key
+     * @return Key Instance
+     * @throws Exception if client request causes an error
+     */
+    Key createKey(String options) throws Exception {
+        String urlPath = "/keys";
+        return this.gson.fromJson(this.meilisearchHttpRequest.post(urlPath, options), Key.class);
+    }
+
+    /**
+     * Deletes a key
+     *
+     * @param key String containing the key
+     * @return MeiliSearch API response
+     * @throws Exception if client request causes an error
+     */
+    String deleteKey(String key) throws Exception {
+        String urlPath = "/keys/" + key;
+        return this.meilisearchHttpRequest.delete(urlPath);
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -112,6 +112,26 @@ class MeiliSearchHttpRequest {
     }
 
     /**
+     * Replaces the requested resource with new data
+     *
+     * @param api Path to the requested resource
+     * @param body Replacement data for the requested resource
+     * @return updated resource
+     * @throws Exception if the client has an error
+     * @throws MeiliSearchApiException if the response is an error
+     */
+    String patch(String api, String body) throws Exception, MeiliSearchApiException {
+        HttpResponse<?> httpResponse =
+                this.client.patch(
+                        factory.create(HttpMethod.PATCH, api, Collections.emptyMap(), body));
+        if (httpResponse.getStatusCode() >= 400) {
+            throw new MeiliSearchApiException(
+                    jsonHandler.decode(httpResponse.getContent(), APIError.class));
+        }
+        return new String(httpResponse.getContentAsBytes());
+    }
+
+    /**
      * Deletes the specified resource
      *
      * @param api Path to the requested resource

--- a/src/main/java/com/meilisearch/sdk/api/documents/Task.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/Task.java
@@ -7,8 +7,6 @@ public class Task {
 
     private String indexUid;
 
-    // private Details details;
-
     private String type;
 
     private String duration;

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -71,6 +71,11 @@ public class ApacheHttpClient extends AbstractHttpClient {
     }
 
     @Override
+    public HttpResponse<?> patch(HttpRequest<?> request) throws Exception {
+        return execute(request);
+    }
+
+    @Override
     public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
         return execute(request);
     }

--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -48,6 +48,9 @@ public class CustomOkHttpClient extends AbstractHttpClient {
             case PUT:
                 builder.put(getBodyFromRequest(request));
                 break;
+            case PATCH:
+                builder.patch(getBodyFromRequest(request));
+                break;
             case DELETE:
                 if (request.hasContent()) builder.delete(getBodyFromRequest(request));
                 else builder.delete();
@@ -92,6 +95,13 @@ public class CustomOkHttpClient extends AbstractHttpClient {
 
     @Override
     public HttpResponse<?> put(HttpRequest<?> request) throws Exception {
+        Request okRequest = buildRequest(request);
+        Response execute = client.newCall(okRequest).execute();
+        return buildResponse(execute);
+    }
+
+    @Override
+    public HttpResponse<?> patch(HttpRequest<?> request) throws Exception {
         Request okRequest = buildRequest(request);
         Response execute = client.newCall(okRequest).execute();
         return buildResponse(execute);

--- a/src/main/java/com/meilisearch/sdk/http/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/HttpClient.java
@@ -10,5 +10,7 @@ public interface HttpClient<T extends HttpRequest<?>, R extends HttpResponse<?>>
 
     R put(T request) throws Exception;
 
+    R patch(T request) throws Exception;
+
     R delete(T request) throws Exception;
 }

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
@@ -5,5 +5,6 @@ public enum HttpMethod {
     GET,
     POST,
     PUT,
+    PATCH,
     DELETE
 }

--- a/src/test/java/com/meilisearch/integration/KeysTest.java
+++ b/src/test/java/com/meilisearch/integration/KeysTest.java
@@ -74,7 +74,7 @@ public class KeysTest extends AbstractIT {
         assertNotNull(key.getUpdatedAt());
     }
 
-    /** Test Create a simple API Key with description */
+    /** Test Create an API Key with description */
     @Test
     public void testClientCreateKeyWithDescription() throws Exception {
         String keyInfo =
@@ -91,7 +91,7 @@ public class KeysTest extends AbstractIT {
         assertNotNull(key.getUpdatedAt());
     }
 
-    /** Test Create a simple API Key with description */
+    /** Test Create an API Key with expiresAt */
     @Test
     public void testClientCreateKeyWithExpirationDate() throws Exception {
         String keyInfo =
@@ -106,5 +106,37 @@ public class KeysTest extends AbstractIT {
         assertEquals("2042-01-30T00:00:00Z", key.getExpiresAt());
         assertNotNull(key.getCreatedAt());
         assertNotNull(key.getUpdatedAt());
+    }
+
+    /** Test Update an API Key */
+    @Test
+    public void testClientUpdateKey() throws Exception {
+        String keyInfo = "{\"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": null }";
+        String keyChanges =
+                "{\"actions\": [\"search\"], \"indexes\": [\"testUpdateKey\"], \"expiresAt\": \"2042-01-30\" }";
+        Key createKey = client.createKey(keyInfo);
+        Key updateKey = client.updateKey(createKey.getKey(), keyChanges);
+
+        assertTrue(createKey instanceof Key);
+        assertTrue(updateKey instanceof Key);
+        assertNotNull(updateKey.getKey());
+        assertEquals("*", createKey.getActions()[0]);
+        assertEquals("search", updateKey.getActions()[0]);
+        assertEquals("*", createKey.getIndexes()[0]);
+        assertEquals("testUpdateKey", updateKey.getIndexes()[0]);
+        assertNull(createKey.getExpiresAt());
+        assertEquals("2042-01-30T00:00:00Z", updateKey.getExpiresAt());
+        assertNotNull(updateKey.getCreatedAt());
+        assertNotNull(updateKey.getUpdatedAt());
+    }
+
+    /** Test Delete an API Key */
+    @Test
+    public void testClientDeleteKey() throws Exception {
+        String keyInfo = "{\"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": null }";
+        Key createKey = client.createKey(keyInfo);
+        String response = client.deleteKey(createKey.getKey());
+
+        assertThrows(Exception.class, () -> client.getKey(createKey.getKey()));
     }
 }

--- a/src/test/java/com/meilisearch/integration/KeysTest.java
+++ b/src/test/java/com/meilisearch/integration/KeysTest.java
@@ -1,0 +1,110 @@
+package com.meilisearch.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.meilisearch.integration.classes.AbstractIT;
+import com.meilisearch.sdk.Key;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("integrationKey")
+public class KeysTest extends AbstractIT {
+
+    @BeforeEach
+    public void initialize() {
+        this.setUp();
+    }
+
+    @AfterAll
+    static void cleanMeiliSearch() {
+        cleanup();
+        deleteAllKeys();
+    }
+
+    /** Test Get Keys */
+    @Test
+    public void testClientGetKeys() throws Exception {
+        Key[] keys = client.getKeys();
+        assertEquals(2, keys.length);
+
+        for (Key key : keys) {
+            assertTrue(key instanceof Key);
+            assertNotNull(key.getKey());
+            assertNotNull(key.getActions());
+            assertNotNull(key.getIndexes());
+            assertNotNull(key.getDescription());
+            assertNull(key.getExpiresAt());
+            assertNotNull(key.getCreatedAt());
+            assertNotNull(key.getUpdatedAt());
+        }
+    }
+
+    /** Test Get Key */
+    @Test
+    public void testClientGetKey() throws Exception {
+        String keyInfo = "{\"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": null }";
+        Key createKey = client.createKey(keyInfo);
+        Key key = client.getKey(createKey.getKey());
+
+        assertTrue(key instanceof Key);
+        assertNotNull(key.getKey());
+        assertNotNull(key.getActions());
+        assertNotNull(key.getIndexes());
+        assertNull(key.getDescription());
+        assertNull(key.getExpiresAt());
+        assertNotNull(key.getCreatedAt());
+        assertNotNull(key.getUpdatedAt());
+    }
+
+    /** Test Create a simple API Key without description */
+    @Test
+    public void testClientCreateDefaultKey() throws Exception {
+        String keyInfo = "{\"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": null }";
+        Key key = client.createKey(keyInfo);
+
+        assertTrue(key instanceof Key);
+        assertNotNull(key.getKey());
+        assertEquals("*", key.getActions()[0]);
+        assertEquals("*", key.getIndexes()[0]);
+        assertNull(key.getDescription());
+        assertNull(key.getExpiresAt());
+        assertNotNull(key.getCreatedAt());
+        assertNotNull(key.getUpdatedAt());
+    }
+
+    /** Test Create a simple API Key with description */
+    @Test
+    public void testClientCreateKeyWithDescription() throws Exception {
+        String keyInfo =
+                "{\"description\": \"testClientCreateKey\", \"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": null }";
+        Key key = client.createKey(keyInfo);
+
+        assertTrue(key instanceof Key);
+        assertNotNull(key.getKey());
+        assertEquals("*", key.getActions()[0]);
+        assertEquals("*", key.getIndexes()[0]);
+        assertEquals("testClientCreateKey", key.getDescription());
+        assertNull(key.getExpiresAt());
+        assertNotNull(key.getCreatedAt());
+        assertNotNull(key.getUpdatedAt());
+    }
+
+    /** Test Create a simple API Key with description */
+    @Test
+    public void testClientCreateKeyWithExpirationDate() throws Exception {
+        String keyInfo =
+                "{\"actions\": [\"*\"], \"indexes\": [\"*\"], \"expiresAt\": \"2042-01-30\" }";
+        Key key = client.createKey(keyInfo);
+
+        assertTrue(key instanceof Key);
+        assertNotNull(key.getKey());
+        assertEquals("*", key.getActions()[0]);
+        assertEquals("*", key.getIndexes()[0]);
+        assertNull(key.getDescription());
+        assertEquals("2042-01-30T00:00:00Z", key.getExpiresAt());
+        assertNotNull(key.getCreatedAt());
+        assertNotNull(key.getUpdatedAt());
+    }
+}

--- a/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
+++ b/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken;
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.Key;
 import com.meilisearch.sdk.Task;
 import com.meilisearch.sdk.utils.Movie;
 import java.io.*;
@@ -74,6 +75,20 @@ public abstract class AbstractIT {
             Index[] indexes = ms.getIndexList();
             for (Index index : indexes) {
                 ms.deleteIndex(index.getUid());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void deleteAllKeys() {
+        try {
+            Client ms = new Client(new Config("http://localhost:7700", "masterKey"));
+            Key[] keys = ms.getKeys();
+            for (Key key : keys) {
+                if ((key.getDescription() == null) || (key.getDescription().contains("test"))) {
+                    ms.deleteKey(key.getKey());
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
@@ -123,6 +123,26 @@ class ApacheHttpClientTest {
     }
 
     @Test
+    void patch() throws Exception {
+        SimpleHttpResponse expectedResponse =
+                SimpleHttpResponse.create(200, "some body", ContentType.APPLICATION_JSON);
+        responseQueue.push(expectedResponse);
+        BasicHttpRequest request =
+                new BasicHttpRequest(
+                        HttpMethod.PUT, "/test", Collections.emptyMap(), "thisisabody");
+        BasicHttpResponse response = (BasicHttpResponse) classToTest.patch(request);
+
+        assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
+        assertThat(response.getContentAsBytes(), equalTo(expectedResponse.getBodyBytes()));
+
+        SimpleHttpRequest expectedRequest = requestQueue.poll();
+        assertThat(expectedRequest, notNullValue());
+        assertThat(expectedRequest.getBodyText(), equalTo(request.getContent()));
+        assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
+        assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
+    }
+
+    @Test
     void delete() throws Exception {
         SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(204);
         responseQueue.push(expectedResponse);

--- a/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
@@ -153,6 +153,25 @@ class CustomOkHttpClientTest {
     }
 
     @Test
+    void patch() throws Exception {
+        BasicHttpRequest request =
+                new BasicHttpRequest(
+                        HttpMethod.PATCH, "/test", Collections.emptyMap(), "some body");
+        BasicHttpResponse response = (BasicHttpResponse) classToTest.patch(request);
+
+        assertThat(response.getStatusCode(), equalTo(200));
+        assertThat(response.getContent(), equalTo(request.getContent()));
+
+        Request expectedRequest = requestQueue.poll();
+        assertThat(expectedRequest, notNullValue());
+        assertThat(request.getContent(), equalTo(readBody(expectedRequest.body())));
+        assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
+        assertThat(
+                expectedRequest.url().toString(),
+                equalTo(this.config.getHostUrl() + request.getPath()));
+    }
+
+    @Test
     void delete() throws Exception {
         BasicHttpRequest request =
                 new BasicHttpRequest(


### PR DESCRIPTION
### Breaking Changes

Granular management of API keys is now added to MeiliSearch. New methods have been created to manage this:
- `http.patch` use by `updateKey`
- `client.getKey` get information about a specific API key.
- `client.createKey` create a new API key.
- `client.deleteKey` delete an API key.
- `client.updateKey` update an API key.

The class HttpURLConnection doesn't accept the PATCH method, I create a workaround and an issue #318 