### PR TITLE
Provide a generic to http put method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -135,10 +135,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task updateIndex(String uid, String primaryKey) throws MeilisearchException {
-        Task task =
-                jsonHandler.decode(
-                        this.indexesHandler.updatePrimaryKey(uid, primaryKey), Task.class);
-        return task;
+        return this.indexesHandler.updatePrimaryKey(uid, primaryKey);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -128,9 +128,7 @@ class Documents {
         if (primaryKey != null) {
             urlPath += "?primaryKey=" + primaryKey;
         }
-        Task task = httpClient.jsonHandler.decode(httpClient.put(urlPath, document), Task.class);
-
-        return task;
+        return httpClient.put(urlPath, document, Task.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -108,14 +108,17 @@ public class HttpClient {
      * @return updated resource
      * @throws MeilisearchException if the response is an error
      */
-    <T> String put(String api, T body) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.put(request.create(HttpMethod.PUT, api, Collections.emptyMap(), body));
+    <S, T> T put(String api, S body, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.PUT, api, Collections.emptyMap(), body);
+        HttpResponse<T> httpRequest = this.client.put(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -75,12 +75,12 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String updatePrimaryKey(String uid, String primaryKey) throws MeilisearchException {
+    Task updatePrimaryKey(String uid, String primaryKey) throws MeilisearchException {
         HashMap<String, Object> index = new HashMap<String, Object>();
         index.put("primaryKey", primaryKey);
 
         String requestQuery = "/indexes/" + uid;
-        return httpClient.put(requestQuery, index);
+        return httpClient.put(requestQuery, index, Task.class);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Most of the methods had to use the `jsonHandler` after the call to the `put` method through the client. The purpose of this PR is to bypass this step to simplify the call to the `put` method via the client:
```java
    Task updateDocuments(String uid, String document)
            throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/documents";
        Task task = httpClient.jsonHandler.decode(httpClient.put(urlPath, document), Task.class);

        return task;
    }
```
became
```java
    Task updateDocuments(String uid, String document)
            throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/documents";
        return httpClient.put(urlPath, document, Task.class);
    }
```