### PR TITLE
Add cancel task api for v0.30.0

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -8,6 +8,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.json.JsonHandler;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Key;
 import com.meilisearch.sdk.model.KeyUpdate;
@@ -264,6 +265,18 @@ public class Client {
      */
     public TaskInfo cancelTasks(CancelTasksQuery param) throws MeilisearchException {
         return this.tasksHandler.cancelTasks(param);
+    }
+
+    /**
+     * Delete a finished (succeeded, failed, or canceled) task
+     * https://docs.meilisearch.com/reference/api/tasks.html#delete-tasks
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     */
+    public TaskInfo deleteTasks(DeleteTasksQuery param) throws MeilisearchException {
+        return this.tasksHandler.deleteTasks(param);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.json.JsonHandler;
+import com.meilisearch.sdk.model.CancelTasksQuery;
 import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Key;
 import com.meilisearch.sdk.model.KeyUpdate;
@@ -251,6 +252,18 @@ public class Client {
      */
     public TasksResults getTasks(TasksQuery param) throws MeilisearchException {
         return this.tasksHandler.getTasks(param);
+    }
+
+    /**
+     * Cancel any number of enqueued or processing tasks
+     * https://docs.meilisearch.com/reference/api/tasks.html#cancel-tasks
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     */
+    public TaskInfo cancelTasks(CancelTasksQuery param) throws MeilisearchException {
+        return this.tasksHandler.cancelTasks(param);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -3,7 +3,9 @@ package com.meilisearch.sdk;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.exceptions.MeilisearchTimeoutException;
 import com.meilisearch.sdk.http.URLBuilder;
+import com.meilisearch.sdk.model.CancelTasksQuery;
 import com.meilisearch.sdk.model.Task;
+import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
 import com.meilisearch.sdk.model.TasksResults;
 import java.util.Date;
@@ -97,6 +99,20 @@ public class TasksHandler {
 
         TasksResults result =
                 httpClient.get(tasksPath().addQuery(param.toQuery()).getURL(), TasksResults.class);
+        return result;
+    }
+
+    /**
+     * Delete tasks from the client
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if client request causes an error
+     */
+    TaskInfo cancelTasks(CancelTasksQuery param) throws MeilisearchException {
+        URLBuilder urlb = tasksPath().addSubroute("cancel");
+        TaskInfo result =
+                httpClient.post(urlb.addQuery(param.toQuery()).getURL(), null, TaskInfo.class);
         return result;
     }
 

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -4,6 +4,7 @@ import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.exceptions.MeilisearchTimeoutException;
 import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -113,6 +114,19 @@ public class TasksHandler {
         URLBuilder urlb = tasksPath().addSubroute("cancel");
         TaskInfo result =
                 httpClient.post(urlb.addQuery(param.toQuery()).getURL(), null, TaskInfo.class);
+        return result;
+    }
+
+    /**
+     * Delete tasks from the client
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if client request causes an error
+     */
+    TaskInfo deleteTasks(DeleteTasksQuery param) throws MeilisearchException {
+        TaskInfo result =
+                httpClient.delete(tasksPath().addQuery(param.toQuery()).getURL(), TaskInfo.class);
         return result;
     }
 

--- a/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
@@ -1,0 +1,41 @@
+package com.meilisearch.sdk.model;
+
+import com.meilisearch.sdk.http.URLBuilder;
+import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of a query parameter for tasks route
+ *
+ * <p>https://docs.meilisearch.com/reference/api/tasks.html#query-parameters
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class CancelTasksQuery {
+    private int[] uids;
+    private String[] statuses;
+    private String[] types;
+    private String[] indexUids;
+    private Date beforeEnqueuedAt;
+    private Date afterEnqueuedAt;
+    private Date beforeStartedAt;
+    private Date afterStartedAt;
+
+    public CancelTasksQuery() {}
+
+    public String toQuery() {
+        URLBuilder urlb =
+                new URLBuilder()
+                        .addParameter("statuses", this.getStatuses())
+                        .addParameter("types", this.getTypes())
+                        .addParameter("indexUids", this.getIndexUids())
+                        .addParameter("beforeEnqueuedAt", this.getBeforeEnqueuedAt())
+                        .addParameter("afterEnqueuedAt", this.getAfterEnqueuedAt())
+                        .addParameter("beforeStartedAt", this.getBeforeStartedAt())
+                        .addParameter("afterStartedAt", this.getAfterStartedAt());
+        return urlb.getURL();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
@@ -29,6 +29,7 @@ public class CancelTasksQuery {
     public String toQuery() {
         URLBuilder urlb =
                 new URLBuilder()
+                        .addParameter("uids", this.getUids())
                         .addParameter("statuses", this.getStatuses())
                         .addParameter("types", this.getTypes())
                         .addParameter("indexUids", this.getIndexUids())

--- a/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
@@ -1,0 +1,48 @@
+package com.meilisearch.sdk.model;
+
+import com.meilisearch.sdk.http.URLBuilder;
+import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of a query parameter for tasks route
+ *
+ * <p>https://docs.meilisearch.com/reference/api/tasks.html#query-parameters
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class DeleteTasksQuery {
+    private int[] uids;
+    private String[] statuses;
+    private String[] types;
+    private String[] indexUids;
+    private int[] canceledBy;
+    private Date beforeEnqueuedAt;
+    private Date afterEnqueuedAt;
+    private Date beforeStartedAt;
+    private Date afterStartedAt;
+    private Date beforeFinishedAt;
+    private Date afterFinishedAt;
+
+    public DeleteTasksQuery() {}
+
+    public String toQuery() {
+        URLBuilder urlb =
+                new URLBuilder()
+                        .addParameter("uids", this.getUids())
+                        .addParameter("statuses", this.getStatuses())
+                        .addParameter("types", this.getTypes())
+                        .addParameter("indexUids", this.getIndexUids())
+                        .addParameter("canceledBy", this.getCanceledBy())
+                        .addParameter("beforeEnqueuedAt", this.getBeforeEnqueuedAt())
+                        .addParameter("afterEnqueuedAt", this.getAfterEnqueuedAt())
+                        .addParameter("beforeStartedAt", this.getBeforeStartedAt())
+                        .addParameter("afterStartedAt", this.getAfterStartedAt())
+                        .addParameter("beforeFinishedAt", this.getBeforeFinishedAt())
+                        .addParameter("afterFinishedAt", this.getAfterFinishedAt());
+        return urlb.getURL();
+    }
+}

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -6,6 +6,7 @@ import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -152,6 +153,42 @@ public class TasksTest extends AbstractIT {
         assertNotEquals("", task.getStatus());
         assertNull(task.getIndexUid());
         assertEquals("taskCancelation", task.getType());
+    }
+
+    /** Test Delete Task */
+    @Test
+    public void testClientDeleteTask() throws Exception {
+        DeleteTasksQuery query =
+                new DeleteTasksQuery().setStatuses(new String[] {"enqueued", "succeeded"});
+
+        TaskInfo task = client.deleteTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskDeletion", task.getType());
+    }
+
+    /** Test Delete Task with multiple filters */
+    @Test
+    public void testClientDeleteTaskWithMultipleFilters() throws Exception {
+        Date date = new Date();
+        DeleteTasksQuery query =
+                new DeleteTasksQuery()
+                        .setUids(new int[] {0, 1, 2})
+                        .setStatuses(new String[] {"enqueued", "succeeded"})
+                        .setTypes(new String[] {"indexDeletion"})
+                        .setIndexUids(new String[] {"index"})
+                        .setBeforeEnqueuedAt(date);
+
+        TaskInfo task = client.deleteTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskDeletion", task.getType());
     }
 
     /** Test waitForTask */

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.model.CancelTasksQuery;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -115,6 +116,42 @@ public class TasksTest extends AbstractIT {
         assertEquals(limit, result.getLimit());
         assertNotNull(result.getFrom());
         assertNotNull(result.getNext());
+    }
+
+    /** Test Cancel Task */
+    @Test
+    public void testClientCancelTask() throws Exception {
+        CancelTasksQuery query =
+                new CancelTasksQuery().setStatuses(new String[] {"enqueued", "succeeded"});
+
+        TaskInfo task = client.cancelTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskCancelation", task.getType());
+    }
+
+    /** Test Cancel Task with multiple filters */
+    @Test
+    public void testClientCancelTaskWithMultipleFilters() throws Exception {
+        Date date = new Date();
+        CancelTasksQuery query =
+                new CancelTasksQuery()
+                        .setUids(new int[] {0, 1, 2})
+                        .setStatuses(new String[] {"enqueued", "succeeded"})
+                        .setTypes(new String[] {"indexDeletion"})
+                        .setIndexUids(new String[] {"index"})
+                        .setBeforeEnqueuedAt(date);
+
+        TaskInfo task = client.cancelTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskCancelation", task.getType());
     }
 
     /** Test waitForTask */


### PR DESCRIPTION
Add the cancel task api see spec:  https://github.com/meilisearch/specifications/pull/195

- [x] Implement `CancelTasks()` in the client
  - params: `CancelTasksQuery`
  - returns: `TaskInfo`
- [x] Tests cancelation on query parameters