### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -40,7 +40,7 @@ public class Search {
      * @param attributesToRetrieve Attributes to display in the returned documents
      * @param attributesToCrop Attributes whose values have been cropped
      * @param cropLength Length used to crop field values
-     * @param cropMarker String to customize default crop marker, default value: …
+     * @param cropMarker String to add before and/or after the cropped text, default value: …
      * @param highlightPreTag String to customize highlight tag before every highlighted query
      *     terms, default value: <em>
      * @param highlightPostTag String to customize highlight tag after every highlighted query

--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -40,6 +40,11 @@ public class Search {
      * @param attributesToRetrieve Attributes to display in the returned documents
      * @param attributesToCrop Attributes whose values have been cropped
      * @param cropLength Length used to crop field values
+     * @param cropMarker String to customize default crop marker, default value: …
+     * @param highlightPreTag String to customize highlight tag before every highlighted query
+     *     terms, default value: <em>
+     * @param highlightPostTag String to customize highlight tag after every highlighted query
+     *     terms, default value: </em>
      * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
      * @param filter Filter queries by an attribute value
      * @param matches Defines whether an object that contains information about the matches should
@@ -57,6 +62,9 @@ public class Search {
             String[] attributesToRetrieve,
             String[] attributesToCrop,
             int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
             String[] attributesToHighlight,
             String[] filter,
             boolean matches,
@@ -72,6 +80,9 @@ public class Search {
                         attributesToRetrieve,
                         attributesToCrop,
                         cropLength,
+                        cropMarker,
+                        highlightPreTag,
+                        highlightPostTag,
                         attributesToHighlight,
                         filter,
                         matches,
@@ -114,6 +125,11 @@ public class Search {
      * @param attributesToRetrieve Attributes to display in the returned documents
      * @param attributesToCrop Attributes whose values have been cropped
      * @param cropLength Length used to crop field values
+     * @param cropMarker String to customize default crop marker, default value: …
+     * @param highlightPreTag String to customize highlight tag before every highlighted query
+     *     terms, default value: <em>
+     * @param highlightPostTag String to customize highlight tag after every highlighted query
+     *     terms, default value: </em>
      * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
      * @param filter Filter queries by an attribute value
      * @param matches Defines whether an object that contains information about the matches should
@@ -131,6 +147,9 @@ public class Search {
             String[] attributesToRetrieve,
             String[] attributesToCrop,
             int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
             String[] attributesToHighlight,
             String[] filter,
             boolean matches,
@@ -146,6 +165,9 @@ public class Search {
                         attributesToRetrieve,
                         attributesToCrop,
                         cropLength,
+                        cropMarker,
+                        highlightPreTag,
+                        highlightPostTag,
                         attributesToHighlight,
                         filter,
                         matches,

--- a/src/main/java/com/meilisearch/sdk/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SearchRequest.java
@@ -10,6 +10,9 @@ public class SearchRequest {
     private String[] attributesToRetrieve;
     private String[] attributesToCrop;
     private int cropLength;
+    private String cropMarker;
+    private String highlightPreTag;
+    private String highlightPostTag;
     private String[] attributesToHighlight;
     private String[] filter;
     private String[][] filterArray;
@@ -76,6 +79,9 @@ public class SearchRequest {
                 null,
                 200,
                 null,
+                null,
+                null,
+                null,
                 (String[]) null,
                 false,
                 null,
@@ -117,6 +123,63 @@ public class SearchRequest {
                 attributesToRetrieve,
                 attributesToCrop,
                 cropLength,
+                null,
+                null,
+                null,
+                attributesToHighlight,
+                filter,
+                null,
+                matches,
+                facetsDistribution,
+                sort);
+    }
+
+    /**
+     * Full SearchRequest Constructor for building search queries
+     *
+     * @param q Query string
+     * @param offset Number of documents to skip
+     * @param limit Maximum number of documents returned
+     * @param attributesToRetrieve Attributes to display in the returned documents
+     * @param attributesToCrop Attributes whose values have been cropped
+     * @param cropLength Length used to crop field values
+     * @param cropMarker String to customize default crop marker, default value: …
+     * @param highlightPreTag String to customize highlight tag before every highlighted query
+     *     terms, default value: <em>
+     * @param highlightPostTag String to customize highlight tag after every highlighted query
+     *     terms, default value: </em>
+     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
+     * @param filter Filter queries by an attribute value
+     * @param matches Defines whether an object that contains information about the matches should
+     *     be returned or not
+     * @param facetsDistribution Facets for which to retrieve the matching count
+     * @param sort Sort queries by an attribute value
+     */
+    public SearchRequest(
+            String q,
+            int offset,
+            int limit,
+            String[] attributesToRetrieve,
+            String[] attributesToCrop,
+            int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
+            String[] attributesToHighlight,
+            String[] filter,
+            boolean matches,
+            String[] facetsDistribution,
+            String[] sort) {
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                attributesToCrop,
+                cropLength,
+                cropMarker,
+                highlightPreTag,
+                highlightPostTag,
                 attributesToHighlight,
                 filter,
                 null,
@@ -160,6 +223,63 @@ public class SearchRequest {
                 attributesToRetrieve,
                 attributesToCrop,
                 cropLength,
+                null,
+                null,
+                null,
+                attributesToHighlight,
+                null,
+                filterArray,
+                matches,
+                facetsDistribution,
+                sort);
+    }
+
+    /**
+     * Full SearchRequest Constructor for building search queries with 2D filter Array
+     *
+     * @param q Query string
+     * @param offset Number of documents to skip
+     * @param limit Maximum number of documents returned
+     * @param attributesToRetrieve Attributes to display in the returned documents
+     * @param attributesToCrop Attributes whose values have been cropped
+     * @param cropLength Length used to crop field values
+     * @param cropMarker String to customize default crop marker, default value: …
+     * @param highlightPreTag String to customize highlight tag before every highlighted query
+     *     terms, default value: <em>
+     * @param highlightPostTag String to customize highlight tag after every highlighted query
+     *     terms, default value: </em>
+     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
+     * @param filterArray String array that can take multiple nested filters
+     * @param matches Defines whether an object that contains information about the matches should
+     *     be returned or not
+     * @param facetsDistribution Facets for which to retrieve the matching count
+     * @param sort Sort queries by an attribute value
+     */
+    public SearchRequest(
+            String q,
+            int offset,
+            int limit,
+            String[] attributesToRetrieve,
+            String[] attributesToCrop,
+            int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
+            String[] attributesToHighlight,
+            String[][] filterArray,
+            boolean matches,
+            String[] facetsDistribution,
+            String[] sort) {
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                attributesToCrop,
+                cropLength,
+                cropMarker,
+                highlightPreTag,
+                highlightPostTag,
                 attributesToHighlight,
                 null,
                 filterArray,
@@ -175,6 +295,9 @@ public class SearchRequest {
             String[] attributesToRetrieve,
             String[] attributesToCrop,
             int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
             String[] attributesToHighlight,
             String[] filter,
             String[][] filterArray,
@@ -187,6 +310,9 @@ public class SearchRequest {
         this.attributesToRetrieve = attributesToRetrieve;
         this.attributesToCrop = attributesToCrop;
         this.cropLength = cropLength;
+        this.cropMarker = cropMarker;
+        this.highlightPreTag = highlightPreTag;
+        this.highlightPostTag = highlightPostTag;
         this.attributesToHighlight = attributesToHighlight;
         this.setFilter(filter);
         this.setFilterArray(filterArray);
@@ -246,6 +372,33 @@ public class SearchRequest {
      */
     public int getCropLength() {
         return cropLength;
+    }
+
+    /**
+     * Method for returning the cropMarker
+     *
+     * @return string containing the crop marker
+     */
+    public String getCropMarker() {
+        return cropMarker;
+    }
+
+    /**
+     * Method for returning the highlightPreTag
+     *
+     * @return string containing highlight before tag
+     */
+    public String getHighlightPreTag() {
+        return highlightPreTag;
+    }
+
+    /**
+     * Method for returning the highlightPostTag
+     *
+     * @return string containing highlight after tag
+     */
+    public String getHighlightPostTag() {
+        return highlightPostTag;
     }
 
     /**
@@ -369,6 +522,39 @@ public class SearchRequest {
     }
 
     /**
+     * Method to set the cropMarker
+     *
+     * @param cropMarker Marker used to crop field values
+     * @return altered SearchRequest
+     */
+    public SearchRequest setCropMarker(String cropMarker) {
+        this.cropMarker = cropMarker;
+        return this;
+    }
+
+    /**
+     * Method to set the highlightPreTag
+     *
+     * @param highlightPreTag Highlight tag use before every highlighted query terms
+     * @return altered SearchRequest
+     */
+    public SearchRequest setHighlightPreTag(String highlightPreTag) {
+        this.highlightPreTag = highlightPreTag;
+        return this;
+    }
+
+    /**
+     * Method to set the highlightPostTag
+     *
+     * @param highlightPostTag Highlight tag use after every highlighted query terms
+     * @return altered SearchRequest
+     */
+    public SearchRequest setHighlightPostTag(String highlightPostTag) {
+        this.highlightPostTag = highlightPostTag;
+        return this;
+    }
+
+    /**
      * Method to set the attributesToHighlight
      *
      * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
@@ -447,6 +633,9 @@ public class SearchRequest {
                         .put("limit", this.limit)
                         .put("attributesToRetrieve", this.attributesToRetrieve)
                         .put("cropLength", this.cropLength)
+                        .put("cropMarker", this.cropMarker)
+                        .put("highlightPreTag", this.highlightPreTag)
+                        .put("highlightPostTag", this.highlightPostTag)
                         .put("matches", this.matches)
                         .put("facetsDistribution", this.facetsDistribution)
                         .put("sort", this.sort);

--- a/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/api/documents/SearchRequest.java
@@ -12,6 +12,9 @@ public class SearchRequest {
     private final List<String> attributesToRetrieve;
     private final List<String> attributesToCrop;
     private final int cropLength;
+    private final String cropMarker;
+    private final String highlightPreTag;
+    private final String highlightPostTag;
     private final List<String> attributesToHighlight;
     private final boolean matches;
     private final List<String> sort;
@@ -29,7 +32,21 @@ public class SearchRequest {
     }
 
     public SearchRequest(String q, int offset, int limit, List<String> attributesToRetrieve) {
-        this(q, offset, limit, attributesToRetrieve, null, 200, null, null, null, false, null);
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                null,
+                200,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                null);
     }
 
     public SearchRequest(
@@ -43,7 +60,21 @@ public class SearchRequest {
             String[] filter,
             boolean matches,
             List<String> sort) {
-        this(q, offset, limit, attributesToRetrieve, null, 200, null, filter, null, false, null);
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                null,
+                200,
+                null,
+                null,
+                null,
+                null,
+                filter,
+                null,
+                false,
+                null);
     }
 
     public SearchRequest(
@@ -66,6 +97,9 @@ public class SearchRequest {
                 200,
                 null,
                 null,
+                null,
+                null,
+                null,
                 filterArray,
                 false,
                 null);
@@ -78,6 +112,71 @@ public class SearchRequest {
             List<String> attributesToRetrieve,
             List<String> attributesToCrop,
             int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
+            List<String> attributesToHighlight,
+            String[] filter,
+            boolean matches,
+            List<String> sort) {
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                null,
+                200,
+                cropMarker,
+                highlightPreTag,
+                highlightPostTag,
+                null,
+                filter,
+                null,
+                false,
+                null);
+    }
+
+    public SearchRequest(
+            String q,
+            int offset,
+            int limit,
+            List<String> attributesToRetrieve,
+            List<String> attributesToCrop,
+            int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
+            List<String> attributesToHighlight,
+            String[][] filterArray,
+            boolean matches,
+            List<String> sort) {
+        this(
+                q,
+                offset,
+                limit,
+                attributesToRetrieve,
+                null,
+                200,
+                cropMarker,
+                highlightPreTag,
+                highlightPostTag,
+                null,
+                null,
+                filterArray,
+                false,
+                null);
+    }
+
+    public SearchRequest(
+            String q,
+            int offset,
+            int limit,
+            List<String> attributesToRetrieve,
+            List<String> attributesToCrop,
+            int cropLength,
+            String cropMarker,
+            String highlightPreTag,
+            String highlightPostTag,
             List<String> attributesToHighlight,
             String[] filter,
             String[][] filterArray,
@@ -89,6 +188,9 @@ public class SearchRequest {
         this.attributesToRetrieve = attributesToRetrieve;
         this.attributesToCrop = attributesToCrop;
         this.cropLength = cropLength;
+        this.cropMarker = cropMarker;
+        this.highlightPreTag = highlightPreTag;
+        this.highlightPostTag = highlightPostTag;
         this.attributesToHighlight = attributesToHighlight;
         this.filter = filter;
         this.filterArray = filterArray;
@@ -118,6 +220,18 @@ public class SearchRequest {
 
     public int getCropLength() {
         return cropLength;
+    }
+
+    public String getHighlightPreTag() {
+        return highlightPreTag;
+    }
+
+    public String getHighlightPostTag() {
+        return highlightPostTag;
+    }
+
+    public String getCropMarker() {
+        return cropMarker;
     }
 
     public List<String> getAttributesToHighlight() {

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -120,16 +120,16 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest =
                 new SearchRequest("a").setAttributesToRetrieve(new String[] {"id", "title"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertThat(res_gson.hits[0].getId(), instanceOf(String.class));
-        assertThat(res_gson.hits[0].getTitle(), instanceOf(String.class));
-        assertNull(res_gson.hits[0].getPoster());
-        assertNull(res_gson.hits[0].getOverview());
-        assertNull(res_gson.hits[0].getRelease_date());
-        assertNull(res_gson.hits[0].getLanguage());
-        assertNull(res_gson.hits[0].getGenres());
+        assertEquals(20, resGson.hits.length);
+        assertThat(resGson.hits[0].getId(), instanceOf(String.class));
+        assertThat(resGson.hits[0].getTitle(), instanceOf(String.class));
+        assertNull(resGson.hits[0].getPoster());
+        assertNull(resGson.hits[0].getOverview());
+        assertNull(resGson.hits[0].getRelease_date());
+        assertNull(resGson.hits[0].getLanguage());
+        assertNull(resGson.hits[0].getGenres());
     }
 
     /** Test search crop */
@@ -149,11 +149,11 @@ public class SearchTest extends AbstractIT {
                         .setAttributesToCrop(new String[] {"overview"})
                         .setCropLength(1);
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertEquals(5, res_gson.hits[0].getFormatted().getOverview().length());
-        assertEquals("…and…", res_gson.hits[0].getFormatted().getOverview());
+        assertEquals(20, resGson.hits.length);
+        assertEquals(5, resGson.hits[0].getFormatted().getOverview().length());
+        assertEquals("…and…", resGson.hits[0].getFormatted().getOverview());
     }
 
     /** Test search with customized crop marker */
@@ -174,10 +174,10 @@ public class SearchTest extends AbstractIT {
                         .setCropLength(1)
                         .setCropMarker("(ꈍᴗꈍ)");
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertEquals("(ꈍᴗꈍ)and(ꈍᴗꈍ)", res_gson.hits[0].getFormatted().getOverview());
+        assertEquals(20, resGson.hits.length);
+        assertEquals("(ꈍᴗꈍ)and(ꈍᴗꈍ)", resGson.hits[0].getFormatted().getOverview());
     }
 
     /** Test search highlight */
@@ -195,12 +195,12 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest =
                 new SearchRequest("and").setAttributesToHighlight(new String[] {"title"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
+        assertEquals(20, resGson.hits.length);
         assertEquals(
                 "Harry Potter <em>and</em> the Philosopher's Stone",
-                res_gson.hits[0].getFormatted().getTitle());
+                resGson.hits[0].getFormatted().getTitle());
     }
 
     /** Test search with customized highlight */
@@ -221,12 +221,12 @@ public class SearchTest extends AbstractIT {
                         .setHighlightPreTag("(⊃｡•́‿•̀｡)⊃ ")
                         .setHighlightPostTag(" ⊂(´• ω •`⊂)");
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
+        assertEquals(20, resGson.hits.length);
         assertEquals(
                 "Harry Potter (⊃｡•́‿•̀｡)⊃ and ⊂(´• ω •`⊂) the Philosopher's Stone",
-                res_gson.hits[0].getFormatted().getTitle());
+                resGson.hits[0].getFormatted().getTitle());
     }
 
     /** Test search with phrase */
@@ -241,11 +241,11 @@ public class SearchTest extends AbstractIT {
 
         index.waitForTask(task.getUid());
 
-        Results res_gson = jsonGson.decode(index.rawSearch("coco \"harry\""), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch("coco \"harry\""), Results.class);
 
-        assertEquals(1, res_gson.hits.length);
-        assertEquals("671", res_gson.hits[0].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", res_gson.hits[0].getTitle());
+        assertEquals(1, resGson.hits.length);
+        assertEquals("671", resGson.hits[0].getId());
+        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[0].getTitle());
     }
 
     /** Test search filter */
@@ -268,11 +268,11 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest =
                 new SearchRequest("and").setFilter(new String[] {"title = \"The Dark Knight\""});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(1, res_gson.hits.length);
-        assertEquals("155", res_gson.hits[0].getId());
-        assertEquals("The Dark Knight", res_gson.hits[0].getTitle());
+        assertEquals(1, resGson.hits.length);
+        assertEquals("155", resGson.hits[0].getId());
+        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
     }
 
     /** Test search filter complex */
@@ -296,11 +296,11 @@ public class SearchTest extends AbstractIT {
                 new SearchRequest("and")
                         .setFilter(new String[] {"title = \"The Dark Knight\" OR id = 290859"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(2, res_gson.hits.length);
-        assertEquals("155", res_gson.hits[0].getId());
-        assertEquals("290859", res_gson.hits[1].getId());
+        assertEquals(2, resGson.hits.length);
+        assertEquals("155", resGson.hits[0].getId());
+        assertEquals("290859", resGson.hits[1].getId());
     }
 
     /** Test search facet distribution */
@@ -348,15 +348,15 @@ public class SearchTest extends AbstractIT {
 
         SearchRequest searchRequest = new SearchRequest("and").setSort(new String[] {"title:asc"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertEquals("671", res_gson.hits[0].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", res_gson.hits[0].getTitle());
-        assertEquals("495764", res_gson.hits[1].getId());
+        assertEquals(20, resGson.hits.length);
+        assertEquals("671", resGson.hits[0].getId());
+        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[0].getTitle());
+        assertEquals("495764", resGson.hits[1].getId());
         assertEquals(
                 "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)",
-                res_gson.hits[1].getTitle());
+                resGson.hits[1].getTitle());
     }
 
     /** Test search sort */
@@ -378,15 +378,15 @@ public class SearchTest extends AbstractIT {
 
         SearchRequest searchRequest = new SearchRequest("and").setSort(new String[] {"id:asc"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertEquals("671", res_gson.hits[0].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", res_gson.hits[0].getTitle());
-        assertEquals("495764", res_gson.hits[1].getId());
+        assertEquals(20, resGson.hits.length);
+        assertEquals("671", resGson.hits[0].getId());
+        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[0].getTitle());
+        assertEquals("495764", resGson.hits[1].getId());
         assertEquals(
                 "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)",
-                res_gson.hits[1].getTitle());
+                resGson.hits[1].getTitle());
     }
 
     /** Test search sort */
@@ -409,13 +409,13 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest =
                 new SearchRequest("dark").setSort(new String[] {"id:asc", "title:asc"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(3, res_gson.hits.length);
-        assertEquals("155", res_gson.hits[0].getId());
-        assertEquals("The Dark Knight", res_gson.hits[0].getTitle());
-        assertEquals("290859", res_gson.hits[1].getId());
-        assertEquals("Terminator: Dark Fate", res_gson.hits[1].getTitle());
+        assertEquals(3, resGson.hits.length);
+        assertEquals("155", resGson.hits[0].getId());
+        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
+        assertEquals("290859", resGson.hits[1].getId());
+        assertEquals("Terminator: Dark Fate", resGson.hits[1].getTitle());
     }
 
     /** Test search sort */
@@ -438,13 +438,13 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest =
                 new SearchRequest("").setSort(new String[] {"id:asc", "title:asc"});
 
-        Results res_gson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
+        Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, res_gson.hits.length);
-        assertEquals("155", res_gson.hits[0].getId());
-        assertEquals("The Dark Knight", res_gson.hits[0].getTitle());
-        assertEquals("671", res_gson.hits[1].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", res_gson.hits[1].getTitle());
+        assertEquals(20, resGson.hits.length);
+        assertEquals("155", resGson.hits[0].getId());
+        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
+        assertEquals("671", resGson.hits[1].getId());
+        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[1].getTitle());
     }
 
     /** Test search matches */

--- a/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
@@ -33,6 +33,9 @@ class SearchRequestTest {
                         new String[] {"bubble"},
                         new String[] {"crop"},
                         900,
+                        null,
+                        null,
+                        null,
                         new String[] {"highlight"},
                         new String[] {"test='test'"},
                         true,
@@ -44,6 +47,9 @@ class SearchRequestTest {
         assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
         assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
         assertEquals("crop", classToTest.getAttributesToCrop()[0]);
+        assertEquals(null, classToTest.getCropMarker());
+        assertEquals(null, classToTest.getHighlightPreTag());
+        assertEquals(null, classToTest.getHighlightPostTag());
         assertEquals(null, classToTest.getFilterArray());
         assertEquals(1, classToTest.getFilter().length);
         assertEquals("test='test'", classToTest.getFilter()[0]);
@@ -59,6 +65,9 @@ class SearchRequestTest {
                         new String[] {"bubble"},
                         new String[] {"crop"},
                         900,
+                        "123",
+                        "abc",
+                        "zyx",
                         new String[] {"highlight"},
                         new String[][] {
                             new String[] {"test='test'"}, new String[] {"test1='test1'"}
@@ -69,6 +78,9 @@ class SearchRequestTest {
         assertEquals("This is a Test", classToTest.getQ());
         assertEquals(200, classToTest.getOffset());
         assertEquals(900, classToTest.getLimit());
+        assertEquals("123", classToTest.getCropMarker());
+        assertEquals("abc", classToTest.getHighlightPreTag());
+        assertEquals("zyx", classToTest.getHighlightPostTag());
         assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
         assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
         assertEquals("crop", classToTest.getAttributesToCrop()[0]);
@@ -80,7 +92,7 @@ class SearchRequestTest {
         assertEquals("sort", classToTest.getSort()[0]);
         assertEquals(900, classToTest.getCropLength());
         assertEquals(
-                "{\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"facetsDistribution\":[\"facets\"],\"limit\":900,\"cropLength\":900,\"attributesToHighlight\":[\"highlight\"],\"sort\":[\"sort\"],\"matches\":true,\"attributesToCrop\":[\"crop\"]}",
+                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"facetsDistribution\":[\"facets\"],\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"matches\":true,\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"attributesToCrop\":[\"crop\"]}",
                 classToTest.getQuery());
     }
 }


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced: 

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`
