### PR TITLE
Add delete task api for v0.30.0

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -8,6 +8,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.json.JsonHandler;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Key;
 import com.meilisearch.sdk.model.KeyUpdate;
@@ -264,6 +265,18 @@ public class Client {
      */
     public TaskInfo cancelTasks(CancelTasksQuery param) throws MeilisearchException {
         return this.tasksHandler.cancelTasks(param);
+    }
+
+    /**
+     * Delete a finished (succeeded, failed, or canceled) task
+     * https://docs.meilisearch.com/reference/api/tasks.html#delete-tasks
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     */
+    public TaskInfo deleteTasks(DeleteTasksQuery param) throws MeilisearchException {
+        return this.tasksHandler.deleteTasks(param);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -4,6 +4,7 @@ import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.exceptions.MeilisearchTimeoutException;
 import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -113,6 +114,19 @@ public class TasksHandler {
         URLBuilder urlb = tasksPath().addSubroute("cancel");
         TaskInfo result =
                 httpClient.post(urlb.addQuery(param.toQuery()).getURL(), null, TaskInfo.class);
+        return result;
+    }
+
+    /**
+     * Delete tasks from the client
+     *
+     * @param param accept by the tasks route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if client request causes an error
+     */
+    TaskInfo deleteTasks(DeleteTasksQuery param) throws MeilisearchException {
+        TaskInfo result =
+                httpClient.delete(tasksPath().addQuery(param.toQuery()).getURL(), TaskInfo.class);
         return result;
     }
 

--- a/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
@@ -1,0 +1,47 @@
+package com.meilisearch.sdk.model;
+
+import com.meilisearch.sdk.http.URLBuilder;
+import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of a query parameter for tasks route
+ *
+ * <p>https://docs.meilisearch.com/reference/api/tasks.html#query-parameters
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class DeleteTasksQuery {
+    private int[] uids;
+    private String[] statuses;
+    private String[] types;
+    private String[] indexUids;
+    private int[] canceledBy;
+    private Date beforeEnqueuedAt;
+    private Date afterEnqueuedAt;
+    private Date beforeStartedAt;
+    private Date afterStartedAt;
+    private Date beforeFinishedAt;
+    private Date afterFinishedAt;
+
+    public DeleteTasksQuery() {}
+
+    public String toQuery() {
+        URLBuilder urlb =
+                new URLBuilder()
+                        .addParameter("statuses", this.getStatuses())
+                        .addParameter("types", this.getTypes())
+                        .addParameter("indexUids", this.getIndexUids())
+                        .addParameter("canceledBy", this.getCanceledBy())
+                        .addParameter("beforeEnqueuedAt", this.getBeforeEnqueuedAt())
+                        .addParameter("afterEnqueuedAt", this.getAfterEnqueuedAt())
+                        .addParameter("beforeStartedAt", this.getBeforeStartedAt())
+                        .addParameter("afterStartedAt", this.getAfterStartedAt())
+                        .addParameter("beforeFinishedAt", this.getBeforeFinishedAt())
+                        .addParameter("afterFinishedAt", this.getAfterFinishedAt());
+        return urlb.getURL();
+    }
+}

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -6,6 +6,7 @@ import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.model.CancelTasksQuery;
+import com.meilisearch.sdk.model.DeleteTasksQuery;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -152,6 +153,42 @@ public class TasksTest extends AbstractIT {
         assertNotEquals("", task.getStatus());
         assertNull(task.getIndexUid());
         assertEquals("taskCancelation", task.getType());
+    }
+
+    /** Test Delete Task */
+    @Test
+    public void testClientDeleteTask() throws Exception {
+        DeleteTasksQuery query =
+                new DeleteTasksQuery().setStatuses(new String[] {"enqueued", "succeeded"});
+
+        TaskInfo task = client.deleteTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskDeletion", task.getType());
+    }
+
+    /** Test Delete Task with multiple filters */
+    @Test
+    public void testClientDeleteTaskWithMultipleFilters() throws Exception {
+        Date date = new Date();
+        DeleteTasksQuery query =
+                new DeleteTasksQuery()
+                        .setUids(new int[] {0, 1, 2})
+                        .setStatuses(new String[] {"enqueued", "succeeded"})
+                        .setTypes(new String[] {"indexDeletion"})
+                        .setIndexUids(new String[] {"index"})
+                        .setBeforeEnqueuedAt(date);
+
+        TaskInfo task = client.deleteTasks(query);
+
+        assertTrue(task instanceof TaskInfo);
+        assertNotNull(task.getStatus());
+        assertNotEquals("", task.getStatus());
+        assertNull(task.getIndexUid());
+        assertEquals("taskDeletion", task.getType());
     }
 
     /** Test waitForTask */


### PR DESCRIPTION
Add the delete task api see spec:  https://github.com/meilisearch/specifications/pull/198

- [x] Implement `DeleteTasks()` in the client
  - params: `DeleteTasksQuery`
  - returns: `TaskInfo`
- [x] Tests deletion on query parameters