### PR TITLE
Provide a generic to http get methods

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -135,10 +135,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task updateIndex(String uid, String primaryKey) throws MeilisearchException {
-        Task task =
-                jsonHandler.decode(
-                        this.indexesHandler.updatePrimaryKey(uid, primaryKey), Task.class);
-        return task;
+        return this.indexesHandler.updatePrimaryKey(uid, primaryKey);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -147,8 +147,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task deleteIndex(String uid) throws MeilisearchException {
-        Task task = jsonHandler.decode(this.indexesHandler.delete(uid), Task.class);
-        return task;
+        return this.indexesHandler.delete(uid);
     }
 
     // TODO createDump will return a Task in v0.28

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -55,8 +55,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task createIndex(String uid, String primaryKey) throws MeilisearchException {
-        Task task = jsonHandler.decode(this.indexesHandler.create(uid, primaryKey), Task.class);
-        return task;
+        return this.indexesHandler.create(uid, primaryKey);
     }
 
     /**
@@ -173,7 +172,7 @@ public class Client {
     //  * @throws MeilisearchException if an error occurs
     //  */
     // public Dump createDump() throws MeilisearchException {
-    //     return jsonHandler.decode(this.meiliSearchHttpRequest.post("/dumps", ""), Dump.class);
+    //     return this.meiliSearchHttpRequest.post("/dumps", "", Dump.class);
     // }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -141,9 +141,7 @@ class Documents {
      */
     Task deleteDocument(String uid, String identifier) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents/" + identifier;
-        Task task = httpClient.jsonHandler.decode(httpClient.delete(urlPath), Task.class);
-
-        return task;
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -168,8 +166,6 @@ class Documents {
      */
     Task deleteAllDocuments(String uid) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents";
-        Task task = httpClient.jsonHandler.decode(httpClient.delete(urlPath), Task.class);
-
-        return task;
+        return httpClient.delete(urlPath, Task.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -24,7 +24,7 @@ class Documents {
      */
     String getDocument(String uid, String identifier) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents/" + identifier;
-        return httpClient.get(urlPath);
+        return httpClient.get(urlPath, String.class);
     }
 
     /**
@@ -36,7 +36,7 @@ class Documents {
      */
     String getDocuments(String uid) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents";
-        return httpClient.get(urlPath);
+        return httpClient.get(urlPath, String.class);
     }
 
     /**
@@ -49,7 +49,7 @@ class Documents {
      */
     String getDocuments(String uid, int limit) throws MeilisearchException {
         String urlQuery = "/indexes/" + uid + "/documents?limit=" + limit;
-        return httpClient.get(urlQuery);
+        return httpClient.get(urlQuery, String.class);
     }
 
     /**
@@ -63,7 +63,7 @@ class Documents {
      */
     String getDocuments(String uid, int limit, int offset) throws MeilisearchException {
         String urlQuery = "/indexes/" + uid + "/documents?limit=" + limit + "&offset=" + offset;
-        return httpClient.get(urlQuery);
+        return httpClient.get(urlQuery, String.class);
     }
 
     /**
@@ -93,7 +93,7 @@ class Documents {
                         + "&attributesToRetrieve="
                         + attributesToRetrieveCommaSeparated;
 
-        return httpClient.get(urlQuery);
+        return httpClient.get(urlQuery, String.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -128,9 +128,7 @@ class Documents {
         if (primaryKey != null) {
             urlPath += "?primaryKey=" + primaryKey;
         }
-        Task task = httpClient.jsonHandler.decode(httpClient.put(urlPath, document), Task.class);
-
-        return task;
+        return httpClient.put(urlPath, document, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -110,9 +110,7 @@ class Documents {
         if (primaryKey != null) {
             urlQuery += "?primaryKey=" + primaryKey;
         }
-        Task task = httpClient.jsonHandler.decode(httpClient.post(urlQuery, document), Task.class);
-
-        return task;
+        return httpClient.post(urlQuery, document, Task.class);
     }
 
     /**
@@ -160,10 +158,7 @@ class Documents {
      */
     Task deleteDocuments(String uid, List<String> identifiers) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents/" + "delete-batch";
-        Task task =
-                httpClient.jsonHandler.decode(httpClient.post(urlPath, identifiers), Task.class);
-
-        return task;
+        return httpClient.post(urlPath, identifiers, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -128,14 +128,16 @@ public class HttpClient {
      * @return deleted resource
      * @throws MeilisearchException if the response is an error
      */
-    String delete(String api) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.put(
-                        request.create(HttpMethod.DELETE, api, Collections.emptyMap(), null));
+    <T> T delete(String api, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.DELETE, api, Collections.emptyMap(), null);
+        HttpResponse<T> httpRequest = this.client.delete(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -6,6 +6,7 @@ import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.http.CustomOkHttpClient;
 import com.meilisearch.sdk.http.request.BasicRequest;
 import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.request.HttpRequest;
 import com.meilisearch.sdk.http.response.BasicResponse;
 import com.meilisearch.sdk.http.response.HttpResponse;
 import com.meilisearch.sdk.json.GsonJsonHandler;
@@ -66,13 +67,11 @@ public class HttpClient {
      */
     <T> T get(String api, String param, Class<T> targetClass, Class<?>... parameters)
             throws MeilisearchException {
-        HttpResponse<T> httpResponse =
-                response.create(
-                        this.client.get(
-                                request.create(
-                                        HttpMethod.GET, api + param, Collections.emptyMap(), null)),
-                        targetClass,
-                        parameters);
+        HttpRequest requestConfig =
+                request.create(HttpMethod.GET, api + param, Collections.emptyMap(), null);
+        HttpResponse<T> httpRequest = this.client.get(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass, parameters);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -87,15 +87,17 @@ public class HttpClient {
      * @return results of the search
      * @throws MeilisearchException if the response is an error
      */
-    <T> String post(String api, T body) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.post(
-                        request.create(HttpMethod.POST, api, Collections.emptyMap(), body));
+    <S, T> T post(String api, S body, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.POST, api, Collections.emptyMap(), body);
+        HttpResponse<T> httpRequest = this.client.post(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -51,8 +51,9 @@ public class HttpClient {
      * @return document that was requested
      * @throws MeilisearchException if the response is an error
      */
-    public String get(String api) throws MeilisearchException {
-        return this.get(api, "");
+    <T> T get(String api, Class<T> targetClass, Class<?>... parameters)
+            throws MeilisearchException {
+        return this.get(api, "", targetClass, parameters);
     }
 
     /**
@@ -63,15 +64,20 @@ public class HttpClient {
      * @return document that was requested
      * @throws MeilisearchException if the response is an error
      */
-    String get(String api, String param) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.get(
-                        request.create(HttpMethod.GET, api + param, Collections.emptyMap(), null));
+    <T> T get(String api, String param, Class<T> targetClass, Class<?>... parameters)
+            throws MeilisearchException {
+        HttpResponse<T> httpResponse =
+                response.create(
+                        this.client.get(
+                                request.create(
+                                        HttpMethod.GET, api + param, Collections.emptyMap(), null)),
+                        targetClass,
+                        parameters);
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -108,14 +108,17 @@ public class HttpClient {
      * @return updated resource
      * @throws MeilisearchException if the response is an error
      */
-    <T> String put(String api, T body) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.put(request.create(HttpMethod.PUT, api, Collections.emptyMap(), body));
+    <S, T> T put(String api, S body, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.PUT, api, Collections.emptyMap(), body);
+        HttpResponse<T> httpRequest = this.client.put(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -652,7 +652,7 @@ public class Index implements Serializable {
     public void fetchPrimaryKey() throws MeilisearchException {
         String requestQuery = "/indexes/" + this.uid;
         HttpClient httpClient = config.httpClient;
-        Index retrievedIndex = config.jsonHandler.decode(httpClient.get(requestQuery), Index.class);
+        Index retrievedIndex = httpClient.get(requestQuery, Index.class);
         this.primaryKey = retrievedIndex.getPrimaryKey();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -90,8 +90,8 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String delete(String uid) throws MeilisearchException {
+    Task delete(String uid) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid;
-        return httpClient.delete(requestQuery);
+        return httpClient.delete(requestQuery, Task.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -53,7 +53,7 @@ class IndexesHandler {
      */
     String get(String uid) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid;
-        return httpClient.get(requestQuery);
+        return httpClient.get(requestQuery, String.class);
     }
 
     /**
@@ -63,7 +63,7 @@ class IndexesHandler {
      * @throws MeilisearchException if an error occurs
      */
     String getAll() throws MeilisearchException {
-        return httpClient.get("/indexes");
+        return httpClient.get("/indexes", String.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.Task;
 import java.util.HashMap;
 
 /** Wrapper around the HttpClient class to ease usage for Meilisearch indexes */
@@ -24,7 +25,7 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String create(String uid) throws MeilisearchException {
+    Task create(String uid) throws MeilisearchException {
         return this.create(uid, null);
     }
 
@@ -36,12 +37,12 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String create(String uid, String primaryKey) throws MeilisearchException {
+    Task create(String uid, String primaryKey) throws MeilisearchException {
         HashMap<String, Object> index = new HashMap<String, Object>();
         index.put("uid", uid);
         index.put("primaryKey", primaryKey);
 
-        return httpClient.post("/indexes", index);
+        return httpClient.post("/indexes", index, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -75,12 +75,12 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String updatePrimaryKey(String uid, String primaryKey) throws MeilisearchException {
+    Task updatePrimaryKey(String uid, String primaryKey) throws MeilisearchException {
         HashMap<String, Object> index = new HashMap<String, Object>();
         index.put("primaryKey", primaryKey);
 
         String requestQuery = "/indexes/" + uid;
-        return httpClient.put(requestQuery, index);
+        return httpClient.put(requestQuery, index, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -65,6 +65,6 @@ public class KeysHandler {
      */
     public void deleteKey(String key) throws MeilisearchException {
         String urlPath = "/keys/" + key;
-        this.httpClient.delete(urlPath);
+        httpClient.delete(urlPath, String.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -30,7 +30,7 @@ public class KeysHandler {
      */
     public Key getKey(String uid) throws MeilisearchException {
         String urlPath = "/keys/" + uid;
-        return httpClient.jsonHandler.decode(this.httpClient.get(urlPath), Key.class);
+        return httpClient.get(urlPath, Key.class);
     }
 
     /**
@@ -41,9 +41,7 @@ public class KeysHandler {
      */
     public Result<Key> getKeys() throws MeilisearchException {
         String urlPath = "/keys";
-        Result<Key> result =
-                httpClient.jsonHandler.decode(
-                        this.httpClient.get(urlPath), Result.class, Key.class);
+        Result<Key> result = httpClient.get(urlPath, Result.class, Key.class);
         return result;
     }
 

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -54,7 +54,7 @@ public class KeysHandler {
      */
     public Key createKey(Key options) throws MeilisearchException {
         String urlPath = "/keys";
-        return httpClient.jsonHandler.decode(this.httpClient.post(urlPath, options), Key.class);
+        return httpClient.post(urlPath, options, Key.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -27,7 +27,7 @@ public class Search {
     String rawSearch(String uid, String q) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
         SearchRequest sr = new SearchRequest(q);
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**
@@ -87,7 +87,7 @@ public class Search {
                         matches,
                         facetsDistribution,
                         sort);
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**
@@ -100,7 +100,7 @@ public class Search {
      */
     String rawSearch(String uid, SearchRequest sr) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -32,8 +32,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Settings getSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings"), Settings.class);
+        String urlPath = "/indexes/" + uid + "/settings";
+        return httpClient.get(urlPath, Settings.class);
     }
 
     /**
@@ -72,8 +72,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String[] getRankingRuleSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/ranking-rules"), String[].class);
+        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
+        return httpClient.get(urlPath, String[].class);
     }
 
     /**
@@ -118,8 +118,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Map<String, String[]> getSynonymsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/synonyms"), Map.class);
+        String urlPath = "/indexes/" + uid + "/settings/synonyms";
+        return httpClient.jsonHandler.decode(httpClient.get(urlPath, String.class), Map.class);
     }
 
     /**
@@ -162,8 +162,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String[] getStopWordsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/stop-words"), String[].class);
+        String urlPath = "/indexes/" + uid + "/settings/stop-words";
+        return httpClient.get(urlPath, String[].class);
     }
 
     /**
@@ -206,9 +206,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String[] getSearchableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/searchable-attributes"),
-                String[].class);
+        String urlPath = "/indexes/" + uid + "/settings/searchable-attributes";
+        return httpClient.get(urlPath, String[].class);
     }
 
     /**
@@ -255,9 +254,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String[] getDisplayedAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/displayed-attributes"),
-                String[].class);
+        String urlPath = "/indexes/" + uid + "/settings/displayed-attributes";
+        return httpClient.get(urlPath, String[].class);
     }
 
     /**
@@ -304,9 +302,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String[] getFilterableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/filterable-attributes"),
-                String[].class);
+        String urlPath = "/indexes/" + uid + "/settings/filterable-attributes";
+        return httpClient.get(urlPath, String[].class);
     }
 
     /**
@@ -353,10 +350,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public String getDistinctAttributeSettings(String uid) throws MeilisearchException {
-        String response =
-                httpClient.jsonHandler.decode(
-                        httpClient.get("/indexes/" + uid + "/settings/distinct-attribute"),
-                        String.class);
+        String urlPath = "/indexes/" + uid + "/settings/distinct-attribute";
+        String response = httpClient.get(urlPath, String.class);
         return response.equals("null") ? null : response.substring(1, response.length() - 1);
     }
 
@@ -402,9 +397,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public TypoTolerance getTypoToleranceSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.get("/indexes/" + uid + "/settings/typo-tolerance"),
-                TypoTolerance.class);
+        String urlPath = "/indexes/" + uid + "/settings/typo-tolerance";
+        return httpClient.get(urlPath, TypoTolerance.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -46,8 +46,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task updateSettings(String uid, Settings settings) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post("/indexes/" + uid + "/settings", settings), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings";
+        return httpClient.post(urlPath, settings, Task.class);
     }
 
     /**
@@ -87,12 +87,10 @@ public class SettingsHandler {
      */
     public Task updateRankingRuleSettings(String uid, String[] rankingRules)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/ranking-rules",
-                        rankingRules == null
-                                ? httpClient.jsonHandler.encode(rankingRules)
-                                : rankingRules),
+        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
+        return httpClient.post(
+                urlPath,
+                rankingRules == null ? httpClient.jsonHandler.encode(rankingRules) : rankingRules,
                 Task.class);
     }
 
@@ -133,10 +131,10 @@ public class SettingsHandler {
      */
     public Task updateSynonymsSettings(String uid, Map<String, String[]> synonyms)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/synonyms",
-                        synonyms == null ? httpClient.jsonHandler.encode(synonyms) : synonyms),
+        String urlPath = "/indexes/" + uid + "/settings/synonyms";
+        return httpClient.post(
+                urlPath,
+                synonyms == null ? httpClient.jsonHandler.encode(synonyms) : synonyms,
                 Task.class);
     }
 
@@ -177,10 +175,10 @@ public class SettingsHandler {
      */
     public Task updateStopWordsSettings(String uid, String[] stopWords)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/stop-words",
-                        stopWords == null ? httpClient.jsonHandler.encode(stopWords) : stopWords),
+        String urlPath = "/indexes/" + uid + "/settings/stop-words";
+        return httpClient.post(
+                urlPath,
+                stopWords == null ? httpClient.jsonHandler.encode(stopWords) : stopWords,
                 Task.class);
     }
 
@@ -222,12 +220,12 @@ public class SettingsHandler {
      */
     public Task updateSearchableAttributesSettings(String uid, String[] searchableAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/searchable-attributes",
-                        searchableAttributes == null
-                                ? httpClient.jsonHandler.encode(searchableAttributes)
-                                : searchableAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/searchable-attributes";
+        return httpClient.post(
+                urlPath,
+                searchableAttributes == null
+                        ? httpClient.jsonHandler.encode(searchableAttributes)
+                        : searchableAttributes,
                 Task.class);
     }
 
@@ -270,12 +268,12 @@ public class SettingsHandler {
      */
     public Task updateDisplayedAttributesSettings(String uid, String[] displayAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/displayed-attributes",
-                        displayAttributes == null
-                                ? httpClient.jsonHandler.encode(displayAttributes)
-                                : displayAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/displayed-attributes";
+        return httpClient.post(
+                urlPath,
+                displayAttributes == null
+                        ? httpClient.jsonHandler.encode(displayAttributes)
+                        : displayAttributes,
                 Task.class);
     }
 
@@ -318,12 +316,12 @@ public class SettingsHandler {
      */
     public Task updateFilterableAttributesSettings(String uid, String[] filterableAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/filterable-attributes",
-                        filterableAttributes == null
-                                ? httpClient.jsonHandler.encode(filterableAttributes)
-                                : filterableAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/filterable-attributes";
+        return httpClient.post(
+                urlPath,
+                filterableAttributes == null
+                        ? httpClient.jsonHandler.encode(filterableAttributes)
+                        : filterableAttributes,
                 Task.class);
     }
 
@@ -366,12 +364,12 @@ public class SettingsHandler {
      */
     public Task updateDistinctAttributeSettings(String uid, String distinctAttribute)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/distinct-attribute",
-                        distinctAttribute == null
-                                ? httpClient.jsonHandler.encode(distinctAttribute)
-                                : "\"" + distinctAttribute + "\""),
+        String urlPath = "/indexes/" + uid + "/settings/distinct-attribute";
+        return httpClient.post(
+                urlPath,
+                distinctAttribute == null
+                        ? httpClient.jsonHandler.encode(distinctAttribute)
+                        : "\"" + distinctAttribute + "\"",
                 Task.class);
     }
 
@@ -412,12 +410,12 @@ public class SettingsHandler {
      */
     public Task updateTypoToleranceSettings(String uid, TypoTolerance typoTolerance)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/typo-tolerance",
-                        typoTolerance == null
-                                ? httpClient.jsonHandler.encode(typoTolerance)
-                                : typoTolerance),
+        String urlPath = "/indexes/" + uid + "/settings/typo-tolerance";
+        return httpClient.post(
+                urlPath,
+                typoTolerance == null
+                        ? httpClient.jsonHandler.encode(typoTolerance)
+                        : typoTolerance,
                 Task.class);
     }
 

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -59,8 +59,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -103,8 +103,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetRankingRulesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/ranking-rules"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -147,8 +147,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSynonymsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/synonyms"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/synonyms";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -191,8 +191,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetStopWordsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/stop-words"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/stop-words";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -238,9 +238,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSearchableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/searchable-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/searchable-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -286,9 +285,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetDisplayedAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/displayed-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/displayed-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -334,9 +332,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetFilterableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/filterable-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/filterable-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -382,8 +379,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetDistinctAttributeSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/distinct-attribute"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/distinct-attribute";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -428,7 +425,7 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetTypoToleranceSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/typo-tolerance"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/typo-tolerance";
+        return httpClient.delete(urlPath, Task.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -35,7 +35,7 @@ public class TasksHandler {
      */
     public Task getTask(String indexUid, int taskUid) throws MeilisearchException {
         String urlPath = "/indexes/" + indexUid + "/tasks/" + taskUid;
-        return httpClient.jsonHandler.decode(this.httpClient.get(urlPath), Task.class);
+        return httpClient.get(urlPath, Task.class);
     }
 
     /**
@@ -48,9 +48,7 @@ public class TasksHandler {
     public Result<Task> getTasks(String indexUid) throws MeilisearchException {
         String urlPath = "/indexes/" + indexUid + "/tasks";
 
-        Result<Task> result =
-                httpClient.jsonHandler.decode(
-                        this.httpClient.get(urlPath), Result.class, Task.class);
+        Result<Task> result = httpClient.get(urlPath, Result.class, Task.class);
         return result;
     }
 
@@ -63,7 +61,7 @@ public class TasksHandler {
      */
     public Task getTask(int taskUid) throws MeilisearchException {
         String urlPath = "/tasks/" + taskUid;
-        return httpClient.jsonHandler.decode(this.httpClient.get(urlPath), Task.class);
+        return httpClient.get(urlPath, Task.class);
     }
 
     /**
@@ -75,9 +73,7 @@ public class TasksHandler {
     public Result<Task> getTasks() throws MeilisearchException {
         String urlPath = "/tasks";
 
-        Result<Task> result =
-                httpClient.jsonHandler.decode(
-                        this.httpClient.get(urlPath), Result.class, Task.class);
+        Result<Task> result = httpClient.get(urlPath, Result.class, Task.class);
         return result;
     }
 

--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -31,7 +31,7 @@ public class CustomOkHttpClient {
         this.client = new OkHttpClient();
     }
 
-    public HttpResponse execute(HttpRequest request) throws MeilisearchException {
+    public <T> HttpResponse<T> execute(HttpRequest request) throws MeilisearchException {
         try {
             Request okRequest = buildRequest(request);
             Response response = client.newCall(okRequest).execute();
@@ -78,13 +78,13 @@ public class CustomOkHttpClient {
         return builder.build();
     }
 
-    private HttpResponse buildResponse(Response response) throws IOException {
+    private <T> HttpResponse<T> buildResponse(Response response) throws IOException {
         String body = null;
         ResponseBody responseBody = response.body();
         if (responseBody != null) body = responseBody.string();
 
-        return new HttpResponse(
-                parseHeaders(response.headers().toMultimap()), response.code(), body);
+        return new HttpResponse<T>(
+                parseHeaders(response.headers().toMultimap()), response.code(), (T) body);
     }
 
     private Map<String, String> parseHeaders(Map<String, List<String>> headers) {
@@ -95,19 +95,19 @@ public class CustomOkHttpClient {
         return headerMap;
     }
 
-    public HttpResponse get(HttpRequest request) throws MeilisearchException {
+    public <T> HttpResponse<T> get(HttpRequest request) throws MeilisearchException {
         return execute(request);
     }
 
-    public HttpResponse post(HttpRequest request) throws MeilisearchException {
+    public <T> HttpResponse<T> post(HttpRequest request) throws MeilisearchException {
         return execute(request);
     }
 
-    public HttpResponse put(HttpRequest request) throws MeilisearchException {
+    public <T> HttpResponse<T> put(HttpRequest request) throws MeilisearchException {
         return execute(request);
     }
 
-    public HttpResponse delete(HttpRequest request) throws MeilisearchException {
+    public <T> HttpResponse<T> delete(HttpRequest request) throws MeilisearchException {
         return execute(request);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
@@ -13,6 +13,7 @@ public class BasicResponse {
             HttpResponse<T> httpResponse, Class<T> targetClass, Class<?>... parameters) {
         try {
             T content = this.jsonHandler.decode(httpResponse.getContent(), targetClass, parameters);
+
             return new HttpResponse<T>(
                     httpResponse.getHeaders(),
                     httpResponse.getStatusCode(),

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
@@ -12,13 +12,11 @@ public class BasicResponse {
     public <T> HttpResponse<T> create(
             HttpResponse<T> httpResponse, Class<T> targetClass, Class<?>... parameters) {
         try {
+            T content = this.jsonHandler.decode(httpResponse.getContent(), targetClass, parameters);
             return new HttpResponse<T>(
                     httpResponse.getHeaders(),
                     httpResponse.getStatusCode(),
-                    httpResponse.getContent() == null
-                            ? null
-                            : this.jsonHandler.decode(
-                                    httpResponse.getContent(), targetClass, parameters));
+                    httpResponse.getContent() == null ? null : content);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
@@ -9,14 +9,16 @@ public class BasicResponse {
         this.jsonHandler = jsonHandler;
     }
 
-    public <T> HttpResponse create(HttpResponse response, Class<?> targetClass) {
+    public <T> HttpResponse<T> create(
+            HttpResponse<T> httpResponse, Class<T> targetClass, Class<?>... parameters) {
         try {
-            return new HttpResponse(
-                    response.getHeaders(),
-                    response.getStatusCode(),
-                    response.getContent() == null
+            return new HttpResponse<T>(
+                    httpResponse.getHeaders(),
+                    httpResponse.getStatusCode(),
+                    httpResponse.getContent() == null
                             ? null
-                            : this.jsonHandler.decode(response.getContent(), targetClass));
+                            : this.jsonHandler.decode(
+                                    httpResponse.getContent(), targetClass, parameters));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
@@ -18,8 +18,4 @@ public class HttpResponse<T> {
     public boolean hasContent() {
         return content != null;
     }
-
-    public byte[] getContentAsBytes() {
-        return ((String) content).getBytes();
-    }
 }

--- a/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/HttpResponse.java
@@ -4,12 +4,12 @@ import java.util.Map;
 import lombok.Getter;
 
 @Getter
-public class HttpResponse {
+public class HttpResponse<T> {
     private final Map<String, String> headers;
     private final int statusCode;
-    private final String content;
+    private final T content;
 
-    public HttpResponse(Map<String, String> headers, int statusCode, String content) {
+    public HttpResponse(Map<String, String> headers, int statusCode, T content) {
         this.headers = headers;
         this.statusCode = statusCode;
         this.content = content;
@@ -20,6 +20,6 @@ public class HttpResponse {
     }
 
     public byte[] getContentAsBytes() {
-        return content.getBytes();
+        return ((String) content).getBytes();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -49,7 +49,7 @@ public class GsonJsonHandler implements JsonHandler {
         }
         try {
             if (parameters == null || parameters.length == 0) {
-                return (T) gson.fromJson((String) o, targetClass);
+                return gson.<T>fromJson((String) o, targetClass);
             } else {
                 TypeToken<?> parameterized = TypeToken.getParameterized(targetClass, parameters);
                 return gson.fromJson((String) o, parameterized.getType());


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Most of the methods had to use the `jsonHandler` after the call to the `get` method through the client. The purpose of this PR is to bypass this step to simplify the call to the get method via the client:
```java
    public String[] getRankingRuleSettings(String uid) throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/settings/synonyms";
        return httpClient.jsonHandler.decode(httpClient.get(urlPath, String.class), String[].class);
    }
```
became
```java
    public String[] getRankingRuleSettings(String uid) throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
        return httpClient.get(urlPath, String[].class);
    }
```

**Note:**

This method still need a call to the `decode` method from `jsonHandler`
```java
    public Map<String, String[]> getSynonymsSettings(String uid) throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/settings/synonyms";
        return httpClient.jsonHandler.decode(httpClient.get(urlPath, String.class), Map.class);
    }
```