### PR TITLE
Update version for the next release (v0.7.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 group = 'com.meilisearch.sdk'
 archivesBaseName = 'meilisearch-java'
-version = '0.7.1'
+version = '0.7.2'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This version makes this package compatible with MeiliSearch v0.27.0🎉 
Check out the changelog of [MeiliSearch v0.27.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.27.0) for more information about the changes.

## 🚀 Enhancements

- Ensure nested field support #374 @alallema
- Add new search parameters `highlightPreTag`, `highlightPostTag` and `cropMarker` #375 @alallema
