### PR TITLE
Add swap indexes api for v0.30.0

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -15,6 +15,7 @@ import com.meilisearch.sdk.model.KeyUpdate;
 import com.meilisearch.sdk.model.KeysQuery;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.Stats;
+import com.meilisearch.sdk.model.SwapIndexesParams;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
@@ -164,6 +165,18 @@ public class Client {
      */
     public TaskInfo deleteIndex(String uid) throws MeilisearchException {
         return this.indexesHandler.deleteIndex(uid);
+    }
+
+    /**
+     * Swap the documents, settings, and task history of two or more indexes
+     * https://docs.meilisearch.com/reference/api/indexes.html#swap-indexes
+     *
+     * @param param accepted by the swap-indexes route
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     */
+    public TaskInfo swapIndexes(SwapIndexesParams[] param) throws MeilisearchException {
+        return config.httpClient.post("/swap-indexes", param, TaskInfo.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/model/SwapIndexesParams.java
+++ b/src/main/java/com/meilisearch/sdk/model/SwapIndexesParams.java
@@ -1,0 +1,15 @@
+package com.meilisearch.sdk.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/** Swap Indexes Params data structure */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class SwapIndexesParams {
+    protected String[] indexes;
+
+    public SwapIndexesParams() {}
+}

--- a/src/main/java/com/meilisearch/sdk/model/TaskDetails.java
+++ b/src/main/java/com/meilisearch/sdk/model/TaskDetails.java
@@ -27,6 +27,7 @@ public class TaskDetails {
     protected int canceledTasks;
     protected String originalFilter;
     protected int deletedTasks;
+    protected SwapIndexesParams[] swaps;
 
     public TaskDetails() {}
 }

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -11,6 +11,7 @@ import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.model.IndexesQuery;
 import com.meilisearch.sdk.model.Results;
+import com.meilisearch.sdk.model.SwapIndexesParams;
 import com.meilisearch.sdk.model.Task;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.utils.Movie;
@@ -199,6 +200,38 @@ public class ClientTest extends AbstractIT {
         client.waitForTask(task.getTaskUid());
 
         assertThrows(MeilisearchApiException.class, () -> client.getIndex(indexUid));
+    }
+
+    /** Test swapIndexes */
+    @Test
+    public void testSwapIndexes() throws Exception {
+        String indexUidA = "IndexA";
+        String indexUidB = "IndexB";
+        Index indexA = createEmptyIndex(indexUidA);
+        Index indexB = createEmptyIndex(indexUidB);
+        TaskInfo taskAddDocumentIndexA =
+                indexA.addDocuments(
+                        "[{"
+                                + "\"id\": 1,"
+                                + "\"title\": \"Document1\""
+                                + "},"
+                                + "{"
+                                + "\"id\": 2,"
+                                + "\"title\": \"Document2\""
+                                + "}]");
+        indexA.waitForTask(taskAddDocumentIndexA.getTaskUid());
+
+        SwapIndexesParams[] params =
+                new SwapIndexesParams[] {
+                    new SwapIndexesParams().setIndexes(new String[] {indexUidA, indexUidB})
+                };
+        TaskInfo task = client.swapIndexes(params);
+
+        assertEquals("indexSwap", task.getType());
+        assertEquals("Document1", indexB.getDocument("1", Movie.class).getTitle());
+        assertEquals("Document2", indexB.getDocument("2", Movie.class).getTitle());
+        assertThrows(MeilisearchApiException.class, () -> indexA.getDocument("1", Movie.class));
+        assertThrows(MeilisearchApiException.class, () -> indexA.getDocument("2", Movie.class));
     }
 
     /** Test call to index method with an inexistent index */


### PR DESCRIPTION
As [per the specification](https://github.com/meilisearch/specifications/pull/192)

## SWAP INDEXES

- [x] create `swapIndexesParams` type
- [x] create `swapIndexes` method in the client
    - params: TasksQuery
    - returns: TaskInfo
- [x] test to swap on indexes:
- [x] add `swaps` in task details
