### PR TITLE
Add a builder for SearchRequest class

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -30,65 +30,7 @@ public class Search {
      */
     String rawSearch(String uid, String q) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
-        SearchRequest sr = new SearchRequest(q);
-        return httpClient.post(requestQuery, sr, String.class);
-    }
-
-    /**
-     * Performs a search on a given index with a given query
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param cropMarker String to add before and/or after the cropped text, default value: …
-     * @param highlightPreTag String to customize highlight tag before every highlighted query terms
-     * @param highlightPostTag String to customize highlight tag after every highlighted query terms
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filter Filter queries by an attribute value
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     * @return search results, as raw data
-     * @throws MeilisearchException Search Exception or Client Error
-     */
-    String rawSearch(
-            String uid,
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String cropMarker,
-            String highlightPreTag,
-            String highlightPostTag,
-            String[] attributesToHighlight,
-            String[] filter,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort)
-            throws MeilisearchException {
-        String requestQuery = "/indexes/" + uid + "/search";
-        SearchRequest sr =
-                new SearchRequest(
-                        q,
-                        offset,
-                        limit,
-                        attributesToRetrieve,
-                        attributesToCrop,
-                        cropLength,
-                        cropMarker,
-                        highlightPreTag,
-                        highlightPostTag,
-                        attributesToHighlight,
-                        filter,
-                        showMatchesPosition,
-                        facets,
-                        sort);
+        SearchRequest sr = SearchRequest.builder().q(q).build();
         return httpClient.post(requestQuery, sr, String.class);
     }
 
