### PR TITLE
Apply dumps changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -562,8 +562,6 @@ landing_getting_started_1: |-
   );
 post_dump_1: |-
   client.createDump();
-get_dump_status_1: |-
-  client.getDumpStatus("20201101-110357260");
 phrase_search_1: |-
   client.index("movies").search("\"african american\" horror");
 sorting_guide_update_sortable_attributes_1: |-

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -159,26 +159,16 @@ public class Client {
         return this.indexesHandler.delete(uid);
     }
 
-    // TODO createDump will return a Task in v0.28
-    // /**
-    //  * Triggers the creation of a Meilisearch dump.
-    //  * https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
-    //  *
-    //  * @return Dump instance
-    //  * @throws MeilisearchException if an error occurs
-    //  */
-    // public Dump createDump() throws MeilisearchException {
-    //     return this.dumpHandler.createDump();
-    // }
-    // /**
-    //  * Creates a dump https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
-    //  *
-    //  * @return Dump object with Meilisearch API response
-    //  * @throws MeilisearchException if an error occurs
-    //  */
-    // public Dump createDump() throws MeilisearchException {
-    //     return this.meiliSearchHttpRequest.post("/dumps", "", Dump.class);
-    // }
+    /**
+     * Triggers the creation of a Meilisearch dump.
+     * https://docs.meilisearch.com/reference/api/dump.html#create-a-dump
+     *
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     */
+    public TaskInfo createDump() throws MeilisearchException {
+        return config.httpClient.post("/dumps", "", TaskInfo.class);
+    }
 
     /**
      * Gets the status and availability of a Meilisearch instance

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -237,24 +237,14 @@ public class ClientTest extends AbstractIT {
         assertEquals(primaryKey, index.getPrimaryKey());
     }
 
-    // /** Test call to create dump */
-    // TODO rewrite Dump test
-    // @Test
-    // public void testCreateDump() throws Exception {
-    //     Dump dump = client.createDump();
-    //     String status = dump.getStatus();
+    /** Test call to create dump */
+    @Test
+    public void testCreateDump() throws Exception {
+        TaskInfo task = client.createDump();
+        client.waitForTask(task.getTaskUid());
+        Task dump = client.getTask(task.getTaskUid());
 
-    //     assertEquals(status, "in_progress");
-    // }
-
-    // /** Test call to get dump status by uid */
-    // @Test
-    // public void testGetDumpStatus() throws Exception {
-    //     Dump dump = client.createDump();
-    //     String uid = dump.getUid();
-    //     String status = client.getDumpStatus(uid);
-
-    //     assertNotNull(status);
-    //     assertNotNull(uid);
-    // }
+        assertEquals(task.getStatus(), "enqueued");
+        assertEquals("dumpCreation", dump.getType());
+    }
 }


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- [x] Remove code sample get_dump_status_1
- [x] Remove method `getDumpStatus`
- [x] `createDump` now return a `TaskInfo` object