### PR TITLE
Update version for the next release (v0.8.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -401,7 +401,7 @@ getting_started_add_documents_md: |-
   <dependency>
     <groupId>com.meilisearch.sdk</groupId>
     <artifactId>meilisearch-java</artifactId>
-    <version>0.7.2</version>
+    <version>0.8.0</version>
     <type>pom</type>
   </dependency>
   ```
@@ -409,7 +409,7 @@ getting_started_add_documents_md: |-
   **Gradle**
   Add the following line to the `dependencies` section of your `build.gradle`:
   ```groovy
-  implementation 'com.meilisearch.sdk:meilisearch-java:0.7.2'
+  implementation 'com.meilisearch.sdk:meilisearch-java:0.8.0'
   ```
 
   ```java

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add the following code to the `<dependencies>` section of your project:
 <dependency>
   <groupId>com.meilisearch.sdk</groupId>
   <artifactId>meilisearch-java</artifactId>
-  <version>0.7.2</version>
+  <version>0.8.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -66,7 +66,7 @@ Add the following code to the `<dependencies>` section of your project:
 Add the following line to the `dependencies` section of your `build.gradle`:
 
 ```groovy
-implementation 'com.meilisearch.sdk:meilisearch-java:0.7.2'
+implementation 'com.meilisearch.sdk:meilisearch-java:0.8.0'
 ```
 
 ### Run Meilisearch <!-- omit in toc -->

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 
 group = 'com.meilisearch.sdk'
 archivesBaseName = 'meilisearch-java'
-version = '0.7.2'
+version = '0.8.0'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This version includes a major redesign of the SDK. ([#425](https://github.com/meilisearch/meilisearch-java/pull/425)) [@alallema](https://github.com/alallema)

## ⚠️ Breaking changes

* Redesign of the client (#449) @alallema:
    * Use `OkHttp` library by default for the Meilisearch client
    * No interface for the creation of a Client disappearing of the class `GenericServiceTemplate`, `ServiceTemplate`, `AbstractClient`, `ApacheClient`, and `DefaultHttpClient`.
* Rename `getAllIndexes` method in `getIndexes` (#477) @alallema
* All parameters of the managers accessible in the client are now private: `Config`, `IndexesHandler`, `InstanceHandler`, ` TasksHandler`, `KeysHandler`, `JsonHandler`.
* Factories for the answer and the response disappeared, those classes were removed: `BasicRequestFactory`, `BasicHttpResponse`, `BasicHttpRequest`, and `MeilisearchHttpRequest`.
* Rewriting of the JsonHandler
    * Offering the possibility to use `Gson`, `Jackson` or create your own handler.([#432]
    * Remove `JsonbJsonHandler`.
* Dump returns a `Task`from v0.28.0 so the `createDump` method has been removed just as the `DumpHandler` class.
* Renaming class `Details` in `TaskDetails`
* All methods return now a `MeilisearchException` instead of a `Exception`.

## 🚀 Enhancements

* Replaced traditional getter setter by `@Getter` `@Setter` from Lombok library ([#385](https://github.com/meilisearch/meilisearch-java/pull/385)) [@ghousek1](https://github.com/ghousek1)
* Improve Docker configuration in the package ([#399](https://github.com/meilisearch/meilisearch-java/pull/399))
* Add code-coverage tool (jacoco) ([#422](https://github.com/meilisearch/meilisearch-java/pull/422)) [@brunoocasali](https://github.com/brunoocasali)
* Refactoring:
    * Rewriting of the Error Handler ([#438](https://github.com/meilisearch/meilisearch-java/pull/438)) [@alallema](https://github.com/alallema)
        * Like the other SDKs, this one now contains `MeilisearchApiError`, `MeiliSearchCommunicationError`, `MeilisearchTimeoutError`, `JsonDecodingException` as well as `JsonEncodingException`.
        * All methods return now a `MeilisearchException` instead of a Exception.
(https://github.com/meilisearch/meilisearch-java/pull/432))  [@alallema](https://github.com/alallema)
    * Rewrite some missing method (#473) [@alallema](https://github.com/alallema)
        * health()
        * isHealthy()
        * getVersion()
        * getStats()
        * index.getStats()
        * updateKey() ([#476](https://github.com/meilisearch/meilisearch-java/pull/476)) [@alallema](https://github.com/alallema)
    * Add typo tolerance settings ([#371](https://github.com/meilisearch/meilisearch-java/pull/371)) [@alallema](https://github.com/alallema)
    * Add toString method to SearchRequest Class ([#451](https://github.com/meilisearch/meilisearch-java/pull/451)) [@alallema](https://github.com/alallema)
    * Add support to PATCH HTTP method ([#472](https://github.com/meilisearch/meilisearch-java/pull/472)) [@alallema](https://github.com/alallema)


Thanks again to @alallema,  @brunoocasali,   @ghousek1, @kisaga ! 🎉
