### PR TITLE
Add tasks filters for v0.30

### DIFF
--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -91,12 +91,7 @@ public class TasksHandler {
      * @throws MeilisearchException if client request causes an error
      */
     TasksResults getTasks(String indexUid, TasksQuery param) throws MeilisearchException {
-        String[] newIndexUid = new String[param.getIndexUid().length + 1];
-        if (param != null && param.getIndexUid() != null) {
-            for (int i = 0; i < param.getIndexUid().length; i++)
-                newIndexUid[i] = param.getIndexUid()[i];
-            newIndexUid[param.getIndexUid().length] = indexUid;
-        }
+        param = addIndexUidToQuery(indexUid, param);
 
         TasksResults result =
                 httpClient.get(tasksPath().addQuery(param.toQuery()).getURL(), TasksResults.class);
@@ -172,5 +167,21 @@ public class TasksHandler {
     /** Creates an URLBuilder for the constant route tasks */
     private URLBuilder tasksPath() {
         return new URLBuilder("/tasks");
+    }
+
+    /** Add index uid to index uids list in task query */
+    TasksQuery addIndexUidToQuery(String indexUid, TasksQuery param) {
+        if (param != null && param.getIndexUids() != null) {
+            String[] newIndexUid = new String[param.getIndexUids().length + 1];
+            for (int i = 0; i < param.getIndexUids().length; i++)
+                newIndexUid[i] = param.getIndexUids()[i];
+            newIndexUid[param.getIndexUids().length] = indexUid;
+            param.setIndexUids(newIndexUid);
+        } else if (param != null) {
+            param.setIndexUids(new String[] {indexUid});
+        } else {
+            param = new TasksQuery().setIndexUids(new String[] {indexUid});
+        }
+        return param;
     }
 }

--- a/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
@@ -1,5 +1,8 @@
 package com.meilisearch.sdk.http;
 
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
 import lombok.Getter;
 
 @Getter
@@ -52,6 +55,27 @@ public class URLBuilder {
         return this;
     }
 
+    public URLBuilder addParameter(String parameter, int[] value) {
+        if (value != null && value.length > 0) {
+            addSeparator();
+            params.append(parameter);
+            params.append("=");
+            params.append(formatArrayParameters(value));
+        }
+        return this;
+    }
+
+    public URLBuilder addParameter(String parameter, Date value) {
+        if (value != null) {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            addSeparator();
+            params.append(parameter);
+            params.append("=");
+            params.append(formatter.format(value));
+        }
+        return this;
+    }
+
     public URLBuilder addQuery(String query) {
         this.params.append(query);
         return this;
@@ -68,6 +92,11 @@ public class URLBuilder {
 
     private String formatArrayParameters(String[] fields) {
         return String.join(",", fields);
+    }
+
+    private String formatArrayParameters(int[] fields) {
+        String[] arr = Arrays.stream(fields).mapToObj(String::valueOf).toArray(String[]::new);
+        return String.join(",", arr);
     }
 
     public String getURL() {

--- a/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
@@ -1,6 +1,7 @@
 package com.meilisearch.sdk.model;
 
 import com.meilisearch.sdk.http.URLBuilder;
+import java.util.Date;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -14,11 +15,19 @@ import lombok.experimental.Accessors;
 @Getter
 @Accessors(chain = true)
 public class TasksQuery {
+    private int[] uids;
     private int limit = -1;
     private int from = -1;
-    private String[] status;
-    private String[] type;
-    private String[] indexUid;
+    private String[] statuses;
+    private String[] types;
+    private String[] indexUids;
+    private int[] canceledBy;
+    private Date beforeEnqueuedAt;
+    private Date afterEnqueuedAt;
+    private Date beforeStartedAt;
+    private Date afterStartedAt;
+    private Date beforeFinishedAt;
+    private Date afterFinishedAt;
 
     public TasksQuery() {}
 
@@ -27,9 +36,17 @@ public class TasksQuery {
                 new URLBuilder()
                         .addParameter("limit", this.getLimit())
                         .addParameter("from", this.getFrom())
-                        .addParameter("status", this.getStatus())
-                        .addParameter("type", this.getType())
-                        .addParameter("indexUid", this.getIndexUid());
+                        .addParameter("uids", this.getUids())
+                        .addParameter("statuses", this.getStatuses())
+                        .addParameter("types", this.getTypes())
+                        .addParameter("indexUids", this.getIndexUids())
+                        .addParameter("canceledBy", this.getCanceledBy())
+                        .addParameter("beforeEnqueuedAt", this.getBeforeEnqueuedAt())
+                        .addParameter("afterEnqueuedAt", this.getAfterEnqueuedAt())
+                        .addParameter("beforeStartedAt", this.getBeforeStartedAt())
+                        .addParameter("afterStartedAt", this.getAfterStartedAt())
+                        .addParameter("beforeFinishedAt", this.getBeforeFinishedAt())
+                        .addParameter("afterFinishedAt", this.getAfterFinishedAt());
         return urlb.getURL();
     }
 }

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -12,6 +12,7 @@ import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
 import com.meilisearch.sdk.model.TasksResults;
 import com.meilisearch.sdk.utils.Movie;
+import java.util.Date;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -100,6 +101,43 @@ public class TasksTest extends AbstractIT {
         assertNotNull(result.getResults().length);
     }
 
+    /** Test Get Tasks with uid as filter */
+    @Test
+    public void testClientGetTasksWithUidFilter() throws Exception {
+        TasksQuery query = new TasksQuery().setUids(new int[] {1});
+        TasksResults result = client.getTasks(query);
+
+        assertNotNull(result.getLimit());
+        assertNotNull(result.getFrom());
+        assertNotNull(result.getNext());
+        assertNotNull(result.getResults().length);
+    }
+
+    /** Test Get Tasks with beforeEnqueuedAt as filter */
+    @Test
+    public void testClientGetTasksWithDateFilter() throws Exception {
+        Date date = new Date();
+        TasksQuery query = new TasksQuery().setBeforeEnqueuedAt(date);
+        TasksResults result = client.getTasks(query);
+
+        assertNotNull(result.getLimit());
+        assertNotNull(result.getFrom());
+        assertNotNull(result.getNext());
+        assertNotNull(result.getResults().length);
+    }
+
+    /** Test Get Tasks with canceledBy as filter */
+    @Test
+    public void testClientGetTasksWithCanceledByFilter() throws Exception {
+        TasksQuery query = new TasksQuery().setCanceledBy(new int[] {1});
+        TasksResults result = client.getTasks(query);
+
+        assertNotNull(result.getLimit());
+        assertNotNull(result.getFrom());
+        assertNotNull(result.getNext());
+        assertNotNull(result.getResults().length);
+    }
+
     /** Test Get Tasks with all query parameters */
     @Test
     public void testClientGetTasksAllQueryParameters() throws Exception {
@@ -109,14 +147,14 @@ public class TasksTest extends AbstractIT {
                 new TasksQuery()
                         .setLimit(limit)
                         .setFrom(from)
-                        .setStatus(new String[] {"enqueued", "succeeded"})
-                        .setType(new String[] {"indexDeletion"});
+                        .setStatuses(new String[] {"enqueued", "succeeded"})
+                        .setTypes(new String[] {"indexDeletion"});
         TasksResults result = client.getTasks(query);
-        Task[] tasks = result.getResults();
 
         assertEquals(limit, result.getLimit());
         assertNotNull(result.getFrom());
         assertNotNull(result.getNext());
+        assertNotNull(result.getResults().length);
     }
 
     /** Test Cancel Task */

--- a/src/test/java/com/meilisearch/sdk/TaskHandlerUtilsTest.java
+++ b/src/test/java/com/meilisearch/sdk/TaskHandlerUtilsTest.java
@@ -1,0 +1,56 @@
+package com.meilisearch.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.meilisearch.sdk.model.TasksQuery;
+import org.junit.jupiter.api.Test;
+
+class TasksHandlerUtilsTest {
+
+    @Test
+    void addIndexUidToQueryWithParamNull() {
+        final Config config = new Config("http://localhost:7700", "masterKey");
+        TasksHandler classToTest = new TasksHandler(config);
+        TasksQuery param = null;
+        TasksQuery query = classToTest.addIndexUidToQuery("indexName", param);
+
+        assertEquals("?indexUids=indexName", query.toQuery().toString());
+    }
+
+    @Test
+    void addIndexUidToQueryWithParam() {
+        final Config config = new Config("http://localhost:7700", "masterKey");
+        TasksHandler classToTest = new TasksHandler(config);
+        TasksQuery param = new TasksQuery().setIndexUids(new String[] {});
+        TasksQuery query = classToTest.addIndexUidToQuery("indexName", param);
+
+        assertEquals("?indexUids=indexName", query.toQuery().toString());
+    }
+
+    @Test
+    void addIndexUidToQueryWithOneIndexUid() {
+        final Config config = new Config("http://localhost:7700", "masterKey");
+        TasksHandler classToTest = new TasksHandler(config);
+        TasksQuery param = new TasksQuery().setIndexUids(new String[] {"indexName2"});
+        TasksQuery query = classToTest.addIndexUidToQuery("indexName1", param);
+
+        assertEquals("?indexUids=indexName2,indexName1", query.toQuery().toString());
+    }
+
+    @Test
+    void addIndexUidToQueryWithMultipleIndexUids() {
+        final Config config = new Config("http://localhost:7700", "masterKey");
+        TasksHandler classToTest = new TasksHandler(config);
+        TasksQuery param =
+                new TasksQuery()
+                        .setIndexUids(
+                                new String[] {
+                                    "indexName2", "indexName3", "indexName4", "indexName5"
+                                });
+        TasksQuery query = classToTest.addIndexUidToQuery("indexName1", param);
+
+        assertEquals(
+                "?indexUids=indexName2,indexName3,indexName4,indexName5,indexName1",
+                query.toQuery().toString());
+    }
+}

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -2,6 +2,8 @@ package com.meilisearch.sdk.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class URLBuilderTest {
@@ -51,7 +53,7 @@ public class URLBuilderTest {
     }
 
     @Test
-    void addParameterStringArray() {
+    void addParameterStringStringArray() {
         classToTest.addParameter("parameter1", new String[] {"1", "a"});
         assertEquals("?parameter1=1,a", classToTest.getParams().toString());
 
@@ -62,6 +64,44 @@ public class URLBuilderTest {
         assertEquals(
                 "?parameter1=1,a&parameter2=2,b&parameter3=3,c",
                 classToTest.getParams().toString());
+    }
+
+    @Test
+    void addParameterStringIntArray() {
+        classToTest.addParameter("parameter1", new int[] {1, 2});
+        assertEquals("?parameter1=1,2", classToTest.getParams().toString());
+
+        classToTest.addParameter("parameter2", new int[] {3, 4});
+        assertEquals("?parameter1=1,2&parameter2=3,4", classToTest.getParams().toString());
+
+        classToTest.addParameter("parameter3", new int[] {5, 6});
+        assertEquals(
+                "?parameter1=1,2&parameter2=3,4&parameter3=5,6",
+                classToTest.getParams().toString());
+    }
+
+    @Test
+    void addParameterStringDate() {
+        Date date = new Date();
+
+        classToTest.addParameter("parameter1", date);
+        String parameterDate1 =
+                classToTest
+                        .getParams()
+                        .toString()
+                        .substring(12, classToTest.getParams().toString().length());
+        assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate1));
+        assertTrue(classToTest.getParams().toString().contains("?parameter1="));
+
+        classToTest.addParameter("parameter2", date);
+        String parameterDate2 =
+                classToTest
+                        .getParams()
+                        .toString()
+                        .substring(34, classToTest.getParams().toString().length());
+        assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate2));
+        assertTrue(classToTest.getParams().toString().contains("?parameter1="));
+        assertTrue(classToTest.getParams().toString().contains("&parameter2="));
     }
 
     @Test

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -2,6 +2,7 @@ package com.meilisearch.sdk.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
@@ -81,8 +82,9 @@ public class URLBuilderTest {
     }
 
     @Test
-    void addParameterStringDate() {
-        Date date = new Date();
+    void addParameterStringDate() throws Exception {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date date = format.parse("2042-01-30");
 
         classToTest.addParameter("parameter1", date);
         String parameterDate1 =
@@ -91,7 +93,7 @@ public class URLBuilderTest {
                         .toString()
                         .substring(12, classToTest.getParams().toString().length());
         assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate1));
-        assertTrue(classToTest.getParams().toString().contains("?parameter1="));
+        assertEquals("?parameter1=2042-01-30", classToTest.getParams().toString());
 
         classToTest.addParameter("parameter2", date);
         String parameterDate2 =
@@ -100,8 +102,8 @@ public class URLBuilderTest {
                         .toString()
                         .substring(34, classToTest.getParams().toString().length());
         assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate2));
-        assertTrue(classToTest.getParams().toString().contains("?parameter1="));
-        assertTrue(classToTest.getParams().toString().contains("&parameter2="));
+        assertEquals(
+                "?parameter1=2042-01-30&parameter2=2042-01-30", classToTest.getParams().toString());
     }
 
     @Test


### PR DESCRIPTION
Add new filters on the `get /tasks` route.

Present in this [spec](https://github.com/meilisearch/specifications/pull/195)

V0.30.0
in TasksQuery:
  - [x] Add `uids`
  - [x] Add `CanceledBy`
  - [x] Add `BeforeEnqueuedAt`
  - [x] Add `AfterEnqueuedAt`
  - [x] Add `BeforeStartedAt`
  - [x] Add `AfterStatedAt`
  - [x] Add `BeforeFinishedAt`
  - [x] Add `AfterFinishedAt`
  - [x] Rename `status` to `statuses`
  - [x] Rename `type` to `types` 
  - [x] Rename `indexUid` to `indexUids`

Tests:
  - [x] `uid`
  - [x] `canceledBy`
  - [x] `beforeEnqueuedAt`

