### PR TITLE
Updated Readme.md - fixed maven-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add the following code to the `<dependencies>` section of your project:
   <groupId>com.meilisearch.sdk</groupId>
   <artifactId>meilisearch-java</artifactId>
   <version>0.11.0</version>
-  <type>pom</type>
+  <type>compile</type>
 </dependency>
 ```
 


### PR DESCRIPTION
Changed dependecy-type from "pom" to "compile" in readme - when using pom it will only add the dependecies declared in the meilisearch-java-pom, but not the SDK itself. Below the definition for gradle uses "implementation", this means "compile" in Maven-Slang. To afford the same goal (use the SDK in the project), it should be compile, not only pom.

# Pull Request

## Related issue
none

## What does this PR do?
- changes documentation for using SDK with maven

