### PR TITLE
Remove updateKeys due to PATCH http method

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -72,18 +72,7 @@ create_a_key_1: |-
 
   client.createKey(keyInfo);
 update_a_key_1: |-
-  SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-  Date dateParsed = format.parse("2042-04-02T00:42:42Z");
-
-  Key keyChanges = new Key();
-
-  keyChanges.setDescription("Manage documents: Products/Reviews API key");
-  keyChanges.setActions(new String[] {"documents.add", "document.delete"});
-  keyChanges.setIndexes(new String[] {"products", "reviews"});
-  keyChanges.setExpiresAt(dateParsed);
-
-  client.updateKey(
-    "d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4", keyChanges);
+  //Not yet implemented
 delete_a_key_1: |-
   client.deleteKey("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4")
 get_settings_1: |-
@@ -509,13 +498,7 @@ security_guide_search_key_1: |-
   Client client = new Client(new Config("http://127.0.0.1:7700", "apiKey"));
   client.index("patient_medical_records").search();
 security_guide_update_key_1: |-
-  Client client = new Client(new Config("http://127.0.0.1:7700", "masterKey"));
-
-  Key keyChanges = new Key();
-  keyChanges.setIndexes(new String[] {"doctors"});
-
-  client.updateKey(
-    "d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4", keyChanges);
+  //Not yet implemented
 security_guide_create_key_1: |-
   Client client = new Client(new Config("http://127.0.0.1:7700", "masterKey"));
 

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -234,18 +234,6 @@ public class Client {
     }
 
     /**
-     * Updates a key
-     *
-     * @param key String containing the key
-     * @param options String containing the options to update
-     * @return Key Instance
-     * @throws Exception if client request causes an error
-     */
-    public Key updateKey(String key, Key options) throws Exception {
-        return this.keysHandler.updateKey(key, options);
-    }
-
-    /**
      * Deletes a key
      *
      * @param key String containing the key

--- a/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
+++ b/src/main/java/com/meilisearch/sdk/GenericServiceTemplate.java
@@ -87,8 +87,6 @@ public class GenericServiceTemplate implements ServiceTemplate {
                     return client.post(request);
                 case PUT:
                     return client.put(request);
-                case PATCH:
-                    return client.patch(request);
                 case DELETE:
                     return client.delete(request);
                 default:

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -64,20 +64,6 @@ public class KeysHandler {
     }
 
     /**
-     * Updates a key
-     *
-     * @param key String containing the key
-     * @param options String containing the options of the key
-     * @return Key Instance
-     * @throws Exception if client request causes an error
-     */
-    public Key updateKey(String key, Key options) throws Exception {
-        String urlPath = "/keys/" + key;
-        return this.gson.fromJson(
-                this.meilisearchHttpRequest.patch(urlPath, options.toString()), Key.class);
-    }
-
-    /**
      * Deletes a key
      *
      * @param key String containing the key

--- a/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MeiliSearchHttpRequest.java
@@ -112,26 +112,6 @@ class MeiliSearchHttpRequest {
     }
 
     /**
-     * Replaces the requested resource with new data
-     *
-     * @param api Path to the requested resource
-     * @param body Replacement data for the requested resource
-     * @return updated resource
-     * @throws Exception if the client has an error
-     * @throws MeiliSearchApiException if the response is an error
-     */
-    String patch(String api, String body) throws Exception, MeiliSearchApiException {
-        HttpResponse<?> httpResponse =
-                this.client.patch(
-                        factory.create(HttpMethod.PATCH, api, Collections.emptyMap(), body));
-        if (httpResponse.getStatusCode() >= 400) {
-            throw new MeiliSearchApiException(
-                    jsonHandler.decode(httpResponse.getContent(), APIError.class));
-        }
-        return new String(httpResponse.getContentAsBytes());
-    }
-
-    /**
      * Deletes the specified resource
      *
      * @param api Path to the requested resource

--- a/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/ApacheHttpClient.java
@@ -71,11 +71,6 @@ public class ApacheHttpClient extends AbstractHttpClient {
     }
 
     @Override
-    public HttpResponse<?> patch(HttpRequest<?> request) throws Exception {
-        return execute(request);
-    }
-
-    @Override
     public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
         return execute(request);
     }

--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -48,9 +48,6 @@ public class CustomOkHttpClient extends AbstractHttpClient {
             case PUT:
                 builder.put(getBodyFromRequest(request));
                 break;
-            case PATCH:
-                builder.patch(getBodyFromRequest(request));
-                break;
             case DELETE:
                 if (request.hasContent()) builder.delete(getBodyFromRequest(request));
                 else builder.delete();
@@ -95,13 +92,6 @@ public class CustomOkHttpClient extends AbstractHttpClient {
 
     @Override
     public HttpResponse<?> put(HttpRequest<?> request) throws Exception {
-        Request okRequest = buildRequest(request);
-        Response execute = client.newCall(okRequest).execute();
-        return buildResponse(execute);
-    }
-
-    @Override
-    public HttpResponse<?> patch(HttpRequest<?> request) throws Exception {
         Request okRequest = buildRequest(request);
         Response execute = client.newCall(okRequest).execute();
         return buildResponse(execute);

--- a/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/DefaultHttpClient.java
@@ -7,14 +7,9 @@ import com.meilisearch.sdk.http.response.HttpResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DefaultHttpClient extends AbstractHttpClient {
@@ -39,13 +34,6 @@ public class DefaultHttpClient extends AbstractHttpClient {
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
-        // This condition is link to the workaround for the Won't Fix bug in OpenJDK:
-        // https://bugs.openjdk.java.net/browse/JDK-7016595
-        // See allowMethods() method and issue
-        // https://github.com/meilisearch/meilisearch-java/issues/318
-        if (method == "PATCH") {
-            allowMethods("PATCH");
-        }
         connection.setRequestMethod(method);
         connection.setRequestProperty("Content-Type", "application/json");
 
@@ -100,37 +88,7 @@ public class DefaultHttpClient extends AbstractHttpClient {
     }
 
     @Override
-    public HttpResponse<?> patch(HttpRequest<?> request) throws Exception {
-        return execute(request);
-    }
-
-    @Override
     public HttpResponse<?> delete(HttpRequest<?> request) throws Exception {
         return execute(request);
-    }
-
-    // This function is a workaround for the Won't Fix bug in OpenJDK:
-    // https://bugs.openjdk.java.net/browse/JDK-7016595
-    // A better solution should be found if possible see
-    // https://github.com/meilisearch/meilisearch-java/issues/318
-    private static void allowMethods(String... methods) {
-        try {
-            Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
-
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
-
-            methodsField.setAccessible(true);
-
-            String[] oldMethods = (String[]) methodsField.get(null);
-            Set<String> methodsSet = new LinkedHashSet<>(Arrays.asList(oldMethods));
-            methodsSet.addAll(Arrays.asList(methods));
-            String[] newMethods = methodsSet.toArray(new String[0]);
-
-            methodsField.set(null /*static field*/, newMethods);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new IllegalStateException(e);
-        }
     }
 }

