### PR TITLE
Update Index API for Meilisearch v.28

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -68,8 +68,7 @@ public class Client {
     }
 
     /**
-     * Gets all indexes
-     * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+     * Gets all indexes https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
@@ -83,10 +82,9 @@ public class Client {
     }
 
     /**
-     * Gets indexes
-     * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+     * Gets indexes https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
-     * @param query parameters accepted by the get indexes route
+     * @param params query parameters accepted by the get indexes route
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
@@ -99,8 +97,7 @@ public class Client {
     }
 
     /**
-     * Gets all indexes
-     * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+     * Gets all indexes https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @return List of indexes from the Meilisearch API as String
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.json.JsonHandler;
+import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Key;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.Stats;
@@ -63,7 +64,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public TaskInfo createIndex(String uid, String primaryKey) throws MeilisearchException {
-        return this.indexesHandler.create(uid, primaryKey);
+        return this.indexesHandler.createIndex(uid, primaryKey);
     }
 
     /**
@@ -73,9 +74,25 @@ public class Client {
      * @return Array of indexes in the Meilisearch client
      * @throws MeilisearchException if an error occurs
      */
-    public Index[] getIndexes() throws MeilisearchException {
-        Index[] indexes = jsonHandler.decode(getRawIndexes(), Index[].class);
-        for (Index index : indexes) {
+    public Results<Index> getIndexes() throws MeilisearchException {
+        Results<Index> indexes = this.indexesHandler.getIndexes();
+        for (Index index : indexes.getResults()) {
+            index.setConfig(this.config);
+        }
+        return indexes;
+    }
+
+    /**
+     * Gets indexes in the current Meilisearch instance
+     * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+     *
+     * @param param accept by the indexes route
+     * @return Array of indexes in the Meilisearch client
+     * @throws MeilisearchException if an error occurs
+     */
+    public Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
+        Results<Index> indexes = this.indexesHandler.getIndexes(param);
+        for (Index index : indexes.getResults()) {
             index.setConfig(this.config);
         }
         return indexes;
@@ -89,7 +106,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public String getRawIndexes() throws MeilisearchException {
-        return this.indexesHandler.getAll();
+        return this.indexesHandler.getRawIndexes();
     }
 
     /**
@@ -117,21 +134,9 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public Index getIndex(String uid) throws MeilisearchException {
-        Index index = jsonHandler.decode(getRawIndex(uid), Index.class);
+        Index index = this.indexesHandler.getIndex(uid);
         index.setConfig(this.config);
         return index;
-    }
-
-    /**
-     * Gets single index by its unique identifier
-     * https://docs.meilisearch.com/reference/api/indexes.html#get-one-index
-     *
-     * @param uid Unique identifier of the index to get
-     * @return Meilisearch API response as String
-     * @throws MeilisearchException if an error occurs
-     */
-    public String getRawIndex(String uid) throws MeilisearchException {
-        return this.indexesHandler.get(uid);
     }
 
     /**
@@ -156,7 +161,7 @@ public class Client {
      * @throws MeilisearchException if an error occurs
      */
     public TaskInfo deleteIndex(String uid) throws MeilisearchException {
-        return this.indexesHandler.delete(uid);
+        return this.indexesHandler.deleteIndex(uid);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -90,8 +90,8 @@ public class Client {
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
-    public Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
-        Results<Index> indexes = this.indexesHandler.getIndexes(param);
+    public Results<Index> getIndexes(IndexesQuery params) throws MeilisearchException {
+        Results<Index> indexes = this.indexesHandler.getIndexes(params);
         for (Index index : indexes.getResults()) {
             index.setConfig(this.config);
         }

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -268,7 +268,7 @@ public class Client {
      * https://docs.meilisearch.com/reference/api/keys.html#get-one-key
      *
      * @param uid Identifier of the requested Key
-     * @return Meilisearch API response as Key Instance
+     * @return Key Instance
      * @throws MeilisearchException if an error occurs
      */
     public Key getKey(String uid) throws MeilisearchException {

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -68,7 +68,7 @@ public class Client {
     }
 
     /**
-     * Gets all indexes https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+     * Gets indexes https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -68,7 +68,7 @@ public class Client {
     }
 
     /**
-     * Gets all indexes in the current Meilisearch instance
+     * Gets all indexes
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @return Results containing a list of indexes from the Meilisearch API
@@ -83,7 +83,7 @@ public class Client {
     }
 
     /**
-     * Gets indexes in the current Meilisearch instance
+     * Gets indexes
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @param query parameters accepted by the get indexes route
@@ -99,7 +99,7 @@ public class Client {
     }
 
     /**
-     * Gets all indexes in the current Meilisearch instance
+     * Gets all indexes
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
      * @return List of indexes from the Meilisearch API as String
@@ -140,7 +140,7 @@ public class Client {
     }
 
     /**
-     * Updates the primary key of an index in the Meilisearch instance
+     * Updates the primary key of an index
      * https://docs.meilisearch.com/reference/api/indexes.html#update-an-index
      *
      * @param uid Unique identifier of the index to update

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -71,7 +71,7 @@ public class Client {
      * Gets all indexes in the current Meilisearch instance
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
-     * @return Array of indexes in the Meilisearch client
+     * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
     public Results<Index> getIndexes() throws MeilisearchException {
@@ -86,8 +86,8 @@ public class Client {
      * Gets indexes in the current Meilisearch instance
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
-     * @param param accept by the indexes route
-     * @return Array of indexes in the Meilisearch client
+     * @param query parameters accepted by the get indexes route
+     * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
     public Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
@@ -102,7 +102,7 @@ public class Client {
      * Gets all indexes in the current Meilisearch instance
      * https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
      *
-     * @return Meilisearch API response as String
+     * @return List of indexes from the Meilisearch API as String
      * @throws MeilisearchException if an error occurs
      */
     public String getRawIndexes() throws MeilisearchException {
@@ -115,7 +115,7 @@ public class Client {
      * methods in the Index class.
      *
      * @param uid Unique identifier of the index
-     * @return Index instance
+     * @return Meilisearch API response as Index instance
      * @throws MeilisearchException if an error occurs
      */
     public Index index(String uid) throws MeilisearchException {
@@ -130,7 +130,7 @@ public class Client {
      * https://docs.meilisearch.com/reference/api/indexes.html#get-one-index
      *
      * @param uid Unique identifier of the index to get
-     * @return Meilisearch API response
+     * @return Meilisearch API response as Index instance
      * @throws MeilisearchException if an error occurs
      */
     public Index getIndex(String uid) throws MeilisearchException {
@@ -225,7 +225,7 @@ public class Client {
      * https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
      *
      * @param uid Identifier of the requested Task
-     * @return Task Instance
+     * @return Meilisearch API response as Task Instance
      * @throws MeilisearchException if an error occurs
      */
     public Task getTask(int uid) throws MeilisearchException {
@@ -235,7 +235,7 @@ public class Client {
     /**
      * Retrieves list of tasks https://docs.meilisearch.com/reference/api/tasks.html#get-tasks
      *
-     * @return List of tasks in the Meilisearch client
+     * @return TasksResults containing a list of tasks from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
     public TasksResults getTasks() throws MeilisearchException {
@@ -246,7 +246,7 @@ public class Client {
      * Retrieves list of tasks https://docs.meilisearch.com/reference/api/tasks.html#get-tasks
      *
      * @param param accept by the tasks route
-     * @return List of tasks in the Meilisearch client
+     * @return TasksResults containing a list of tasks from the Meilisearch API
      * @throws MeilisearchException if an error occurs
      */
     public TasksResults getTasks(TasksQuery param) throws MeilisearchException {
@@ -268,7 +268,7 @@ public class Client {
      * https://docs.meilisearch.com/reference/api/keys.html#get-one-key
      *
      * @param uid Identifier of the requested Key
-     * @return Key Instance
+     * @return Meilisearch API response as Key Instance
      * @throws MeilisearchException if an error occurs
      */
     public Key getKey(String uid) throws MeilisearchException {

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -29,7 +29,7 @@ class IndexesHandler {
      * Creates an index with a unique identifier
      *
      * @param uid Unique identifier to create the index with
-     * @return Meilisearch API response
+     * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
      */
     TaskInfo createIndex(String uid) throws MeilisearchException {
@@ -41,7 +41,7 @@ class IndexesHandler {
      *
      * @param uid Unique identifier to create the index with
      * @param primaryKey Field to use as the primary key for documents in that index
-     * @return Meilisearch API response
+     * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
      */
     TaskInfo createIndex(String uid, String primaryKey) throws MeilisearchException {
@@ -56,7 +56,7 @@ class IndexesHandler {
      * Gets an index from its uid
      *
      * @param uid Unique identifier of the index to get
-     * @return Meilisearch API response
+     * @return Meilisearch API response as Index instance
      * @throws MeilisearchException if an error occurs
      */
     Index getIndex(String uid) throws MeilisearchException {
@@ -69,7 +69,7 @@ class IndexesHandler {
     /**
      * Gets all indexes in the current Meilisearch instance
      *
-     * @return Meilisearch API response
+     * @return Results containing a list of indexes
      * @throws MeilisearchException if an error occurs
      */
     Results<Index> getIndexes() throws MeilisearchException {
@@ -79,8 +79,8 @@ class IndexesHandler {
     /**
      * Gets indexes in the current Meilisearch instance
      *
-     * @param param accept by the indexes route
-     * @return Meilisearch API response
+     * @param query parameters accepted by the indexes route
+     * @return Results containing a list of indexes
      * @throws MeilisearchException if an error occurs
      */
     Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
@@ -90,7 +90,7 @@ class IndexesHandler {
     /**
      * Gets all indexes in the current Meilisearch instance
      *
-     * @return Meilisearch API response
+     * @return List of indexes as String
      * @throws MeilisearchException if an error occurs
      */
     String getRawIndexes() throws MeilisearchException {
@@ -102,7 +102,7 @@ class IndexesHandler {
      *
      * @param uid Unique identifier of the index to update
      * @param primaryKey New primary key field to use for documents in that index
-     * @return Meilisearch API response
+     * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
      */
     TaskInfo updatePrimaryKey(String uid, String primaryKey) throws MeilisearchException {
@@ -119,7 +119,7 @@ class IndexesHandler {
      * Deletes an index in the Meilisearch instance
      *
      * @param uid Unique identifier of the index to delete
-     * @return Meilisearch API response
+     * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
      */
     TaskInfo deleteIndex(String uid) throws MeilisearchException {

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -84,12 +84,7 @@ class IndexesHandler {
      * @throws MeilisearchException if an error occurs
      */
     Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addParameter("limit", param.getLimit())
-                .addParameter("offset", param.getOffset());
-        String urlQuery = urlb.getURL();
-        return httpClient.get(urlQuery, Results.class, Index.class);
+        return httpClient.get(param.toQuery(param), Results.class, Index.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -39,7 +39,7 @@ class IndexesHandler {
     /**
      * Creates an index with a unique identifier
      *
-     * @param uid Unique identifier to create the index with
+     * @param uid Unique identifier of the index
      * @param primaryKey Field to use as the primary key for documents in that index
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -1,7 +1,6 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
-import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.TaskInfo;
@@ -60,10 +59,7 @@ class IndexesHandler {
      * @throws MeilisearchException if an error occurs
      */
     Index getIndex(String uid) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid);
-        String urlPath = urlb.getURL();
-        return httpClient.get(urlPath, Index.class);
+        return httpClient.get(new IndexesQuery().toQuery(uid), Index.class);
     }
 
     /**
@@ -84,7 +80,7 @@ class IndexesHandler {
      * @throws MeilisearchException if an error occurs
      */
     Results<Index> getIndexes(IndexesQuery params) throws MeilisearchException {
-        return httpClient.get(param.toQuery(params), Results.class, Index.class);
+        return httpClient.get(params.toQuery(params), Results.class, Index.class);
     }
 
     /**
@@ -109,10 +105,7 @@ class IndexesHandler {
         HashMap<String, String> index = new HashMap<String, String>();
         index.put("primaryKey", primaryKey);
 
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid);
-        String urlPath = urlb.getURL();
-        return httpClient.patch(urlPath, index, TaskInfo.class);
+        return httpClient.patch(new IndexesQuery().toQuery(uid), index, TaskInfo.class);
     }
 
     /**
@@ -123,9 +116,6 @@ class IndexesHandler {
      * @throws MeilisearchException if an error occurs
      */
     TaskInfo deleteIndex(String uid) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid);
-        String urlPath = urlb.getURL();
-        return httpClient.delete(urlPath, TaskInfo.class);
+        return httpClient.delete(new IndexesQuery().toQuery(uid), TaskInfo.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -84,7 +84,7 @@ class IndexesHandler {
     }
 
     /**
-     * Gets all indexes in the current Meilisearch instance
+     * Gets indexes in the current Meilisearch instance
      *
      * @return List of indexes as String
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -1,6 +1,9 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.http.URLBuilder;
+import com.meilisearch.sdk.model.IndexesQuery;
+import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.TaskInfo;
 import java.util.HashMap;
 
@@ -29,8 +32,8 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    TaskInfo create(String uid) throws MeilisearchException {
-        return this.create(uid, null);
+    TaskInfo createIndex(String uid) throws MeilisearchException {
+        return this.createIndex(uid, null);
     }
 
     /**
@@ -41,7 +44,7 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    TaskInfo create(String uid, String primaryKey) throws MeilisearchException {
+    TaskInfo createIndex(String uid, String primaryKey) throws MeilisearchException {
         HashMap<String, String> index = new HashMap<String, String>();
         index.put("uid", uid);
         index.put("primaryKey", primaryKey);
@@ -56,9 +59,11 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String get(String uid) throws MeilisearchException {
-        String requestQuery = "/indexes/" + uid;
-        return httpClient.get(requestQuery, String.class);
+    Index getIndex(String uid) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid);
+        String urlPath = urlb.getURL();
+        return httpClient.get(urlPath, Index.class);
     }
 
     /**
@@ -67,7 +72,33 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    String getAll() throws MeilisearchException {
+    Results<Index> getIndexes() throws MeilisearchException {
+        return httpClient.get("/indexes", Results.class, Index.class);
+    }
+
+    /**
+     * Gets indexes in the current Meilisearch instance
+     *
+     * @param param accept by the indexes route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset());
+        String urlQuery = urlb.getURL();
+        return httpClient.get(urlQuery, Results.class, Index.class);
+    }
+
+    /**
+     * Gets all indexes in the current Meilisearch instance
+     *
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    String getRawIndexes() throws MeilisearchException {
         return httpClient.get("/indexes", String.class);
     }
 
@@ -83,8 +114,10 @@ class IndexesHandler {
         HashMap<String, String> index = new HashMap<String, String>();
         index.put("primaryKey", primaryKey);
 
-        String requestQuery = "/indexes/" + uid;
-        return httpClient.patch(requestQuery, index, TaskInfo.class);
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid);
+        String urlPath = urlb.getURL();
+        return httpClient.patch(urlPath, index, TaskInfo.class);
     }
 
     /**
@@ -94,8 +127,10 @@ class IndexesHandler {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    TaskInfo delete(String uid) throws MeilisearchException {
-        String requestQuery = "/indexes/" + uid;
-        return httpClient.delete(requestQuery, TaskInfo.class);
+    TaskInfo deleteIndex(String uid) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid);
+        String urlPath = urlb.getURL();
+        return httpClient.delete(urlPath, TaskInfo.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -28,7 +28,7 @@ class IndexesHandler {
     /**
      * Creates an index with a unique identifier
      *
-     * @param uid Unique identifier to create the index with
+     * @param uid Unique identifier of the index
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
      */

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -63,7 +63,7 @@ class IndexesHandler {
     }
 
     /**
-     * Gets all indexes in the current Meilisearch instance
+     * Gets indexes in the current Meilisearch instance
      *
      * @return Results containing a list of indexes
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -83,8 +83,8 @@ class IndexesHandler {
      * @return Results containing a list of indexes
      * @throws MeilisearchException if an error occurs
      */
-    Results<Index> getIndexes(IndexesQuery param) throws MeilisearchException {
-        return httpClient.get(param.toQuery(param), Results.class, Index.class);
+    Results<Index> getIndexes(IndexesQuery params) throws MeilisearchException {
+        return httpClient.get(param.toQuery(params), Results.class, Index.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -44,7 +44,7 @@ public class TasksHandler {
     /**
      * Retrieves all tasks from the client
      *
-     * @return List of task instance
+     * @return TasksResults containing a list of task instance
      * @throws MeilisearchException if client request causes an error
      */
     TasksResults getTasks() throws MeilisearchException {
@@ -58,7 +58,7 @@ public class TasksHandler {
      * Retrieves all tasks from the client
      *
      * @param param accept by the tasks route
-     * @return List of task instance
+     * @return TasksResults containing a list of task instance
      * @throws MeilisearchException if client request causes an error
      */
     TasksResults getTasks(TasksQuery param) throws MeilisearchException {
@@ -79,7 +79,7 @@ public class TasksHandler {
      * Retrieves all tasks from specified index uid
      *
      * @param indexUid Index identifier to index of the requested Tasks
-     * @return List of task instance
+     * @return TasksResults containing a list of task instance
      * @throws MeilisearchException if client request causes an error
      */
     TasksResults getTasks(String indexUid) throws MeilisearchException {
@@ -96,7 +96,7 @@ public class TasksHandler {
      *
      * @param indexUid Index identifier to index of the requested Tasks
      * @param param accept by the tasks route
-     * @return List of task instance
+     * @return TasksResults containing a list of task instance
      * @throws MeilisearchException if client request causes an error
      */
     TasksResults getTasks(String indexUid, TasksQuery param) throws MeilisearchException {

--- a/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
@@ -19,6 +19,12 @@ public class IndexesQuery {
 
     public IndexesQuery() {}
 
+    public String toQuery(String uid) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid);
+        return urlb.getURL();
+    }
+
     public String toQuery(IndexesQuery param) {
         URLBuilder urlb = new URLBuilder();
         urlb.addSubroute("indexes")

--- a/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
@@ -1,0 +1,20 @@
+package com.meilisearch.sdk.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of a query parameter for index route
+ *
+ * <p>https://docs.meilisearch.com/reference/api/indexes.html#query-parameters
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class IndexesQuery {
+    private int offset = -1;
+    private int limit = -1;
+
+    public IndexesQuery() {}
+}

--- a/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Data structure of a query parameter for index route
+ * Data structure of the query parameters when fetching indexes
  *
  * <p>https://docs.meilisearch.com/reference/api/indexes.html#query-parameters
  */

--- a/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.model;
 
+import com.meilisearch.sdk.http.URLBuilder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -17,4 +18,12 @@ public class IndexesQuery {
     private int limit = -1;
 
     public IndexesQuery() {}
+
+    public String toQuery(IndexesQuery param) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset());
+        return urlb.getURL();
+    }
 }

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -9,10 +9,12 @@ import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
+import com.meilisearch.sdk.model.IndexesQuery;
+import com.meilisearch.sdk.model.Results;
+import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.utils.Movie;
 import java.util.Arrays;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,10 +30,6 @@ public class ClientTest extends AbstractIT {
         setUp();
         setUpJacksonClient();
         if (testData == null) testData = this.getTestData(MOVIES_INDEX, Movie.class);
-    }
-
-    @AfterAll
-    static void cleanMeilisearch() {
         cleanup();
     }
 
@@ -43,8 +41,6 @@ public class ClientTest extends AbstractIT {
 
         assertEquals(index.getUid(), indexUid);
         assertNull(index.getPrimaryKey());
-
-        client.deleteIndex(index.getUid());
     }
 
     /** Test Index creation without PrimaryKey with Jackson Json Handler */
@@ -57,8 +53,6 @@ public class ClientTest extends AbstractIT {
 
         assertEquals(index.getUid(), indexUid);
         assertNull(index.getPrimaryKey());
-
-        clientJackson.deleteIndex(index.getUid());
     }
 
     /** Test Index creation with PrimaryKey */
@@ -69,8 +63,6 @@ public class ClientTest extends AbstractIT {
 
         assertEquals(index.getUid(), indexUid);
         assertEquals(index.getPrimaryKey(), this.primaryKey);
-
-        client.deleteIndex(index.getUid());
     }
 
     /** Test Index creation with PrimaryKey with Jackson Json Handler */
@@ -83,8 +75,6 @@ public class ClientTest extends AbstractIT {
 
         assertEquals(index.getUid(), indexUid);
         assertEquals(index.getPrimaryKey(), this.primaryKey);
-
-        clientJackson.deleteIndex(index.getUid());
     }
 
     /** Test Index creation twice doesn't throw an error: already exists */
@@ -102,8 +92,6 @@ public class ClientTest extends AbstractIT {
         assertEquals(indexDuplicate.getUid(), indexUid);
         assertEquals(index.getPrimaryKey(), this.primaryKey);
         assertEquals(indexDuplicate.getPrimaryKey(), this.primaryKey);
-
-        client.deleteIndex(index.getUid());
     }
 
     /** Test update Index PrimaryKey */
@@ -122,8 +110,6 @@ public class ClientTest extends AbstractIT {
         assertTrue(index instanceof Index);
         assertEquals(index.getUid(), indexUid);
         assertEquals(index.getPrimaryKey(), this.primaryKey);
-
-        client.deleteIndex(index.getUid());
     }
 
     /** Test getIndex */
@@ -135,22 +121,6 @@ public class ClientTest extends AbstractIT {
 
         assertEquals(index.getUid(), getIndex.getUid());
         assertEquals(index.getPrimaryKey(), getIndex.getPrimaryKey());
-
-        client.deleteIndex(index.getUid());
-    }
-
-    /** Test getRawIndex */
-    @Test
-    public void testGetRawIndex() throws Exception {
-        String indexUid = "GetRawIndex";
-        Index index = createEmptyIndex(indexUid, this.primaryKey);
-        String getIndex = client.getRawIndex(indexUid);
-        JsonObject indexJson = JsonParser.parseString(getIndex).getAsJsonObject();
-
-        assertEquals(index.getUid(), indexJson.get("uid").getAsString());
-        assertEquals(index.getPrimaryKey(), indexJson.get("primaryKey").getAsString());
-
-        client.deleteIndex(index.getUid());
     }
 
     /** Test getIndexes */
@@ -159,14 +129,41 @@ public class ClientTest extends AbstractIT {
         String[] indexUids = {"GetIndexes", "GetIndexes2"};
         createEmptyIndex(indexUids[0]);
         createEmptyIndex(indexUids[1], this.primaryKey);
-        Index[] indexes = client.getIndexes();
+        Results<Index> indexes = client.getIndexes();
 
-        assertEquals(2, indexes.length);
+        assertEquals(2, indexes.getResults().length);
         assert (Arrays.asList(indexUids).contains(indexUids[0]));
         assert (Arrays.asList(indexUids).contains(indexUids[1]));
+    }
 
-        client.deleteIndex(indexUids[0]);
-        client.deleteIndex(indexUids[1]);
+    /** Test getIndexes with limit */
+    @Test
+    public void testGetIndexesLimit() throws Exception {
+        int limit = 1;
+        String[] indexUids = {"GetIndexesLimit", "GetIndexesLimit2"};
+        IndexesQuery query = new IndexesQuery().setLimit(limit);
+        createEmptyIndex(indexUids[0]);
+        createEmptyIndex(indexUids[1], this.primaryKey);
+        Results<Index> indexes = client.getIndexes(query);
+
+        assertEquals(limit, indexes.getResults().length);
+        assertEquals(limit, indexes.getLimit());
+    }
+
+    /** Test getIndexes with limit and offset */
+    @Test
+    public void testGetIndexesLimitAndOffset() throws Exception {
+        int limit = 1;
+        int offset = 1;
+        String[] indexUids = {"GetIndexesLimitOffset", "GetIndexesLimitOffset2"};
+        IndexesQuery query = new IndexesQuery().setLimit(limit).setOffset(offset);
+        createEmptyIndex(indexUids[0]);
+        createEmptyIndex(indexUids[1], this.primaryKey);
+        Results<Index> indexes = client.getIndexes(query);
+
+        assertEquals(limit, indexes.getResults().length);
+        assertEquals(limit, indexes.getLimit());
+        assertEquals(offset, indexes.getOffset());
     }
 
     /** Test getRawIndexes */
@@ -177,16 +174,14 @@ public class ClientTest extends AbstractIT {
         createEmptyIndex(indexUids[1], this.primaryKey);
 
         String indexes = client.getRawIndexes();
-        JsonArray jsonIndexArray = JsonParser.parseString(indexes).getAsJsonArray();
+        JsonObject jsonIndexObject = JsonParser.parseString(indexes).getAsJsonObject();
+        JsonArray jsonIndexArray = jsonIndexObject.getAsJsonArray("results");
 
-        assertEquals(4, jsonIndexArray.size());
+        assertEquals(2, jsonIndexArray.size());
         assert (Arrays.asList(indexUids)
                 .contains(jsonIndexArray.get(0).getAsJsonObject().get("uid").getAsString()));
         assert (Arrays.asList(indexUids)
                 .contains(jsonIndexArray.get(1).getAsJsonObject().get("uid").getAsString()));
-
-        client.deleteIndex(indexUids[0]);
-        client.deleteIndex(indexUids[1]);
     }
 
     /** Test deleteIndex */

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -15,6 +15,7 @@ import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.utils.Movie;
 import java.util.Arrays;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,11 @@ public class ClientTest extends AbstractIT {
         setUp();
         setUpJacksonClient();
         if (testData == null) testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        cleanup();
+    }
+
+    @AfterAll
+    static void cleanMeilisearch() {
         cleanup();
     }
 

--- a/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
+++ b/src/test/java/com/meilisearch/integration/classes/AbstractIT.java
@@ -105,7 +105,8 @@ public abstract class AbstractIT {
             Client ms = new Client(new Config(getMeilisearchHost(), "masterKey"));
             Results<Index> indexes = ms.getIndexes();
             for (Index index : indexes.getResults()) {
-                ms.deleteIndex(index.getUid());
+                TaskInfo task = ms.deleteIndex(index.getUid());
+                ms.waitForTask(task.getTaskUid());
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/meilisearch/issues/2373

## What does this PR do?

### Changes

- [x] `client.getIndexes()` accept pagination metadata, added limit (default: 20), offset (default: 0), total
- [x] Wrap the indexes objects in a `Results` object
- [x] Remove `client.getRawIndex()` method 
- [x] `client.getRawIndexes()` method return a `String`
- [x] Creation of `IndexesQuery` class
- [x] Rename the methods of the "IndexesHandler" to match the name of the Client methods 

```java
    client.getIndexes()
```

returns for example
```bash
com.meilisearch.sdk.model.Results@2a742aa2
```

```java
    client.getRawIndexes()
```

returns for example

```bash
{"results":[],"offset":0,"limit":20,"total":0}
```

