### PR TITLE
Fix test due to changes v0.27.0

### DIFF
--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -270,7 +270,7 @@ public class SearchTest extends AbstractIT {
 
         SearchResult searchResult = index.search(searchRequest);
 
-        assertEquals(3, searchResult.getHits().size());
+        assertEquals(1, searchResult.getHits().size());
         assertNotNull(searchResult.getFacetsDistribution());
     }
 


### PR DESCRIPTION
Changes in the request result of a search query due to a new implementation of `typo-tolerance`.
Until now `typo` on the first letter is now counting as 2 typos