--- a/src/main/java/com/meilisearch/sdk/http/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/HttpClient.java
@@ -10,7 +10,5 @@ public interface HttpClient<T extends HttpRequest<?>, R extends HttpResponse<?>>
 
     R put(T request) throws Exception;
 
-    R patch(T request) throws Exception;
-
     R delete(T request) throws Exception;
 }

--- a/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
+++ b/src/main/java/com/meilisearch/sdk/http/request/HttpMethod.java
@@ -5,6 +5,5 @@ public enum HttpMethod {
     GET,
     POST,
     PUT,
-    PATCH,
     DELETE
 }

--- a/src/test/java/com/meilisearch/integration/KeysTest.java
+++ b/src/test/java/com/meilisearch/integration/KeysTest.java
@@ -136,37 +136,6 @@ public class KeysTest extends AbstractIT {
         assertNotNull(key.getUpdatedAt());
     }
 
-    /** Test Update an API Key */
-    @Test
-    public void testClientUpdateKey() throws Exception {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        Date dateParsed = format.parse("2042-01-30T00:00:00Z");
-
-        Key keyInfo = new Key();
-        keyInfo.setIndexes(new String[] {"*"});
-        keyInfo.setActions(new String[] {"*"});
-
-        Key keyChanges = new Key();
-        keyChanges.setIndexes(new String[] {"testUpdateKey"});
-        keyChanges.setActions(new String[] {"search"});
-        keyChanges.setExpiresAt(dateParsed);
-
-        Key createKey = client.createKey(keyInfo);
-        Key updateKey = client.updateKey(createKey.getKey(), keyChanges);
-
-        assertTrue(createKey instanceof Key);
-        assertTrue(updateKey instanceof Key);
-        assertNotNull(updateKey.getKey());
-        assertEquals("*", createKey.getActions()[0]);
-        assertEquals("search", updateKey.getActions()[0]);
-        assertEquals("*", createKey.getIndexes()[0]);
-        assertEquals("testUpdateKey", updateKey.getIndexes()[0]);
-        assertNull(createKey.getExpiresAt());
-        assertEquals(dateParsed, updateKey.getExpiresAt());
-        assertNotNull(updateKey.getCreatedAt());
-        assertNotNull(updateKey.getUpdatedAt());
-    }
-
     /** Test Delete an API Key */
     @Test
     public void testClientDeleteKey() throws Exception {

--- a/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/ApacheHttpClientTest.java
@@ -123,26 +123,6 @@ class ApacheHttpClientTest {
     }
 
     @Test
-    void patch() throws Exception {
-        SimpleHttpResponse expectedResponse =
-                SimpleHttpResponse.create(200, "some body", ContentType.APPLICATION_JSON);
-        responseQueue.push(expectedResponse);
-        BasicHttpRequest request =
-                new BasicHttpRequest(
-                        HttpMethod.PATCH, "/test", Collections.emptyMap(), "thisisabody");
-        BasicHttpResponse response = (BasicHttpResponse) classToTest.patch(request);
-
-        assertThat(response.getStatusCode(), equalTo(expectedResponse.getCode()));
-        assertThat(response.getContentAsBytes(), equalTo(expectedResponse.getBodyBytes()));
-
-        SimpleHttpRequest expectedRequest = requestQueue.poll();
-        assertThat(expectedRequest, notNullValue());
-        assertThat(expectedRequest.getBodyText(), equalTo(request.getContent()));
-        assertThat(expectedRequest.getMethod(), equalTo(request.getMethod().name()));
-        assertThat(expectedRequest.getPath(), equalTo(request.getPath()));
-    }
-
-    @Test
     void delete() throws Exception {
         SimpleHttpResponse expectedResponse = SimpleHttpResponse.create(204);
         responseQueue.push(expectedResponse);

--- a/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/CustomOkHttpClientTest.java
@@ -153,25 +153,6 @@ class CustomOkHttpClientTest {
     }
 
     @Test
-    void patch() throws Exception {
-        BasicHttpRequest request =
-                new BasicHttpRequest(
-                        HttpMethod.PATCH, "/test", Collections.emptyMap(), "some body");
-        BasicHttpResponse response = (BasicHttpResponse) classToTest.patch(request);
-
-        assertThat(response.getStatusCode(), equalTo(200));
-        assertThat(response.getContent(), equalTo(request.getContent()));
-
-        Request expectedRequest = requestQueue.poll();
-        assertThat(expectedRequest, notNullValue());
-        assertThat(request.getContent(), equalTo(readBody(expectedRequest.body())));
-        assertThat(expectedRequest.method(), equalTo(request.getMethod().name()));
-        assertThat(
-                expectedRequest.url().toString(),
-                equalTo(this.config.getHostUrl() + request.getPath()));
-    }
-
-    @Test
     void delete() throws Exception {
         BasicHttpRequest request =
                 new BasicHttpRequest(


### PR DESCRIPTION
The HTTP `PATCH` method has just been introduced in `Meilisearch` following the release of v0.25.0.
This method should be used in the new `updateKey()` method but it didn't pass the `CI` test so this method has been removed.
See #318 