### PR TITLE
Update version for the next release (v0.10.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -455,7 +455,7 @@ getting_started_add_documents_md: |-
   <dependency>
     <groupId>com.meilisearch.sdk</groupId>
     <artifactId>meilisearch-java</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
     <type>pom</type>
   </dependency>
   ```
@@ -463,7 +463,7 @@ getting_started_add_documents_md: |-
   **Gradle**
   Add the following line to the `dependencies` section of your `build.gradle`:
   ```groovy
-  implementation 'com.meilisearch.sdk:meilisearch-java:0.9.0'
+  implementation 'com.meilisearch.sdk:meilisearch-java:0.10.0'
   ```
 
   ```java

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add the following code to the `<dependencies>` section of your project:
 <dependency>
   <groupId>com.meilisearch.sdk</groupId>
   <artifactId>meilisearch-java</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -66,7 +66,7 @@ Add the following code to the `<dependencies>` section of your project:
 Add the following line to the `dependencies` section of your `build.gradle`:
 
 ```groovy
-implementation 'com.meilisearch.sdk:meilisearch-java:0.9.0'
+implementation 'com.meilisearch.sdk:meilisearch-java:0.10.0'
 ```
 
 ### Run Meilisearch <!-- omit in toc -->

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 
 group = 'com.meilisearch.sdk'
 archivesBaseName = 'meilisearch-java'
-version = '0.9.0'
+version = '0.10.0'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/meilisearch/sdk/Version.java
+++ b/src/main/java/com/meilisearch/sdk/Version.java
@@ -1,7 +1,7 @@
 package com.meilisearch.sdk;
 
 public class Version {
-    static final String VERSION = "0.9.0";
+    static final String VERSION = "0.10.0";
 
     public static String getQualifiedVersion() {
         return "Meilisearch Java (v" + VERSION + ")";


### PR DESCRIPTION
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.

## ⚠️ Breaking changes

This breaking change *__may not affect you__*, but in any case, you should check your search queries if you want to keep the same behavior from `v0.28`.
* The `NOT` filter keyword does not have an implicitly `EXIST` operator anymore. Check out for more information: https://github.com/meilisearch/meilisearch/issues/2486
* Correction of naming methods related to Ranking Rules (https://github.com/meilisearch/meilisearch-java/pull/539) @ghousek1

## 🚀 Enhancements

* Ensure support to the new search query parameter `MatchingStrategy` (#434) @alallema
* Ensure support to keys with wildcarded actions.
  - `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`. (#434) @alallema 

Thanks again to @alallema and @ghousek1 ! 🎉