### PR TITLE
Provide a generic to http post methods 

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -55,8 +55,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task createIndex(String uid, String primaryKey) throws MeilisearchException {
-        Task task = jsonHandler.decode(this.indexesHandler.create(uid, primaryKey), Task.class);
-        return task;
+        return this.indexesHandler.create(uid, primaryKey);
     }
 
     /**
@@ -173,7 +172,7 @@ public class Client {
     //  * @throws MeilisearchException if an error occurs
     //  */
     // public Dump createDump() throws MeilisearchException {
-    //     return jsonHandler.decode(this.meiliSearchHttpRequest.post("/dumps", ""), Dump.class);
+    //     return this.meiliSearchHttpRequest.post("/dumps", "", Dump.class);
     // }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -110,9 +110,7 @@ class Documents {
         if (primaryKey != null) {
             urlQuery += "?primaryKey=" + primaryKey;
         }
-        Task task = httpClient.jsonHandler.decode(httpClient.post(urlQuery, document), Task.class);
-
-        return task;
+        return httpClient.post(urlQuery, document, Task.class);
     }
 
     /**
@@ -160,10 +158,7 @@ class Documents {
      */
     Task deleteDocuments(String uid, List<String> identifiers) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents/" + "delete-batch";
-        Task task =
-                httpClient.jsonHandler.decode(httpClient.post(urlPath, identifiers), Task.class);
-
-        return task;
+        return httpClient.post(urlPath, identifiers, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -87,15 +87,17 @@ public class HttpClient {
      * @return results of the search
      * @throws MeilisearchException if the response is an error
      */
-    <T> String post(String api, T body) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.post(
-                        request.create(HttpMethod.POST, api, Collections.emptyMap(), body));
+    <S, T> T post(String api, S body, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.POST, api, Collections.emptyMap(), body);
+        HttpResponse<T> httpRequest = this.client.post(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.Task;
 import java.util.HashMap;
 
 /** Wrapper around the HttpClient class to ease usage for Meilisearch indexes */
@@ -24,7 +25,7 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String create(String uid) throws MeilisearchException {
+    Task create(String uid) throws MeilisearchException {
         return this.create(uid, null);
     }
 
@@ -36,12 +37,12 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String create(String uid, String primaryKey) throws MeilisearchException {
+    Task create(String uid, String primaryKey) throws MeilisearchException {
         HashMap<String, Object> index = new HashMap<String, Object>();
         index.put("uid", uid);
         index.put("primaryKey", primaryKey);
 
-        return httpClient.post("/indexes", index);
+        return httpClient.post("/indexes", index, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -54,7 +54,7 @@ public class KeysHandler {
      */
     public Key createKey(Key options) throws MeilisearchException {
         String urlPath = "/keys";
-        return httpClient.jsonHandler.decode(this.httpClient.post(urlPath, options), Key.class);
+        return httpClient.post(urlPath, options, Key.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -27,7 +27,7 @@ public class Search {
     String rawSearch(String uid, String q) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
         SearchRequest sr = new SearchRequest(q);
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**
@@ -87,7 +87,7 @@ public class Search {
                         matches,
                         facetsDistribution,
                         sort);
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**
@@ -100,7 +100,7 @@ public class Search {
      */
     String rawSearch(String uid, SearchRequest sr) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
-        return httpClient.post(requestQuery, sr);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -46,8 +46,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task updateSettings(String uid, Settings settings) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post("/indexes/" + uid + "/settings", settings), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings";
+        return httpClient.post(urlPath, settings, Task.class);
     }
 
     /**
@@ -87,12 +87,10 @@ public class SettingsHandler {
      */
     public Task updateRankingRuleSettings(String uid, String[] rankingRules)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/ranking-rules",
-                        rankingRules == null
-                                ? httpClient.jsonHandler.encode(rankingRules)
-                                : rankingRules),
+        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
+        return httpClient.post(
+                urlPath,
+                rankingRules == null ? httpClient.jsonHandler.encode(rankingRules) : rankingRules,
                 Task.class);
     }
 
@@ -133,10 +131,10 @@ public class SettingsHandler {
      */
     public Task updateSynonymsSettings(String uid, Map<String, String[]> synonyms)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/synonyms",
-                        synonyms == null ? httpClient.jsonHandler.encode(synonyms) : synonyms),
+        String urlPath = "/indexes/" + uid + "/settings/synonyms";
+        return httpClient.post(
+                urlPath,
+                synonyms == null ? httpClient.jsonHandler.encode(synonyms) : synonyms,
                 Task.class);
     }
 
@@ -177,10 +175,10 @@ public class SettingsHandler {
      */
     public Task updateStopWordsSettings(String uid, String[] stopWords)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/stop-words",
-                        stopWords == null ? httpClient.jsonHandler.encode(stopWords) : stopWords),
+        String urlPath = "/indexes/" + uid + "/settings/stop-words";
+        return httpClient.post(
+                urlPath,
+                stopWords == null ? httpClient.jsonHandler.encode(stopWords) : stopWords,
                 Task.class);
     }
 
@@ -222,12 +220,12 @@ public class SettingsHandler {
      */
     public Task updateSearchableAttributesSettings(String uid, String[] searchableAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/searchable-attributes",
-                        searchableAttributes == null
-                                ? httpClient.jsonHandler.encode(searchableAttributes)
-                                : searchableAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/searchable-attributes";
+        return httpClient.post(
+                urlPath,
+                searchableAttributes == null
+                        ? httpClient.jsonHandler.encode(searchableAttributes)
+                        : searchableAttributes,
                 Task.class);
     }
 
@@ -270,12 +268,12 @@ public class SettingsHandler {
      */
     public Task updateDisplayedAttributesSettings(String uid, String[] displayAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/displayed-attributes",
-                        displayAttributes == null
-                                ? httpClient.jsonHandler.encode(displayAttributes)
-                                : displayAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/displayed-attributes";
+        return httpClient.post(
+                urlPath,
+                displayAttributes == null
+                        ? httpClient.jsonHandler.encode(displayAttributes)
+                        : displayAttributes,
                 Task.class);
     }
 
@@ -318,12 +316,12 @@ public class SettingsHandler {
      */
     public Task updateFilterableAttributesSettings(String uid, String[] filterableAttributes)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/filterable-attributes",
-                        filterableAttributes == null
-                                ? httpClient.jsonHandler.encode(filterableAttributes)
-                                : filterableAttributes),
+        String urlPath = "/indexes/" + uid + "/settings/filterable-attributes";
+        return httpClient.post(
+                urlPath,
+                filterableAttributes == null
+                        ? httpClient.jsonHandler.encode(filterableAttributes)
+                        : filterableAttributes,
                 Task.class);
     }
 
@@ -366,12 +364,12 @@ public class SettingsHandler {
      */
     public Task updateDistinctAttributeSettings(String uid, String distinctAttribute)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/distinct-attribute",
-                        distinctAttribute == null
-                                ? httpClient.jsonHandler.encode(distinctAttribute)
-                                : "\"" + distinctAttribute + "\""),
+        String urlPath = "/indexes/" + uid + "/settings/distinct-attribute";
+        return httpClient.post(
+                urlPath,
+                distinctAttribute == null
+                        ? httpClient.jsonHandler.encode(distinctAttribute)
+                        : "\"" + distinctAttribute + "\"",
                 Task.class);
     }
 
@@ -412,12 +410,12 @@ public class SettingsHandler {
      */
     public Task updateTypoToleranceSettings(String uid, TypoTolerance typoTolerance)
             throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.post(
-                        "/indexes/" + uid + "/settings/typo-tolerance",
-                        typoTolerance == null
-                                ? httpClient.jsonHandler.encode(typoTolerance)
-                                : typoTolerance),
+        String urlPath = "/indexes/" + uid + "/settings/typo-tolerance";
+        return httpClient.post(
+                urlPath,
+                typoTolerance == null
+                        ? httpClient.jsonHandler.encode(typoTolerance)
+                        : typoTolerance,
                 Task.class);
     }
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Most of the methods had to use the `jsonHandler` after the call to the `post` method through the client. The purpose of this PR is to bypass this step to simplify the call to the `post` method via the client:
```java
    public Task updateRankingRuleSettings(String uid, String[] rankingRules)
            throws MeilisearchException {
        return httpClient.jsonHandler.decode(
                httpClient.post(
                        "/indexes/" + uid + "/settings/ranking-rules",
                        rankingRules == null
                                ? httpClient.jsonHandler.encode(rankingRules)
                                : rankingRules),
                Task.class);
    }
```
became:
```java
    public Task updateRankingRuleSettings(String uid, String[] rankingRules)
            throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
        return httpClient.post(
                urlPath,
                rankingRules == null ? httpClient.jsonHandler.encode(rankingRules) : rankingRules,
                Task.class);
    }
```