### PR TITLE
Update documents API for Meilisearch v.28

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -39,7 +39,7 @@ class Documents {
      *
      * @param uid Partial index identifier for the requested documents
      * @param identifier ID of the document
-     * @param param accept by the documents route
+     * @param param accepted by the get document route
      * @param targetClass Class of the document returned
      * @return Object containing the requested document
      * @throws MeilisearchException if client request causes an error

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -123,7 +123,7 @@ class Documents {
      * Retrieves the document as String at the specified index
      *
      * @param uid Partial index identifier for the requested documents
-     * @param param accept by the documents route
+     * @param param accepted by the documents route
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -96,7 +96,7 @@ class Documents {
      *
      * @param <T> Type of documents returned
      * @param uid Partial index identifier for the requested documents
-     * @param param accept by the documents route
+     * @param param accepted by the get documents route
      * @param targetClass Class of documents returned
      * @return Object containing the requested document
      * @throws MeilisearchException if the client request causes an error

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -1,8 +1,9 @@
 package com.meilisearch.sdk;
 
-import static java.util.Collections.singletonList;
-
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.http.URLBuilder;
+import com.meilisearch.sdk.model.DocumentsQuery;
+import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.TaskInfo;
 import java.util.List;
 
@@ -21,82 +22,162 @@ class Documents {
     /**
      * Retrieves the document at the specified index uid with the specified identifier
      *
+     * @param <T> Type of the document returned
+     * @param uid Partial index identifier for the requested documents
+     * @param identifier ID of the document
+     * @param targetClass Class of the document returned
+     * @return Object containing the requested document
+     * @throws MeilisearchException if the client request causes an error
+     */
+    <T> T getDocument(String uid, String identifier, Class<T> targetClass)
+            throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier);
+        String urlPath = urlb.getURL();
+        return httpClient.<T>get(urlPath, targetClass);
+    }
+
+    /**
+     * Retrieves the document at the specified index uid with the specified identifier
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @param identifier ID of the document
+     * @param param accept by the documents route
+     * @param targetClass Class of the document returned
+     * @return Object containing the requested document
+     * @throws MeilisearchException if client request causes an error
+     */
+    <T> T getDocument(String uid, String identifier, DocumentsQuery param, Class<T> targetClass)
+            throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier)
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        String urlQuery = urlb.getURL();
+        return httpClient.<T>get(urlQuery, targetClass);
+    }
+
+    /**
+     * Retrieves the document at the specified index uid with the specified identifier
+     *
      * @param uid Partial index identifier for the requested documents
      * @param identifier ID of the document
      * @return String containing the requested document
      * @throws MeilisearchException if client request causes an error
      */
-    String getDocument(String uid, String identifier) throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents/" + identifier;
+    String getRawDocument(String uid, String identifier) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier);
+        String urlPath = urlb.getURL();
         return httpClient.get(urlPath, String.class);
     }
 
     /**
-     * Retrieves the document at the specified index
+     * Retrieves the document at the specified index uid with the specified identifier
      *
      * @param uid Partial index identifier for the requested documents
+     * @param identifier ID of the document
+     * @param param accept by the documents route
      * @return String containing the requested document
-     * @throws MeilisearchException if the client request causes an error
+     * @throws MeilisearchException if client request causes an error
      */
-    String getDocuments(String uid) throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents";
-        return httpClient.get(urlPath, String.class);
-    }
-
-    /**
-     * Retrieves the document at the specified index
-     *
-     * @param uid Partial index identifier for the requested documents
-     * @param limit Limit on the requested documents to be returned
-     * @return String containing the requested document
-     * @throws MeilisearchException if the client request causes an error
-     */
-    String getDocuments(String uid, int limit) throws MeilisearchException {
-        String urlQuery = "/indexes/" + uid + "/documents?limit=" + limit;
-        return httpClient.get(urlQuery, String.class);
-    }
-
-    /**
-     * Retrieves the document at the specified index
-     *
-     * @param uid Partial index identifier for the requested documents
-     * @param limit Limit on the requested documents to be returned
-     * @param offset Specify the offset of the first hit to return
-     * @return String containing the requested document
-     * @throws MeilisearchException if the client request causes an error
-     */
-    String getDocuments(String uid, int limit, int offset) throws MeilisearchException {
-        String urlQuery = "/indexes/" + uid + "/documents?limit=" + limit + "&offset=" + offset;
-        return httpClient.get(urlQuery, String.class);
-    }
-
-    /**
-     * Retrieves the document at the specified index
-     *
-     * @param uid Partial index identifier for the requested documents
-     * @param limit Limit on the requested documents to be returned
-     * @param offset Specify the offset of the first hit to return
-     * @param attributesToRetrieve Document attributes to show
-     * @return String containing the requested document
-     * @throws MeilisearchException if the client request causes an error
-     */
-    String getDocuments(String uid, int limit, int offset, List<String> attributesToRetrieve)
+    String getRawDocument(String uid, String identifier, DocumentsQuery param)
             throws MeilisearchException {
-        if (attributesToRetrieve == null || attributesToRetrieve.size() == 0) {
-            attributesToRetrieve = singletonList("*");
-        }
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier)
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        String urlQuery = urlb.getURL();
+        return httpClient.get(urlQuery, String.class);
+    }
 
