### PR TITLE
Add code-coverage tool (jacoco)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ atlassian-ide-plugin.xml
 
 *.gpg
 secring*
+
+# coverage output
+tmp/coverage

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
 	id 'java-library'
 	id 'maven-publish'
 	id 'signing'
+	id 'jacoco'
 	id 'io.codearte.nexus-staging' version '0.30.0'
 	id "com.diffplug.spotless" version "6.5.2"
 }
@@ -22,6 +23,11 @@ version = '0.7.2'
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8
 	targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+jacoco {
+  toolVersion = "0.8.8"
+  reportsDir = file("$projectDir/tmp/coverage")
 }
 
 repositories {
@@ -78,12 +84,17 @@ task buildJar(type: Jar) {
 }
 
 test {
+	finalizedBy jacocoTestReport
 	useJUnitPlatform {
 		excludeTags('integration')
 	}
 	testLogging {
 		events 'passed', 'skipped', 'failed'
 	}
+}
+
+jacocoTestReport {
+	dependsOn test
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
Add a tool to show the current status of the test coverage.

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/4116980/182514654-de7467d9-c538-43aa-94e9-4e81a13fefc6.png">

There is no specific command to run, just running the tests command from `gradlew`: `./gradlew test integrationTest` and check the report in the `tmp/` folder in the project path.