### PR TITLE
Move HttpClient to Config 

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Config.java
+++ b/src/main/java/com/meilisearch/sdk/Config.java
@@ -10,6 +10,7 @@ public class Config {
     protected final String hostUrl;
     protected final String apiKey;
     protected final JsonHandler jsonHandler;
+    protected final MeilisearchHttpRequest meilisearchHttpRequest;
 
     /**
      * Creates a configuration without an API key
@@ -30,6 +31,7 @@ public class Config {
         this.hostUrl = hostUrl;
         this.apiKey = "";
         this.jsonHandler = jsonHandler;
+        this.meilisearchHttpRequest = new MeilisearchHttpRequest(this);
     }
 
     /**
@@ -42,6 +44,7 @@ public class Config {
         this.hostUrl = hostUrl;
         this.apiKey = apiKey;
         this.jsonHandler = new GsonJsonHandler();
+        this.meilisearchHttpRequest = new MeilisearchHttpRequest(this);
     }
 
     /**
@@ -55,6 +58,7 @@ public class Config {
         this.hostUrl = hostUrl;
         this.apiKey = apiKey;
         this.jsonHandler = jsonHandler;
+        this.meilisearchHttpRequest = new MeilisearchHttpRequest(this);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -11,7 +11,7 @@ class Documents {
     private final MeilisearchHttpRequest meilisearchHttpRequest;
 
     protected Documents(Config config) {
-        meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        meilisearchHttpRequest = config.meilisearchHttpRequest;
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -651,7 +651,7 @@ public class Index implements Serializable {
      */
     public void fetchPrimaryKey() throws MeilisearchException {
         String requestQuery = "/indexes/" + this.uid;
-        MeilisearchHttpRequest meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        MeilisearchHttpRequest meilisearchHttpRequest = config.meilisearchHttpRequest;
         Index retrievedIndex =
                 config.jsonHandler.decode(meilisearchHttpRequest.get(requestQuery), Index.class);
         this.primaryKey = retrievedIndex.getPrimaryKey();

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -18,7 +18,7 @@ public class KeysHandler {
      * @param config Meilisearch configuration
      */
     public KeysHandler(Config config) {
-        this.meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        this.meilisearchHttpRequest = config.meilisearchHttpRequest;
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -13,7 +13,7 @@ public class Search {
      * @param config Meilisearch configuration
      */
     protected Search(Config config) {
-        meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        meilisearchHttpRequest = config.meilisearchHttpRequest;
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -20,7 +20,7 @@ public class SettingsHandler {
      * @param config Meilisearch configuration
      */
     public SettingsHandler(Config config) {
-        meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        meilisearchHttpRequest = config.meilisearchHttpRequest;
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -22,7 +22,7 @@ public class TasksHandler {
      * @param config MeiliSearch configuration
      */
     public TasksHandler(Config config) {
-        this.meilisearchHttpRequest = new MeilisearchHttpRequest(config);
+        this.meilisearchHttpRequest = config.meilisearchHttpRequest;
     }
 
     /**


### PR DESCRIPTION
The `MeilisearchHttpClient` variable has been moved to the `Config` class in a way to be instantiated once instead of being created in each Handler.