### PR TITLE
Provide a generic to http delete method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -147,8 +147,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Task deleteIndex(String uid) throws MeilisearchException {
-        Task task = jsonHandler.decode(this.indexesHandler.delete(uid), Task.class);
-        return task;
+        return this.indexesHandler.delete(uid);
     }
 
     // TODO createDump will return a Task in v0.28

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -141,9 +141,7 @@ class Documents {
      */
     Task deleteDocument(String uid, String identifier) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents/" + identifier;
-        Task task = httpClient.jsonHandler.decode(httpClient.delete(urlPath), Task.class);
-
-        return task;
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -168,8 +166,6 @@ class Documents {
      */
     Task deleteAllDocuments(String uid) throws MeilisearchException {
         String urlPath = "/indexes/" + uid + "/documents";
-        Task task = httpClient.jsonHandler.decode(httpClient.delete(urlPath), Task.class);
-
-        return task;
+        return httpClient.delete(urlPath, Task.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -128,14 +128,16 @@ public class HttpClient {
      * @return deleted resource
      * @throws MeilisearchException if the response is an error
      */
-    String delete(String api) throws MeilisearchException {
-        HttpResponse httpResponse =
-                this.client.put(
-                        request.create(HttpMethod.DELETE, api, Collections.emptyMap(), null));
+    <T> T delete(String api, Class<T> targetClass) throws MeilisearchException {
+        HttpRequest requestConfig =
+                request.create(HttpMethod.DELETE, api, Collections.emptyMap(), null);
+        HttpResponse<T> httpRequest = this.client.delete(requestConfig);
+        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return new String(httpResponse.getContentAsBytes());
+        return httpResponse.getContent();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -90,8 +90,10 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String delete(String uid) throws MeilisearchException {
+    Task delete(String uid) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid;
-        return httpClient.delete(requestQuery);
+        return httpClient.delete(requestQuery, Task.class);
+    }
+
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -94,6 +94,4 @@ class IndexesHandler {
         String requestQuery = "/indexes/" + uid;
         return httpClient.delete(requestQuery, Task.class);
     }
-
-    }
 }

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -65,6 +65,6 @@ public class KeysHandler {
      */
     public void deleteKey(String key) throws MeilisearchException {
         String urlPath = "/keys/" + key;
-        this.httpClient.delete(urlPath);
+        httpClient.delete(urlPath, String.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -59,8 +59,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -103,8 +103,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetRankingRulesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/ranking-rules"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -147,8 +147,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSynonymsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/synonyms"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/synonyms";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -191,8 +191,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetStopWordsSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/stop-words"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/stop-words";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -238,9 +238,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetSearchableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/searchable-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/searchable-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -286,9 +285,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetDisplayedAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/displayed-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/displayed-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -334,9 +332,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetFilterableAttributesSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/filterable-attributes"),
-                Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/filterable-attributes";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -382,8 +379,8 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetDistinctAttributeSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/distinct-attribute"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/distinct-attribute";
+        return httpClient.delete(urlPath, Task.class);
     }
 
     /**
@@ -428,7 +425,7 @@ public class SettingsHandler {
      * @throws MeilisearchException if an error occurs
      */
     public Task resetTypoToleranceSettings(String uid) throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                httpClient.delete("/indexes/" + uid + "/settings/typo-tolerance"), Task.class);
+        String urlPath = "/indexes/" + uid + "/settings/typo-tolerance";
+        return httpClient.delete(urlPath, Task.class);
     }
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Most of the methods had to use the `jsonHandler` after the call to the `delete` method through the client. The purpose of this PR is to bypass this step to simplify the call to the `delete` method via the client:
```java
    public Task resetRankingRulesSettings(String uid) throws MeilisearchException {
        Task task = jsonHandler.decode(this.indexesHandler.delete(uid), Task.class);
        return task;
    }
```
became
```java
    public Task resetRankingRulesSettings(String uid) throws MeilisearchException {
        String urlPath = "/indexes/" + uid + "/settings/ranking-rules";
        return httpClient.delete(urlPath, Task.class);
    }
```