-        String attributesToRetrieveCommaSeparated = String.join(",", attributesToRetrieve);
-        String urlQuery =
-                "/indexes/"
-                        + uid
-                        + "/documents?limit="
-                        + limit
-                        + "&offset="
-                        + offset
-                        + "&attributesToRetrieve="
-                        + attributesToRetrieveCommaSeparated;
+    /**
+     * Retrieves the document at the specified index
+     *
+     * @param <T> Type of documents returned
+     * @param uid Partial index identifier for the requested documents
+     * @param targetClass Class of documents returned
+     * @return Object containing the requested document
+     * @throws MeilisearchException if the client request causes an error
+     */
+    <T> Results<T> getDocuments(String uid, Class<T> targetClass) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
+        String urlPath = urlb.getURL();
+        Results<T> documents = httpClient.<Results>get(urlPath, Results.class, targetClass);
+        return documents;
+    }
 
+    /**
+     * Retrieves the document at the specified index
+     *
+     * @param <T> Type of documents returned
+     * @param uid Partial index identifier for the requested documents
+     * @param param accept by the documents route
+     * @param targetClass Class of documents returned
+     * @return Object containing the requested document
+     * @throws MeilisearchException if the client request causes an error
+     */
+    <T> Results<T> getDocuments(String uid, DocumentsQuery param, Class<T> targetClass)
+            throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        String urlQuery = urlb.getURL();
+
+        Results<T> documents = httpClient.<Results>get(urlQuery, Results.class, targetClass);
+        return documents;
+    }
+
+    /**
+     * Retrieves the document as String at the specified index
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    String getRawDocuments(String uid) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
+        String urlPath = urlb.getURL();
+        return httpClient.get(urlPath, String.class);
+    }
+
+    /**
+     * Retrieves the document as String at the specified index
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @param param accept by the documents route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    String getRawDocuments(String uid, DocumentsQuery param) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        String urlQuery = urlb.getURL();
         return httpClient.get(urlQuery, String.class);
     }
 
@@ -111,10 +192,12 @@ class Documents {
      */
     TaskInfo addDocuments(String uid, String document, String primaryKey)
             throws MeilisearchException {
-        String urlQuery = "/indexes/" + uid + "/documents";
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
         if (primaryKey != null) {
-            urlQuery += "?primaryKey=" + primaryKey;
+            urlb.addParameter("primaryKey", primaryKey);
         }
+        String urlQuery = urlb.getURL();
         return httpClient.post(urlQuery, document, TaskInfo.class);
     }
 
@@ -129,10 +212,12 @@ class Documents {
      */
     TaskInfo updateDocuments(String uid, String document, String primaryKey)
             throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents";
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
         if (primaryKey != null) {
-            urlPath += "?primaryKey=" + primaryKey;
+            urlb.addParameter("primaryKey", primaryKey);
         }
+        String urlPath = urlb.getURL();
         return httpClient.put(urlPath, document, TaskInfo.class);
     }
 
@@ -145,7 +230,12 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocument(String uid, String identifier) throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents/" + identifier;
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier);
+        String urlPath = urlb.getURL();
         return httpClient.delete(urlPath, TaskInfo.class);
     }
 
@@ -158,7 +248,12 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocuments(String uid, List<String> identifiers) throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents/" + "delete-batch";
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute("delete-batch");
+        String urlPath = urlb.getURL();
         return httpClient.post(urlPath, identifiers, TaskInfo.class);
     }
 
