### PR TITLE
Modify setup-java in ci workflow for v3

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,10 +14,12 @@ jobs:
     name: integration-and-unit-tests-against-rc
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: 'zulu'
+        cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Get the latest Meilisearch RC


### PR DESCRIPTION
Following the update of `setup-java` to v3 the distribution is now required.
It's throw an [error](https://github.com/meilisearch/meilisearch-java/actions/runs/3788961009/jobs/6442255873)
```
Run actions/setup-java@v3
  with:
    java-version: 1.8
    java-package: jdk
    check-latest: false
    server-id: github
    server-username: GITHUB_ACTOR
    server-password: GITHUB_TOKEN
    overwrite-settings: true
    job-status: success
    token: ***
Error: Input required and not supplied: distribution
```