@@ -102,7 +44,7 @@ public class Search {
      */
     String rawSearch(String uid, SearchRequest sr) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/search";
-        return httpClient.post(requestQuery, sr.toString(), String.class);
+        return httpClient.post(requestQuery, sr, String.class);
     }
 
     /**
@@ -115,64 +57,6 @@ public class Search {
      */
     SearchResult search(String uid, String q) throws MeilisearchException {
         return httpClient.jsonHandler.decode(rawSearch(uid, q), SearchResult.class);
-    }
-
-    /**
-     * Performs a search on a given index with a given query
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param cropMarker String to customize default crop marker, default value: …
-     * @param highlightPreTag String to customize highlight tag before every highlighted query terms
-     * @param highlightPostTag String to customize highlight tag after every highlighted query terms
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filter Filter queries by an attribute value
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     * @return search results
-     * @throws MeilisearchException Search Exception or Client Error
-     */
-    SearchResult search(
-            String uid,
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String cropMarker,
-            String highlightPreTag,
-            String highlightPostTag,
-            String[] attributesToHighlight,
-            String[] filter,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort)
-            throws MeilisearchException {
-        return httpClient.jsonHandler.decode(
-                rawSearch(
-                        uid,
-                        q,
-                        offset,
-                        limit,
-                        attributesToRetrieve,
-                        attributesToCrop,
-                        cropLength,
-                        cropMarker,
-                        highlightPreTag,
-                        highlightPostTag,
-                        attributesToHighlight,
-                        filter,
-                        showMatchesPosition,
-                        facets,
-                        sort),
-                SearchResult.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SearchRequest.java
@@ -70,10 +70,10 @@ public class SearchRequest {
         JSONObject jsonObject =
                 new JSONObject()
                         .put("q", this.q)
-                        .put("offset", this.offset == null ? null : this.offset)
-                        .put("limit", this.limit == null ? null : this.limit)
+                        .put("offset", this.offset)
+                        .put("limit", this.limit)
                         .put("attributesToRetrieve", this.attributesToRetrieve)
-                        .put("cropLength", this.cropLength == null ? null : this.cropLength)
+                        .put("cropLength", this.cropLength)
                         .put("cropMarker", this.cropMarker)
                         .put("highlightPreTag", this.highlightPreTag)
                         .put("highlightPostTag", this.highlightPostTag)
@@ -82,9 +82,7 @@ public class SearchRequest {
                                 this.matchingStrategy == null
                                         ? null
                                         : this.matchingStrategy.toString())
-                        .put(
-                                "showMatchesPosition",
-                                this.showMatchesPosition == null ? null : this.showMatchesPosition)
+                        .put("showMatchesPosition", this.showMatchesPosition)
                         .put("facets", this.facets)
                         .put("sort", this.sort)
                         .putOpt("attributesToCrop", this.attributesToCrop)

--- a/src/main/java/com/meilisearch/sdk/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SearchRequest.java
@@ -1,22 +1,29 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.model.MatchingStrategy;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.json.JSONObject;
 
 /** Search request query string builder */
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
 @Setter
 @Accessors(chain = true)
 public class SearchRequest {
     private String q;
-    private int offset;
-    private int limit;
+    private Integer offset;
+    private Integer limit;
     private String[] attributesToRetrieve;
     private String[] attributesToCrop;
-    private int cropLength;
+    private Integer cropLength;
     private String cropMarker;
     private String highlightPreTag;
     private String highlightPostTag;
@@ -24,12 +31,9 @@ public class SearchRequest {
     private String[] attributesToHighlight;
     private String[] filter;
     private String[][] filterArray;
-    private boolean showMatchesPosition;
+    private Boolean showMatchesPosition;
     private String[] facets;
     private String[] sort;
-
-    /** Empty SearchRequest constructor */
-    public SearchRequest() {}
 
     /**
      * Constructor for SearchRequest for building search queries with the default values: offset: 0,
@@ -40,298 +44,8 @@ public class SearchRequest {
      * @param q Query String
      */
     public SearchRequest(String q) {
-        this(q, 0);
-    }
-
-    /**
-     * Constructor for SearchRequest for building search queries with the default values: limit: 20,
-     * attributesToRetrieve: ["*"], attributesToCrop: null, cropLength: 200, attributesToHighlight:
-     * null, filter: null, showMatchesPosition: false, facets: null, sort: null
-     *
-     * @param q Query String
-     * @param offset Number of documents to skip
-     */
-    public SearchRequest(String q, int offset) {
-        this(q, offset, 20);
-    }
-
-    /**
-     * Constructor for SearchRequest for building search queries with the default values:
-     * attributesToRetrieve: ["*"], attributesToCrop: null, cropLength: 200, attributesToHighlight:
-     * null, filter: null, showMatchesPosition: false, facets: null, sort: null
-     *
-     * @param q Query String
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     */
-    public SearchRequest(String q, int offset, int limit) {
-        this(q, offset, limit, new String[] {"*"});
-    }
-
-    /**
-     * Constructor for SearchRequest for building search queries with the default values:
-     * attributesToCrop: null, cropLength: 200, attributesToHighlight: null, filter: null,
-     * showMatchesPosition: false, facets: null, sort: null
-     *
-     * @param q Query String
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     */
-    public SearchRequest(String q, int offset, int limit, String[] attributesToRetrieve) {
-        this(
-                q,
-                offset,
-                limit,
-                attributesToRetrieve,
-                null,
-                200,
-                null,
-                null,
-                null,
-                null,
-                (String[]) null,
-                false,
-                null,
-                null);
-    }
-
-    /**
-     * Full SearchRequest Constructor for building search queries
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filter Filter queries by an attribute value
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     */
-    public SearchRequest(
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String[] attributesToHighlight,
-            String[] filter,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort) {
-        this(
-                q,
-                offset,
-                limit,
-                attributesToRetrieve,
-                attributesToCrop,
-                cropLength,
-                null,
-                null,
-                null,
-                null,
-                attributesToHighlight,
-                filter,
-                null,
-                showMatchesPosition,
-                facets,
-                sort);
-    }
-
-    /**
-     * Full SearchRequest Constructor for building search queries
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param cropMarker String to customize default crop marker, default value: …
-     * @param highlightPreTag String to customize highlight tag before every highlighted query terms
-     * @param highlightPostTag String to customize highlight tag after every highlighted query terms
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filter Filter queries by an attribute value
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     */
-    public SearchRequest(
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String cropMarker,
-            String highlightPreTag,
-            String highlightPostTag,
-            String[] attributesToHighlight,
-            String[] filter,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort) {
-        this(
-                q,
-                offset,
-                limit,
-                attributesToRetrieve,
-                attributesToCrop,
-                cropLength,
-                cropMarker,
-                highlightPreTag,
-                highlightPostTag,
-                null,
-                attributesToHighlight,
-                filter,
-                null,
-                showMatchesPosition,
-                facets,
-                sort);
-    }
-
-    /**
-     * Full SearchRequest Constructor for building search queries with 2D filter Array
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filterArray String array that can take multiple nested filters
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     */
-    public SearchRequest(
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String[] attributesToHighlight,
-            String[][] filterArray,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort) {
-        this(
-                q,
-                offset,
-                limit,
-                attributesToRetrieve,
-                attributesToCrop,
-                cropLength,
-                null,
-                null,
-                null,
-                null,
-                attributesToHighlight,
-                null,
-                filterArray,
-                showMatchesPosition,
-                facets,
-                sort);
-    }
-
-    /**
-     * Full SearchRequest Constructor for building search queries with 2D filter Array
-     *
-     * @param q Query string
-     * @param offset Number of documents to skip
-     * @param limit Maximum number of documents returned
-     * @param attributesToRetrieve Attributes to display in the returned documents
-     * @param attributesToCrop Attributes whose values have been cropped
-     * @param cropLength Length used to crop field values
-     * @param cropMarker String to customize default crop marker, default value: …
-     * @param highlightPreTag String to customize highlight tag before every highlighted query terms
-     * @param highlightPostTag String to customize highlight tag after every highlighted query terms
-     * @param matchingStrategy MatchingStrategy to defines the strategy used to match query terms in
-     *     documents
-     * @param attributesToHighlight Attributes whose values will contain highlighted matching terms
-     * @param filterArray String array that can take multiple nested filters
-     * @param showMatchesPosition Defines whether an object that contains information about the
-     *     matches should be returned or not
-     * @param facets Facets for which to retrieve the matching count
-     * @param sort Sort queries by an attribute value
-     */
-    public SearchRequest(
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String cropMarker,
-            String highlightPreTag,
-            String highlightPostTag,
-            MatchingStrategy matchingStrategy,
-            String[] attributesToHighlight,
-            String[][] filterArray,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort) {
-        this(
-                q,
-                offset,
-                limit,
-                attributesToRetrieve,
-                attributesToCrop,
-                cropLength,
-                cropMarker,
-                highlightPreTag,
-                highlightPostTag,
-                matchingStrategy,
-                attributesToHighlight,
-                null,
-                filterArray,
-                showMatchesPosition,
-                facets,
-                sort);
-    }
-
-    private SearchRequest(
-            String q,
-            int offset,
-            int limit,
-            String[] attributesToRetrieve,
-            String[] attributesToCrop,
-            int cropLength,
-            String cropMarker,
-            String highlightPreTag,
-            String highlightPostTag,
-            MatchingStrategy matchingStrategy,
-            String[] attributesToHighlight,
-            String[] filter,
-            String[][] filterArray,
-            boolean showMatchesPosition,
-            String[] facets,
-            String[] sort) {
+        this();
         this.q = q;
-        this.offset = offset;
-        this.limit = limit;
-        this.attributesToRetrieve = attributesToRetrieve;
-        this.attributesToCrop = attributesToCrop;
-        this.cropLength = cropLength;
-        this.cropMarker = cropMarker;
-        this.highlightPreTag = highlightPreTag;
-        this.highlightPostTag = highlightPostTag;
-        this.matchingStrategy = matchingStrategy;
-        this.attributesToHighlight = attributesToHighlight;
-        this.setFilter(filter);
-        this.setFilterArray(filterArray);
-        this.showMatchesPosition = showMatchesPosition;
-        this.facets = facets;
-        this.sort = sort;
     }
 
     /**
@@ -356,10 +70,10 @@ public class SearchRequest {
         JSONObject jsonObject =
                 new JSONObject()
                         .put("q", this.q)
-                        .put("offset", this.offset)
-                        .put("limit", this.limit)
+                        .put("offset", this.offset == null ? null : this.offset)
+                        .put("limit", this.limit == null ? null : this.limit)
                         .put("attributesToRetrieve", this.attributesToRetrieve)
-                        .put("cropLength", this.cropLength)
+                        .put("cropLength", this.cropLength == null ? null : this.cropLength)
                         .put("cropMarker", this.cropMarker)
                         .put("highlightPreTag", this.highlightPreTag)
                         .put("highlightPostTag", this.highlightPostTag)
@@ -368,7 +82,9 @@ public class SearchRequest {
                                 this.matchingStrategy == null
                                         ? null
                                         : this.matchingStrategy.toString())
-                        .put("showMatchesPosition", this.showMatchesPosition)
+                        .put(
+                                "showMatchesPosition",
+                                this.showMatchesPosition == null ? null : this.showMatchesPosition)
                         .put("facets", this.facets)
                         .put("sort", this.sort)
                         .putOpt("attributesToCrop", this.attributesToCrop)

--- a/src/test/java/com/meilisearch/integration/SearchNestedTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchNestedTest.java
@@ -87,7 +87,10 @@ public class SearchNestedTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         index.waitForTask(index.updateSettings(newSettings).getTaskUid());
         SearchRequest searchRequest =
-                new SearchRequest("An Awesome").setSort(new String[] {"info.reviewNb:desc"});
+                SearchRequest.builder()
+                        .q("An Awesome")
+                        .sort(new String[] {"info.reviewNb:desc"})
+                        .build();
 
         Results searchResultGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
@@ -110,7 +113,10 @@ public class SearchNestedTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         index.waitForTask(index.updateSettings(newSettings).getTaskUid());
         SearchRequest searchRequest =
-                new SearchRequest("An Awesome").setSort(new String[] {"info.reviewNb:desc"});
+                SearchRequest.builder()
+                        .q("An Awesome")
+                        .sort(new String[] {"info.reviewNb:desc"})
+                        .build();
         Results searchResultGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
         assertEquals(1, searchResultGson.hits.length);

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -76,7 +76,7 @@ public class SearchTest extends AbstractIT {
 
         index.waitForTask(task.getTaskUid());
 
-        SearchRequest searchRequest = new SearchRequest("a").setOffset(20);
+        SearchRequest searchRequest = SearchRequest.builder().q("a").offset(20).build();
         SearchResult searchResult = index.search(searchRequest);
 
         assertEquals(10, searchResult.getHits().size());
@@ -94,7 +94,7 @@ public class SearchTest extends AbstractIT {
 
         index.waitForTask(task.getTaskUid());
 
-        SearchRequest searchRequest = new SearchRequest("a").setLimit(2);
+        SearchRequest searchRequest = SearchRequest.builder().q("a").limit(2).build();
         SearchResult searchResult = index.search(searchRequest);
 
         assertEquals(2, searchResult.getHits().size());
@@ -141,9 +141,11 @@ public class SearchTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
 
         SearchRequest searchRequest =
-                new SearchRequest("and")
-                        .setAttributesToCrop(new String[] {"overview"})
-                        .setCropLength(1);
+                SearchRequest.builder()
+                        .q("and")
+                        .attributesToCrop(new String[] {"overview"})
+                        .cropLength(1)
+                        .build();
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
@@ -165,10 +167,12 @@ public class SearchTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
 
         SearchRequest searchRequest =
-                new SearchRequest("and")
-                        .setAttributesToCrop(new String[] {"overview"})
-                        .setCropLength(1)
-                        .setCropMarker("(ꈍᴗꈍ)");
+                SearchRequest.builder()
+                        .q("and")
+                        .attributesToCrop(new String[] {"overview"})
+                        .cropLength(1)
+                        .cropMarker("(ꈍᴗꈍ)")
+                        .build();
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
@@ -212,10 +216,12 @@ public class SearchTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
 
         SearchRequest searchRequest =
-                new SearchRequest("and")
-                        .setAttributesToHighlight(new String[] {"title"})
-                        .setHighlightPreTag("(⊃｡•́‿•̀｡)⊃ ")
-                        .setHighlightPostTag(" ⊂(´• ω •`⊂)");
+                SearchRequest.builder()
+                        .q("and")
+                        .attributesToHighlight(new String[] {"title"})
+                        .highlightPreTag("(⊃｡•́‿•̀｡)⊃ ")
+                        .highlightPostTag(" ⊂(´• ω •`⊂)")
+                        .build();
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
@@ -370,7 +376,8 @@ public class SearchTest extends AbstractIT {
         settings.setSortableAttributes(new String[] {"id"});
         index.waitForTask(index.updateSettings(settings).getTaskUid());
 
-        SearchRequest searchRequest = new SearchRequest("and").setSort(new String[] {"id:asc"});
+        SearchRequest searchRequest =
+                SearchRequest.builder().q("and").sort(new String[] {"id:asc"}).build();
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
@@ -401,7 +408,10 @@ public class SearchTest extends AbstractIT {
         index.waitForTask(index.updateSettings(settings).getTaskUid());
 
         SearchRequest searchRequest =
-                new SearchRequest("dark").setSort(new String[] {"id:asc", "title:asc"});
+                SearchRequest.builder()
+                        .q("dark")
+                        .sort(new String[] {"id:asc", "title:asc"})
+                        .build();
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 

--- a/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
@@ -23,7 +23,8 @@ class SearchRequestTest {
 
     @Test
     void toStringQueryAndOffset() {
-        SearchRequest classToTest = new SearchRequest("This is a Test").setOffset(200);
+        SearchRequest classToTest =
+                new SearchRequest("This is a Test").setQuery("This is a Test").setOffset(200);
 
         assertEquals("{\"q\":\"This is a Test\",\"offset\":200}", classToTest.toString());
     }

--- a/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
@@ -11,57 +11,131 @@ class SearchRequestTest {
     void toStringSimpleQuery() {
         SearchRequest classToTest = new SearchRequest("This is a Test");
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"*\"],\"offset\":0,\"showMatchesPosition\":false,\"limit\":20,\"cropLength\":200}",
-                classToTest.toString());
+        assertEquals("{\"q\":\"This is a Test\"}", classToTest.toString());
+    }
+
+    @Test
+    void toStringSimpleQueryWithBuilder() {
+        SearchRequest classToTest = SearchRequest.builder().q("This is a Test").build();
+
+        assertEquals("{\"q\":\"This is a Test\"}", classToTest.toString());
     }
 
     @Test
     void toStringQueryAndOffset() {
-        SearchRequest classToTest = new SearchRequest("This is a Test", 200);
+        SearchRequest classToTest = new SearchRequest("This is a Test").setOffset(200);
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"*\"],\"offset\":200,\"showMatchesPosition\":false,\"limit\":20,\"cropLength\":200}",
-                classToTest.toString());
+        assertEquals("{\"q\":\"This is a Test\",\"offset\":200}", classToTest.toString());
+    }
+
+    @Test
+    void toStringQueryAndOffsetWithBuilder() {
+        SearchRequest classToTest = SearchRequest.builder().q("This is a Test").offset(200).build();
+
+        assertEquals("{\"q\":\"This is a Test\",\"offset\":200}", classToTest.toString());
     }
 
     @Test
     void toStringQueryLimitAndOffset() {
-        SearchRequest classToTest = new SearchRequest("This is a Test", 200, 900);
+        SearchRequest classToTest =
+                new SearchRequest("This is a Test").setOffset(200).setLimit(900);
 
         assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"*\"],\"offset\":200,\"showMatchesPosition\":false,\"limit\":900,\"cropLength\":200}",
-                classToTest.toString());
+                "{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}", classToTest.toString());
+    }
+
+    @Test
+    void toStringQueryLimitAndOffsetWithBuilder() {
+        SearchRequest classToTest =
+                SearchRequest.builder().q("This is a Test").offset(200).limit(900).build();
+
+        assertEquals(
+                "{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}", classToTest.toString());
     }
 
     @Test
     void toStringQueryLimitOffsetAndAttributesToRetrieve() {
         SearchRequest classToTest =
-                new SearchRequest("This is a Test", 200, 900, new String[] {"bubble"});
+                new SearchRequest("This is a Test")
+                        .setOffset(200)
+                        .setLimit(900)
+                        .setAttributesToRetrieve(new String[] {"bubble"});
 
         assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"showMatchesPosition\":false,\"limit\":900,\"cropLength\":200}",
+                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}",
                 classToTest.toString());
+    }
+
+    @Test
+    void toStringQueryLimitOffsetAndAttributesToRetrieveWithBuilder() {
+        SearchRequest classToTest =
+                SearchRequest.builder()
+                        .q("This is a Test")
+                        .attributesToRetrieve(new String[] {"bubble"})
+                        .limit(900)
+                        .offset(200)
+                        .build();
+
+        assertEquals(
+                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}",
+                classToTest.toString());
+    }
+
+    @Test
+    void toStringQueryLimitOffsetAndPageAndHitPerPage() {
+        SearchRequest classToTest =
+                SearchRequest.builder().q("This is a Test").limit(20).offset(0).build();
+
+        assertEquals(
+                "{\"q\":\"This is a Test\",\"offset\":0,\"limit\":20}", classToTest.toString());
     }
 
     @Test
     void toStringEveryParameters() {
         SearchRequest classToTest =
-                new SearchRequest(
-                        "This is a Test",
-                        200,
-                        900,
-                        new String[] {"bubble"},
-                        new String[] {"crop"},
-                        900,
-                        null,
-                        null,
-                        null,
-                        new String[] {"highlight"},
-                        new String[] {"test='test'"},
-                        true,
-                        new String[] {"facets"},
-                        new String[] {"sort"});
+                new SearchRequest("This is a Test")
+                        .setOffset(200)
+                        .setLimit(900)
+                        .setAttributesToRetrieve(new String[] {"bubble"})
+                        .setAttributesToHighlight(new String[] {"highlight"})
+                        .setAttributesToCrop(new String[] {"crop"})
+                        .setCropLength(900)
+                        .setFilter(new String[] {"test='test'"})
+                        .setFacets(new String[] {"facets"})
+                        .setSort(new String[] {"sort"});
+
+        assertEquals("This is a Test", classToTest.getQ());
+        assertEquals(200, classToTest.getOffset());
+        assertEquals(900, classToTest.getLimit());
+        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
+        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
+        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
+        assertEquals(null, classToTest.getCropMarker());
+        assertEquals(null, classToTest.getHighlightPreTag());
+        assertEquals(null, classToTest.getHighlightPostTag());
+        assertEquals(null, classToTest.getFilterArray());
+        assertEquals(1, classToTest.getFilter().length);
+        assertEquals("test='test'", classToTest.getFilter()[0]);
+        assertEquals("facets", classToTest.getFacets()[0]);
+        assertEquals("sort", classToTest.getSort()[0]);
+        assertEquals(900, classToTest.getCropLength());
+    }
+
+    @Test
+    void toStringEveryParametersWithBuilder() {
+        SearchRequest classToTest =
+                SearchRequest.builder()
+                        .q("This is a Test")
+                        .limit(900)
+                        .offset(200)
+                        .attributesToRetrieve(new String[] {"bubble"})
+                        .attributesToHighlight(new String[] {"highlight"})
+                        .attributesToCrop(new String[] {"crop"})
+                        .cropLength(900)
+                        .filter(new String[] {"test='test'"})
+                        .facets(new String[] {"facets"})
+                        .sort(new String[] {"sort"})
+                        .build();
 
         assertEquals("This is a Test", classToTest.getQ());
         assertEquals(200, classToTest.getOffset());
@@ -83,24 +157,70 @@ class SearchRequestTest {
     @Test
     void toStringEveryParametersWithArray() {
         SearchRequest classToTest =
-                new SearchRequest(
-                        "This is a Test",
-                        200,
-                        900,
-                        new String[] {"bubble"},
-                        new String[] {"crop"},
-                        900,
-                        "123",
-                        "abc",
-                        "zyx",
-                        MatchingStrategy.ALL,
-                        new String[] {"highlight"},
-                        new String[][] {
-                            new String[] {"test='test'"}, new String[] {"test1='test1'"}
-                        },
-                        true,
-                        new String[] {"facets"},
-                        new String[] {"sort"});
+                new SearchRequest("This is a Test")
+                        .setOffset(200)
+                        .setLimit(900)
+                        .setAttributesToRetrieve(new String[] {"bubble"})
+                        .setAttributesToHighlight(new String[] {"highlight"})
+                        .setAttributesToCrop(new String[] {"crop"})
+                        .setCropLength(900)
+                        .setCropMarker("123")
+                        .setHighlightPreTag("abc")
+                        .setHighlightPostTag("zyx")
+                        .setMatchingStrategy(MatchingStrategy.ALL)
+                        .setFilterArray(
+                                new String[][] {
+                                    new String[] {"test='test'"}, new String[] {"test1='test1'"}
+                                })
+                        .setShowMatchesPosition(true)
+                        .setFacets(new String[] {"facets"})
+                        .setSort(new String[] {"sort"});
+
+        assertEquals("This is a Test", classToTest.getQ());
+        assertEquals(200, classToTest.getOffset());
+        assertEquals(900, classToTest.getLimit());
+        assertEquals("123", classToTest.getCropMarker());
+        assertEquals("abc", classToTest.getHighlightPreTag());
+        assertEquals(MatchingStrategy.ALL, classToTest.getMatchingStrategy());
+        assertEquals("zyx", classToTest.getHighlightPostTag());
+        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
+        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
+        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
+        assertEquals(null, classToTest.getFilter());
+        assertEquals(2, classToTest.getFilterArray().length);
+        assertEquals("test='test'", classToTest.getFilterArray()[0][0]);
+        assertEquals("test1='test1'", classToTest.getFilterArray()[1][0]);
+        assertEquals("facets", classToTest.getFacets()[0]);
+        assertEquals("sort", classToTest.getSort()[0]);
+        assertEquals(900, classToTest.getCropLength());
+        assertEquals(
+                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"matchingStrategy\":\"all\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"attributesToCrop\":[\"crop\"]}",
+                classToTest.toString());
+    }
+
+    @Test
+    void toStringEveryParametersWithArrayWithBuilder() {
+        SearchRequest classToTest =
+                SearchRequest.builder()
+                        .q("This is a Test")
+                        .limit(900)
+                        .offset(200)
+                        .attributesToRetrieve(new String[] {"bubble"})
+                        .attributesToHighlight(new String[] {"highlight"})
+                        .attributesToCrop(new String[] {"crop"})
+                        .cropLength(900)
+                        .cropMarker("123")
+                        .highlightPreTag("abc")
+                        .highlightPostTag("zyx")
+                        .matchingStrategy(MatchingStrategy.ALL)
+                        .filterArray(
+                                new String[][] {
+                                    new String[] {"test='test'"}, new String[] {"test1='test1'"}
+                                })
+                        .showMatchesPosition(true)
+                        .facets(new String[] {"facets"})
+                        .sort(new String[] {"sort"})
+                        .build();
 
         assertEquals("This is a Test", classToTest.getQ());
         assertEquals(200, classToTest.getOffset());
@@ -127,24 +247,26 @@ class SearchRequestTest {
     @Test
     void toStringEveryParametersWithArrayMatchingStrategyNull() {
         SearchRequest classToTest =
-                new SearchRequest(
-                        "This is a Test",
-                        200,
-                        900,
-                        new String[] {"bubble"},
-                        new String[] {"crop"},
-                        900,
-                        "123",
-                        "abc",
-                        "zyx",
-                        null,
-                        new String[] {"highlight"},
-                        new String[][] {
-                            new String[] {"test='test'"}, new String[] {"test1='test1'"}
-                        },
-                        true,
-                        new String[] {"facets"},
-                        new String[] {"sort"});
+                SearchRequest.builder()
+                        .q("This is a Test")
+                        .limit(900)
+                        .offset(200)
+                        .attributesToRetrieve(new String[] {"bubble"})
+                        .attributesToHighlight(new String[] {"highlight"})
+                        .attributesToCrop(new String[] {"crop"})
+                        .cropLength(900)
+                        .cropMarker("123")
+                        .highlightPreTag("abc")
+                        .highlightPostTag("zyx")
+                        .matchingStrategy(null)
+                        .filterArray(
+                                new String[][] {
+                                    new String[] {"test='test'"}, new String[] {"test1='test1'"}
+                                })
+                        .showMatchesPosition(true)
+                        .facets(new String[] {"facets"})
+                        .sort(new String[] {"sort"})
+                        .build();
 
         assertEquals("This is a Test", classToTest.getQ());
         assertEquals(200, classToTest.getOffset());


### PR DESCRIPTION
The `SearchRequest` class has been modified to simplify its use, see #455


- Removing all the constructors with multiple arguments on the Class
- Add the possibility to use a `builder()`
```
SearchRequest.builder()
    .q("")
    .offset(10)
    .limit(200)
    .cropLength(5)
    .cropMarker("…")
    .build();
```
- Keep the possibility to initialize the Class like:
```
new SearchRequest("")
    .setOffset(10)
    .setLimit(200)
    .setCropLength(5)
    .setCropMarker("…");
```