@@ -170,7 +265,9 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteAllDocuments(String uid) throws MeilisearchException {
-        String urlPath = "/indexes/" + uid + "/documents";
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
+        String urlPath = urlb.getURL();
         return httpClient.delete(urlPath, TaskInfo.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -92,7 +92,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index
+     * Gets the document from the specified index
      *
      * @param <T> Type of documents returned
      * @param uid Partial index identifier for the requested documents

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -35,7 +35,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index uid with the specified identifier
+     * Retrieves the document from the specified index uid with the specified identifier
      *
      * @param uid Partial index identifier for the requested documents
      * @param identifier ID of the document

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -20,7 +20,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index uid with the specified identifier
+     * Retrieves the document from the specified index uid with the specified identifier
      *
      * @param <T> Type of the document returned
      * @param uid Partial index identifier for the requested documents
@@ -50,7 +50,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index uid with the specified identifier
+     * Retrieves the document from the specified index uid with the specified identifier
      *
      * @param uid Partial index identifier for the requested documents
      * @param identifier ID of the document
@@ -62,7 +62,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index uid with the specified identifier
+     * Retrieves the document from the specified index uid with the specified identifier
      *
      * @param uid Partial index identifier for the requested documents
      * @param identifier ID of the document
@@ -76,12 +76,12 @@ class Documents {
     }
 
     /**
-     * Retrieves the document at the specified index
+     * Retrieves the document from the specified index
      *
      * @param <T> Type of documents returned
      * @param uid Partial index identifier for the requested documents
      * @param targetClass Class of documents returned
-     * @return Object containing the requested document
+     * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if the client request causes an error
      */
     <T> Results<T> getDocuments(String uid, Class<T> targetClass) throws MeilisearchException {
@@ -92,13 +92,13 @@ class Documents {
     }
 
     /**
-     * Gets the document from the specified index
+     * Retrieves the document from the specified index
      *
      * @param <T> Type of documents returned
      * @param uid Partial index identifier for the requested documents
      * @param param accepted by the get documents route
      * @param targetClass Class of documents returned
-     * @return Object containing the requested document
+     * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if the client request causes an error
      */
     <T> Results<T> getDocuments(String uid, DocumentsQuery param, Class<T> targetClass)
@@ -109,7 +109,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document as String at the specified index
+     * Retrieves the document as a string from the specified index
      *
      * @param uid Partial index identifier for the requested documents
      * @return Meilisearch API response
@@ -172,7 +172,7 @@ class Documents {
     }
 
     /**
-     * Deletes the document at the specified index uid with the specified identifier
+     * Deletes the document from the specified index uid with the specified identifier
      *
      * @param uid Partial index identifier for the requested document
      * @param identifier ID of the document

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -31,13 +31,7 @@ class Documents {
      */
     <T> T getDocument(String uid, String identifier, Class<T> targetClass)
             throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addSubroute(identifier);
-        String urlPath = urlb.getURL();
-        return httpClient.<T>get(urlPath, targetClass);
+        return httpClient.<T>get(new DocumentsQuery().toQuery(uid, identifier), targetClass);
     }
 
     /**
@@ -52,16 +46,7 @@ class Documents {
      */
     <T> T getDocument(String uid, String identifier, DocumentsQuery param, Class<T> targetClass)
             throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addSubroute(identifier)
-                .addParameter("limit", param.getLimit())
-                .addParameter("offset", param.getOffset())
-                .addParameter("fields", param.getFields());
-        String urlQuery = urlb.getURL();
-        return httpClient.<T>get(urlQuery, targetClass);
+        return httpClient.<T>get(param.toQuery(uid, identifier, param), targetClass);
     }
 
     /**
@@ -73,13 +58,7 @@ class Documents {
      * @throws MeilisearchException if client request causes an error
      */
     String getRawDocument(String uid, String identifier) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addSubroute(identifier);
-        String urlPath = urlb.getURL();
-        return httpClient.get(urlPath, String.class);
+        return httpClient.<String>get(new DocumentsQuery().toQuery(uid, identifier), String.class);
     }
 
     /**
@@ -93,16 +72,7 @@ class Documents {
      */
     String getRawDocument(String uid, String identifier, DocumentsQuery param)
             throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addSubroute(identifier)
-                .addParameter("limit", param.getLimit())
-                .addParameter("offset", param.getOffset())
-                .addParameter("fields", param.getFields());
-        String urlQuery = urlb.getURL();
-        return httpClient.get(urlQuery, String.class);
+        return httpClient.<String>get(param.toQuery(uid, identifier, param), String.class);
     }
 
     /**
@@ -115,10 +85,9 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     <T> Results<T> getDocuments(String uid, Class<T> targetClass) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
-        String urlPath = urlb.getURL();
-        Results<T> documents = httpClient.<Results>get(urlPath, Results.class, targetClass);
+        Results<T> documents =
+                httpClient.<Results>get(
+                        new DocumentsQuery().toQuery(uid), Results.class, targetClass);
         return documents;
     }
 
@@ -134,16 +103,8 @@ class Documents {
      */
     <T> Results<T> getDocuments(String uid, DocumentsQuery param, Class<T> targetClass)
             throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addParameter("limit", param.getLimit())
