### PR TITLE
Add explicitly requirement of okhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Add the following line to the `dependencies` section of your `build.gradle`:
 implementation 'com.meilisearch.sdk:meilisearch-java:0.11.0'
 ```
 
+:warning: `meilisearch-java` also requires `okhttp` as a peer dependency.
+
 ### Run Meilisearch <!-- omit in toc -->
 
 There are many easy ways to [download and run a Meilisearch instance](https://docs.meilisearch.com/reference/features/installation.html#download-and-launch).

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'org.json:json:20230227'
 	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-	compileOnly 'com.squareup.okhttp3:okhttp:4.10.0'
+	api 'com.squareup.okhttp3:okhttp:[4.10.0,5.0.0)'
 
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.9.2'))


### PR DESCRIPTION
Since the reported error is just a misconfiguration, I believe we can fix it by always making the lib required since that's true after the refactor #425.

Fix #580 