-                .addParameter("offset", param.getOffset())
-                .addParameter("fields", param.getFields());
-        String urlQuery = urlb.getURL();
-
-        Results<T> documents = httpClient.<Results>get(urlQuery, Results.class, targetClass);
+        Results<T> documents =
+                httpClient.<Results>get(param.toQuery(uid, param), Results.class, targetClass);
         return documents;
     }
 
@@ -155,10 +116,7 @@ class Documents {
      * @throws MeilisearchException if an error occurs
      */
     String getRawDocuments(String uid) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
-        String urlPath = urlb.getURL();
-        return httpClient.get(urlPath, String.class);
+        return httpClient.get(new DocumentsQuery().toQuery(uid), String.class);
     }
 
     /**
@@ -170,15 +128,7 @@ class Documents {
      * @throws MeilisearchException if an error occurs
      */
     String getRawDocuments(String uid, DocumentsQuery param) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addParameter("limit", param.getLimit())
-                .addParameter("offset", param.getOffset())
-                .addParameter("fields", param.getFields());
-        String urlQuery = urlb.getURL();
-        return httpClient.get(urlQuery, String.class);
+        return httpClient.<String>get(param.toQuery(uid, param), String.class);
     }
 
     /**
@@ -230,13 +180,8 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocument(String uid, String identifier) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes")
-                .addSubroute(uid)
-                .addSubroute("documents")
-                .addSubroute(identifier);
-        String urlPath = urlb.getURL();
-        return httpClient.delete(urlPath, TaskInfo.class);
+        return httpClient.<TaskInfo>delete(
+                new DocumentsQuery().toQuery(uid, identifier), TaskInfo.class);
     }
 
     /**
@@ -265,9 +210,6 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteAllDocuments(String uid) throws MeilisearchException {
-        URLBuilder urlb = new URLBuilder();
-        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
-        String urlPath = urlb.getURL();
-        return httpClient.delete(urlPath, TaskInfo.class);
+        return httpClient.<TaskInfo>delete(new DocumentsQuery().toQuery(uid), TaskInfo.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -116,7 +116,7 @@ class Documents {
     }
 
     /**
-     * Retrieves the document as String at the specified index
+     * Retrieves the document as String from the specified index
      *
      * @param uid Partial index identifier for the requested documents
      * @param param accepted by the documents route

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -85,10 +85,8 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     <T> Results<T> getDocuments(String uid, Class<T> targetClass) throws MeilisearchException {
-        Results<T> documents =
-                httpClient.<Results>get(
-                        new DocumentsQuery().toQuery(uid), Results.class, targetClass);
-        return documents;
+        return httpClient.<Results>get(
+                new DocumentsQuery().toQuery(uid), Results.class, targetClass);
     }
 
     /**
@@ -103,9 +101,7 @@ class Documents {
      */
     <T> Results<T> getDocuments(String uid, DocumentsQuery param, Class<T> targetClass)
             throws MeilisearchException {
-        Results<T> documents =
-                httpClient.<Results>get(param.toQuery(uid, param), Results.class, targetClass);
-        return documents;
+        return httpClient.<Results>get(param.toQuery(uid, param), Results.class, targetClass);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -1,7 +1,9 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.DocumentsQuery;
 import com.meilisearch.sdk.model.IndexStats;
+import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.Settings;
 import com.meilisearch.sdk.model.Task;
@@ -49,63 +51,107 @@ public class Index implements Serializable {
      * Gets a documents with the specified uid Refer
      * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
      *
+     * @param <T> Type of documents returned
+     * @param identifier Identifier of the document to get
+     * @param targetClass Class of the document returned
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public <T> T getDocument(String identifier, Class<T> targetClass) throws MeilisearchException {
+        return this.documents.<T>getDocument(this.uid, identifier, targetClass);
+    }
+
+    /**
+     * Gets a documents with the specified uid Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
+     *
+     * @param <T> Type of documents returned
+     * @param identifier Identifier of the document to get
+     * @param param accept by the documents route
+     * @param targetClass Class of documents returned
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public <T> T getDocument(String identifier, DocumentsQuery param, Class<T> targetClass)
+            throws MeilisearchException {
+        return this.documents.<T>getDocument(this.uid, identifier, param, targetClass);
+    }
+
+    /**
+     * Gets a documents with the specified uid Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
+     *
      * @param identifier Identifier of the document to get
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    public String getDocument(String identifier) throws MeilisearchException {
-        return this.documents.getDocument(this.uid, identifier);
+    public String getRawDocument(String identifier) throws MeilisearchException {
+        return this.documents.getRawDocument(this.uid, identifier);
     }
 
     /**
-     * Gets documenta at the specified index Refer
-     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
+     * Gets a documents with the specified uid Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
      *
+     * @param identifier Identifier of the document to get
+     * @param param accept by the documents route
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      */
-    public String getDocuments() throws MeilisearchException {
-        return this.documents.getDocuments(this.uid);
-    }
-
-    /**
-     * Gets documents at the specified index and limit the number of documents returned Refer
-     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
-     *
-     * @param limits Maximum amount of documents to return
-     * @return Meilisearch API response
-     * @throws MeilisearchException if an error occurs
-     */
-    public String getDocuments(int limits) throws MeilisearchException {
-        return this.documents.getDocuments(this.uid, limits);
-    }
-
-    /**
-     * Gets documents at the specified index and limit the number of documents returned Refer
-     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
-     *
-     * @param limits Maximum amount of documents to return
-     * @param offset Number of documents to skip
-     * @return Meilisearch API response
-     * @throws MeilisearchException if an error occurs
-     */
-    public String getDocuments(int limits, int offset) throws MeilisearchException {
-        return this.documents.getDocuments(this.uid, limits, offset);
-    }
-
-    /**
-     * Gets documents at the specified index and limit the number of documents returned Refer
-     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
-     *
-     * @param limits Maximum amount of documents to return
-     * @param offset Number of documents to skip
-     * @param attributesToRetrieve Document attributes to show
-     * @return Meilisearch API response
-     * @throws MeilisearchException if an error occurs
-     */
-    public String getDocuments(int limits, int offset, List<String> attributesToRetrieve)
+    public String getRawDocument(String identifier, DocumentsQuery param)
             throws MeilisearchException {
-        return this.documents.getDocuments(this.uid, limits, offset, attributesToRetrieve);
+        return this.documents.getRawDocument(this.uid, identifier, param);
+    }
+
+    /**
+     * Gets documents at the specified index Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
+     *
+     * @param <T> Type of documents returned
+     * @param targetClass Class of documents returned
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public <T> Results<T> getDocuments(Class<T> targetClass) throws MeilisearchException {
+        return this.documents.getDocuments(this.uid, targetClass);
+    }
+
+    /**
+     * Gets documents at the specified index Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
+     *
+     * @param <T> Type of documents returned
+     * @param param accept by the documents route
+     * @param targetClass Class of documents returned
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public <T> Results<T> getDocuments(DocumentsQuery param, Class<T> targetClass)
+            throws MeilisearchException {
+        return this.documents.getDocuments(this.uid, param, targetClass);
+    }
+
+    /**
+     * Gets documents as String at the specified index Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
+     *
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public String getRawDocuments() throws MeilisearchException {
+        return this.documents.getRawDocuments(this.uid);
+    }
+
+    /**
+     * Gets documents as String at the specified index Refer
+     * https://docs.meilisearch.com/reference/api/documents.html#get-documents
+     *
+     * @param param accept by the documents route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     */
+    public String getRawDocuments(DocumentsQuery param) throws MeilisearchException {
+        return this.documents.getRawDocuments(this.uid, param);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -90,7 +90,7 @@ public class Index implements Serializable {
     }
 
     /**
-     * Gets a documents with the specified uid Refer
+     * Gets a document with the specified uid and parameters
      * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
      *
      * @param identifier Identifier of the document to get

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -67,7 +67,7 @@ public class Index implements Serializable {
      *
      * @param <T> Type of documents returned
      * @param identifier Identifier of the document to get
-     * @param param accept by the documents route
+     * @param param accepted by the get document route
      * @param targetClass Class of documents returned
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -54,7 +54,7 @@ public class Index implements Serializable {
      * @param <T> Type of documents returned
      * @param identifier Identifier of the document to get
      * @param targetClass Class of the document returned
-     * @return Meilisearch API response
+     * @return Object containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public <T> T getDocument(String identifier, Class<T> targetClass) throws MeilisearchException {
@@ -69,7 +69,7 @@ public class Index implements Serializable {
      * @param identifier Identifier of the document to get
      * @param param accepted by the get document route
      * @param targetClass Class of documents returned
-     * @return Meilisearch API response
+     * @return Object containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public <T> T getDocument(String identifier, DocumentsQuery param, Class<T> targetClass)
@@ -82,7 +82,7 @@ public class Index implements Serializable {
      * https://docs.meilisearch.com/reference/api/documents.html#get-one-document
      *
      * @param identifier Identifier of the document to get
-     * @return Meilisearch API response
+     * @return String containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public String getRawDocument(String identifier) throws MeilisearchException {
@@ -95,7 +95,7 @@ public class Index implements Serializable {
      *
      * @param identifier Identifier of the document to get
      * @param param accept by the documents route
-     * @return Meilisearch API response
+     * @return String containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public String getRawDocument(String identifier, DocumentsQuery param)
@@ -109,7 +109,7 @@ public class Index implements Serializable {
      *
      * @param <T> Type of documents returned
      * @param targetClass Class of documents returned
-     * @return Meilisearch API response
+     * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public <T> Results<T> getDocuments(Class<T> targetClass) throws MeilisearchException {
@@ -123,7 +123,7 @@ public class Index implements Serializable {
      * @param <T> Type of documents returned
      * @param param accept by the documents route
      * @param targetClass Class of documents returned
-     * @return Meilisearch API response
+     * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if an error occurs
      */
     public <T> Results<T> getDocuments(DocumentsQuery param, Class<T> targetClass)
@@ -135,7 +135,7 @@ public class Index implements Serializable {
      * Gets documents as String at the specified index Refer
      * https://docs.meilisearch.com/reference/api/documents.html#get-documents
      *
-     * @return Meilisearch API response
+     * @return String containing a list of documents
      * @throws MeilisearchException if an error occurs
      */
     public String getRawDocuments() throws MeilisearchException {
@@ -147,7 +147,7 @@ public class Index implements Serializable {
      * https://docs.meilisearch.com/reference/api/documents.html#get-documents
      *
      * @param param accept by the documents route
-     * @return Meilisearch API response
+     * @return String containing a list of documents
      * @throws MeilisearchException if an error occurs
      */
     public String getRawDocuments(DocumentsQuery param) throws MeilisearchException {

--- a/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Data structure of a query parameter for documents route
+ * Data structure of the query parameters of the documents route
  *
  * <p>https://docs.meilisearch.com/reference/api/documents.html#query-parameters
  */

--- a/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
@@ -1,0 +1,21 @@
+package com.meilisearch.sdk.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of a query parameter for documents route
+ *
+ * <p>https://docs.meilisearch.com/reference/api/documents.html#query-parameters
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class DocumentsQuery {
+    private int offset = -1;
+    private int limit = -1;
+    private String[] fields;
+
+    public DocumentsQuery() {}
+}

--- a/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.model;
 
+import com.meilisearch.sdk.http.URLBuilder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -18,4 +19,42 @@ public class DocumentsQuery {
     private String[] fields;
 
     public DocumentsQuery() {}
+
+    public String toQuery(String uid) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes").addSubroute(uid).addSubroute("documents");
+        return urlb.getURL();
+    }
+
+    public String toQuery(String uid, String identifier) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier);
+        return urlb.getURL();
+    }
+
+    public String toQuery(String uid, DocumentsQuery param) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        return urlb.getURL();
+    }
+
+    public String toQuery(String uid, String identifier, DocumentsQuery param) {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("indexes")
+                .addSubroute(uid)
+                .addSubroute("documents")
+                .addSubroute(identifier)
+                .addParameter("limit", param.getLimit())
+                .addParameter("offset", param.getOffset())
+                .addParameter("fields", param.getFields());
+        return urlb.getURL();
+    }
 }

--- a/src/test/java/com/meilisearch/integration/DocumentsTest.java
+++ b/src/test/java/com/meilisearch/integration/DocumentsTest.java
@@ -1,6 +1,5 @@
 package com.meilisearch.integration;
 
-import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.gson.JsonObject;
@@ -8,19 +7,18 @@ import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
+import com.meilisearch.sdk.model.DocumentsQuery;
+import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.utils.Movie;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("integration")
 public class DocumentsTest extends AbstractIT {
@@ -47,6 +45,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments("[" + singleDocument + "]");
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
 
         assertEquals(1, movies.length);
         assertEquals("419704", movies[0].getId());
@@ -85,7 +85,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo firstTask = index.addDocuments("[" + firstDocument + "]", "language");
         index.waitForTask(firstTask.getTaskUid());
 
-        Movie[] movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         assertEquals(1, movies.length);
         assertEquals("419704", movies[0].getId());
         assertEquals("Ad Astra", movies[0].getTitle());
@@ -93,7 +94,7 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo secondTask = index.addDocuments("[" + secondDocument + "]", "language");
         index.waitForTask(secondTask.getTaskUid());
 
-        movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
         assertEquals(1, movies.length);
         assertEquals("574982", movies[0].getId());
         assertEquals("The Blackout", movies[0].getTitle());
@@ -110,10 +111,10 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         for (int i = 0; i < movies.length; i++) {
-            Movie movie =
-                    this.gson.fromJson(
-                            index.getDocument(testData.getData().get(i).getId()), Movie.class);
+            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
             assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
         }
     }
@@ -129,10 +130,10 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         for (int i = 0; i < movies.length; i++) {
-            Movie movie =
-                    this.gson.fromJson(
-                            index.getDocument(testData.getData().get(i).getId()), Movie.class);
+            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
             assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
         }
     }
@@ -184,6 +185,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         Movie toUpdate = movies[0];
         toUpdate.setTitle("The Perks of Being a Wallflower");
         toUpdate.setOverview("The best movie I've ever seen");
@@ -191,7 +194,7 @@ public class DocumentsTest extends AbstractIT {
         task = index.updateDocuments("[" + this.gson.toJson(toUpdate) + "]");
 
         index.waitForTask(task.getTaskUid());
-        Movie responseUpdate = this.gson.fromJson(index.getDocument(toUpdate.getId()), Movie.class);
+        Movie responseUpdate = index.<Movie>getDocument(toUpdate.getId(), Movie.class);
 
         assertEquals(toUpdate.getTitle(), responseUpdate.getTitle());
         assertEquals(toUpdate.getOverview(), responseUpdate.getOverview());
@@ -219,7 +222,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo firstTask = index.updateDocuments("[" + firstDocument + "]", "language");
         index.waitForTask(firstTask.getTaskUid());
 
-        Movie[] movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         assertEquals(1, movies.length);
         assertEquals("419704", movies[0].getId());
         assertEquals("Ad Astra", movies[0].getTitle());
@@ -243,6 +247,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         List<Movie> toUpdate = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             movies[i].setTitle("Star wars episode: " + i);
@@ -254,8 +260,7 @@ public class DocumentsTest extends AbstractIT {
 
         index.waitForTask(task.getTaskUid());
         for (int j = 0; j < 5; j++) {
-            Movie responseUpdate =
-                    this.gson.fromJson(index.getDocument(toUpdate.get(j).getId()), Movie.class);
+            Movie responseUpdate = index.<Movie>getDocument(toUpdate.get(j).getId(), Movie.class);
             assertEquals(toUpdate.get(j).getTitle(), responseUpdate.getTitle());
             assertEquals(toUpdate.get(j).getOverview(), responseUpdate.getOverview());
         }
@@ -272,6 +277,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo taskIndex = index.addDocuments(testData.getRaw());
 
         index.waitForTask(taskIndex.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         List<Movie> toUpdate = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             movies[i].setTitle("Star wars episode: " + i);
@@ -298,6 +305,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo taskIndex = index.addDocuments(testData.getRaw());
 
         index.waitForTask(taskIndex.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         List<Movie> toUpdate = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             movies[i].setTitle("Star wars episode: " + i);
@@ -324,9 +333,24 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Movie movie = index.<Movie>getDocument(testData.getData().get(0).getId(), Movie.class);
+        assertEquals(movie.getTitle(), testData.getData().get(0).getTitle());
+    }
+
+    /** Test default GetRawDocuments */
+    @Test
+    public void testGetRawDocument() throws Exception {
+
+        String indexUid = "GetRawDocument";
+        Index index = client.index(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo task = index.addDocuments(testData.getRaw());
+
+        index.waitForTask(task.getTaskUid());
         Movie movie =
                 this.gson.fromJson(
-                        index.getDocument(testData.getData().get(0).getId()), Movie.class);
+                        index.getRawDocument(testData.getData().get(0).getId()), Movie.class);
         assertEquals(movie.getTitle(), testData.getData().get(0).getTitle());
     }
 
@@ -341,11 +365,20 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
+
         assertEquals(20, movies.length);
         for (int i = 0; i < movies.length; i++) {
-            Movie movie =
-                    this.gson.fromJson(
-                            index.getDocument(testData.getData().get(i).getId()), Movie.class);
+            assertEquals(movies[i].getTitle(), testData.getData().get(i).getTitle());
+            String[] expectedGenres = testData.getData().get(i).getGenres();
+            String[] foundGenres = movies[i].getGenres();
+            for (int x = 0; x < expectedGenres.length; x++) {
+                assertEquals(expectedGenres[x], foundGenres[x]);
+            }
+        }
+        for (int i = 0; i < movies.length; i++) {
+            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
             assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
             String[] expectedGenres = testData.getData().get(i).getGenres();
             String[] foundGenres = movie.getGenres();
@@ -361,17 +394,18 @@ public class DocumentsTest extends AbstractIT {
 
         String indexUid = "GetDocumentsLimit";
         int limit = 24;
+        DocumentsQuery query = new DocumentsQuery().setLimit(limit);
         Index index = client.index(indexUid);
 
         TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(query, Movie.class);
+        Movie[] movies = result.getResults();
         assertEquals(limit, movies.length);
         for (int i = 0; i < movies.length; i++) {
-            Movie movie =
-                    this.gson.fromJson(
-                            index.getDocument(testData.getData().get(i).getId()), Movie.class);
+            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
             assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
         }
     }
@@ -383,12 +417,18 @@ public class DocumentsTest extends AbstractIT {
         int limit = 2;
         int offset = 2;
         int secondOffset = 5;
+        DocumentsQuery query = new DocumentsQuery().setLimit(limit).setOffset(offset);
         Index index = client.index(indexUid);
 
         TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(query, Movie.class);
+        Movie[] movies = result.getResults();
+        Results<Movie> secondResults =
+                index.getDocuments(query.setOffset(secondOffset), Movie.class);
+        Movie[] secondMovies = secondResults.getResults();
 
         assertEquals(limit, movies.length);
         assertEquals(limit, secondMovies.length);
@@ -399,17 +439,24 @@ public class DocumentsTest extends AbstractIT {
 
     /** Test GetDocuments with limit, offset and specified fields */
     @Test
-    public void testGetDocumentsLimitAndOffsetAndSpecifiedAttributesToRetrieve() throws Exception {
-        String indexUid = "GetDocumentsLimit";
+    public void testGetDocumentsLimitAndOffsetAndSpecifiedFields() throws Exception {
+        String indexUid = "GetDocumentsLimitAndOffsetAndSpecifiedFields";
         int limit = 2;
         int offset = 2;
-        List<String> attributesToRetrieve = Arrays.asList("id", "title");
+        List<String> fields = Arrays.asList("id", "title");
+        DocumentsQuery query =
+                new DocumentsQuery()
+                        .setLimit(limit)
+                        .setOffset(offset)
+                        .setFields(fields.toArray(new String[0]));
         Index index = client.index(indexUid);
 
         TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
+        Results<Movie> result = index.getDocuments(query, Movie.class);
+        Movie[] movies = result.getResults();
 
         assertEquals(limit, movies.length);
 
@@ -467,12 +514,15 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
         index.waitForTask(task.getTaskUid());
 
-        Movie[] movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         Movie toDelete = movies[0];
         task = index.deleteDocument(toDelete.getId());
         index.waitForTask(task.getTaskUid());
 
-        assertThrows(MeilisearchApiException.class, () -> index.getDocument(toDelete.getId()));
+        assertThrows(
+                MeilisearchApiException.class,
+                () -> index.<Movie>getDocument(toDelete.getId(), Movie.class));
     }
 
     /** Test deleteDocuments */
@@ -486,7 +536,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
         index.waitForTask(task.getTaskUid());
 
-        Movie[] movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         assertEquals(20, movies.length);
 
         List<String> identifiersToDelete = getIdentifiersToDelete(movies);
@@ -494,7 +545,7 @@ public class DocumentsTest extends AbstractIT {
         task = index.deleteDocuments(identifiersToDelete);
         index.waitForTask(task.getTaskUid());
 
-        movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
 
         boolean containsDeletedMovie =
                 Arrays.stream(movies)
@@ -519,7 +570,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo taskIndex = index.addDocuments(testData.getRaw());
         index.waitForTask(taskIndex.getTaskUid());
 
-        Movie[] movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        Results<Movie> result = index.getDocuments(Movie.class);
+        Movie[] movies = result.getResults();
         assertEquals(20, movies.length);
 
         TaskInfo task = index.deleteAllDocuments();
@@ -529,7 +581,7 @@ public class DocumentsTest extends AbstractIT {
         assertEquals(task.getType(), "documentDeletion");
         assertNotNull(task.getEnqueuedAt());
 
-        movies = this.gson.fromJson(index.getDocuments(), Movie[].class);
+        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
         assertEquals(0, movies.length);
     }
 }


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

- `GET /documents/:uid`, `GET /documents` Add the possibility to reduce the body payload by using a query parameter called `fields` (previously called `attributesToRetrieve`), check the issue and the spec for the entire behavior.
- The documents objects now return wrap in a `Results`
- Create two separate methods for `GET /documents`:
    - `<T> Results<T> getDocuments(Class<T> targetClass) throws MeilisearchException` -> return an `Object`
    - `String getRawDocuments()` -> return a `String`
- Create two separate methods for `GET /documents/:uid`:
    - `<T> Results<T> getDocument(String identifier, Class<T> targetClass) throws MeilisearchException` -> return an `Object`
    - `String getRawDocument(String identifier)` -> return a `String`
- [x] Adapt DocumentsQuery naming following all the routes
- [x] Adapt and fix tests
- [x] Add test for `getRawDocument`
- [x] Add test for `getRawDocuments`