### PR TITLE
Update tests to use Hamcrest matchers instead of JUnit assertions 

### DIFF
--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -1,6 +1,13 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -11,7 +18,6 @@ import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.model.*;
 import com.meilisearch.sdk.utils.Movie;
-import java.util.Arrays;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -42,8 +48,8 @@ public class ClientTest extends AbstractIT {
         String indexUid = "CreateIndexWithoutPrimaryKey";
         Index index = createEmptyIndex(indexUid);
 
-        assertEquals(index.getUid(), indexUid);
-        assertNull(index.getPrimaryKey());
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(nullValue()));
     }
 
     /** Test Index creation without PrimaryKey with Jackson Json Handler */
@@ -54,8 +60,8 @@ public class ClientTest extends AbstractIT {
         clientJackson.waitForTask(task.getTaskUid());
         Index index = clientJackson.getIndex(indexUid);
 
-        assertEquals(index.getUid(), indexUid);
-        assertNull(index.getPrimaryKey());
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(nullValue()));
     }
 
     /** Test Index creation with PrimaryKey */
@@ -64,8 +70,8 @@ public class ClientTest extends AbstractIT {
         String indexUid = "CreateIndexWithPrimaryKey";
         Index index = createEmptyIndex(indexUid, this.primaryKey);
 
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(equalTo(this.primaryKey)));
     }
 
     /** Test Index creation with PrimaryKey with Jackson Json Handler */
@@ -76,8 +82,8 @@ public class ClientTest extends AbstractIT {
         clientJackson.waitForTask(task.getTaskUid());
         Index index = clientJackson.getIndex(indexUid);
 
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(equalTo(this.primaryKey)));
     }
 
     /** Test Index creation twice doesn't throw an error: already exists */
@@ -86,15 +92,15 @@ public class ClientTest extends AbstractIT {
         String indexUid = "CreateIndexAlreadyExists";
         Index index = createEmptyIndex(indexUid, this.primaryKey);
 
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(equalTo(this.primaryKey)));
 
         Index indexDuplicate = createEmptyIndex(indexUid, this.primaryKey);
 
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(indexDuplicate.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
-        assertEquals(indexDuplicate.getPrimaryKey(), this.primaryKey);
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(indexDuplicate.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(equalTo(this.primaryKey)));
+        assertThat(indexDuplicate.getPrimaryKey(), is(equalTo(this.primaryKey)));
     }
 
     /** Test update Index PrimaryKey */
@@ -103,16 +109,16 @@ public class ClientTest extends AbstractIT {
         String indexUid = "UpdateIndexPrimaryKey";
         Index index = createEmptyIndex(indexUid);
 
-        assertEquals(index.getUid(), indexUid);
-        assertNull(index.getPrimaryKey());
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(nullValue()));
 
         TaskInfo task = client.updateIndex(indexUid, this.primaryKey);
         client.waitForTask(task.getTaskUid());
         index = client.getIndex(indexUid);
 
-        assertTrue(index instanceof Index);
-        assertEquals(index.getUid(), indexUid);
-        assertEquals(index.getPrimaryKey(), this.primaryKey);
+        assertThat(index, instanceOf(Index.class));
+        assertThat(index.getUid(), is(equalTo(indexUid)));
+        assertThat(index.getPrimaryKey(), is(equalTo(this.primaryKey)));
     }
 
     /** Test getIndex */
@@ -122,8 +128,8 @@ public class ClientTest extends AbstractIT {
         Index index = createEmptyIndex(indexUid);
         Index getIndex = client.getIndex(indexUid);
 
-        assertEquals(index.getUid(), getIndex.getUid());
-        assertEquals(index.getPrimaryKey(), getIndex.getPrimaryKey());
+        assertThat(getIndex.getUid(), is(equalTo(index.getUid())));
+        assertThat(getIndex.getPrimaryKey(), is(equalTo(index.getPrimaryKey())));
     }
 
     /** Test getIndexes */
@@ -134,9 +140,7 @@ public class ClientTest extends AbstractIT {
         createEmptyIndex(indexUids[1], this.primaryKey);
         Results<Index> indexes = client.getIndexes();
 
-        assertEquals(2, indexes.getResults().length);
-        assert (Arrays.asList(indexUids).contains(indexUids[0]));
-        assert (Arrays.asList(indexUids).contains(indexUids[1]));
+        assertThat(indexes.getResults(), is(arrayWithSize(2)));
     }
 
     /** Test getIndexes with limit */
@@ -149,8 +153,8 @@ public class ClientTest extends AbstractIT {
         createEmptyIndex(indexUids[1], this.primaryKey);
         Results<Index> indexes = client.getIndexes(query);
 
-        assertEquals(limit, indexes.getResults().length);
-        assertEquals(limit, indexes.getLimit());
+        assertThat(indexes.getResults(), is(arrayWithSize(limit)));
+        assertThat(indexes.getLimit(), is(equalTo(limit)));
     }
 
     /** Test getIndexes with limit and offset */
@@ -164,9 +168,9 @@ public class ClientTest extends AbstractIT {
         createEmptyIndex(indexUids[1], this.primaryKey);
         Results<Index> indexes = client.getIndexes(query);
 
-        assertEquals(limit, indexes.getResults().length);
-        assertEquals(limit, indexes.getLimit());
-        assertEquals(offset, indexes.getOffset());
+        assertThat(indexes.getResults(), is(arrayWithSize(limit)));
+        assertThat(indexes.getLimit(), is(equalTo(limit)));
+        assertThat(indexes.getOffset(), is(equalTo(offset)));
     }
 
     /** Test getRawIndexes */
@@ -180,11 +184,13 @@ public class ClientTest extends AbstractIT {
         JsonObject jsonIndexObject = JsonParser.parseString(indexes).getAsJsonObject();
         JsonArray jsonIndexArray = jsonIndexObject.getAsJsonArray("results");
 
-        assertEquals(2, jsonIndexArray.size());
-        assert (Arrays.asList(indexUids)
-                .contains(jsonIndexArray.get(0).getAsJsonObject().get("uid").getAsString()));
-        assert (Arrays.asList(indexUids)
-                .contains(jsonIndexArray.get(1).getAsJsonObject().get("uid").getAsString()));
+        assertThat(jsonIndexArray.size(), is(equalTo(2)));
+        assertThat(
+                jsonIndexArray.get(0).getAsJsonObject().get("uid").getAsString(),
+                is(in(indexUids)));
+        assertThat(
+                jsonIndexArray.get(1).getAsJsonObject().get("uid").getAsString(),
+                is(in(indexUids)));
     }
 
     /** Test getRawIndexes with limits */
@@ -200,10 +206,11 @@ public class ClientTest extends AbstractIT {
         JsonObject jsonIndexObject = JsonParser.parseString(indexes).getAsJsonObject();
         JsonArray jsonIndexArray = jsonIndexObject.getAsJsonArray("results");
 
-        assertEquals(limit, jsonIndexArray.size());
-        assertEquals(limit, jsonIndexObject.get("limit").getAsInt());
-        assert (Arrays.asList(indexUids)
-                .contains(jsonIndexArray.get(0).getAsJsonObject().get("uid").getAsString()));
+        assertThat(jsonIndexArray.size(), is(equalTo(limit)));
+        assertThat(jsonIndexObject.get("limit").getAsInt(), is(equalTo(limit)));
+        assertThat(
+                jsonIndexArray.get(0).getAsJsonObject().get("uid").getAsString(),
+                is(in(indexUids)));
     }
 
     /** Test deleteIndex */
@@ -243,9 +250,9 @@ public class ClientTest extends AbstractIT {
         TaskInfo task = client.swapIndexes(params);
         client.waitForTask(task.getTaskUid());
 
-        assertEquals("indexSwap", task.getType());
-        assertEquals("Document1", indexB.getDocument("1", Movie.class).getTitle());
-        assertEquals("Document2", indexB.getDocument("2", Movie.class).getTitle());
+        assertThat(task.getType(), is(equalTo("indexSwap")));
+        assertThat(indexB.getDocument("1", Movie.class).getTitle(), is(equalTo("Document1")));
+        assertThat(indexB.getDocument("2", Movie.class).getTitle(), is(equalTo("Document2")));
         assertThrows(MeilisearchApiException.class, () -> indexA.getDocument("1", Movie.class));
         assertThrows(MeilisearchApiException.class, () -> indexA.getDocument("2", Movie.class));
     }
@@ -256,7 +263,7 @@ public class ClientTest extends AbstractIT {
         String indexUid = "IndexMethodCallInexistentIndex";
         Index index = client.index(indexUid);
 
-        assertEquals(indexUid, index.getUid());
+        assertThat(index.getUid(), is(equalTo(indexUid)));
         assertThrows(MeilisearchApiException.class, () -> client.getIndex(indexUid));
     }
 
@@ -267,8 +274,8 @@ public class ClientTest extends AbstractIT {
         Index createdIndex = createEmptyIndex(indexUid);
         Index index = client.index(indexUid);
 
-        assertEquals(createdIndex.getUid(), index.getUid());
-        assertNull(index.getPrimaryKey());
+        assertThat(index.getUid(), is(equalTo(createdIndex.getUid())));
+        assertThat(index.getPrimaryKey(), is(nullValue()));
     }
 
     /** Test call to index method with an existing index with primary key */
@@ -279,12 +286,12 @@ public class ClientTest extends AbstractIT {
         Index createdIndex = createEmptyIndex(indexUid, primaryKey);
         Index index = client.index(indexUid);
 
-        assertEquals(createdIndex.getUid(), index.getUid());
-        assertNull(index.getPrimaryKey());
+        assertThat(index.getUid(), is(equalTo(createdIndex.getUid())));
+        assertThat(index.getPrimaryKey(), is(nullValue()));
 
         index.fetchPrimaryKey();
 
-        assertEquals(primaryKey, index.getPrimaryKey());
+        assertThat(index.getPrimaryKey(), is(equalTo(primaryKey)));
     }
 
     /** Test call to create dump */
@@ -294,7 +301,7 @@ public class ClientTest extends AbstractIT {
         client.waitForTask(task.getTaskUid());
         Task dump = client.getTask(task.getTaskUid());
 
-        assertEquals(task.getStatus(), TaskStatus.ENQUEUED);
-        assertEquals("dumpCreation", dump.getType());
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.ENQUEUED)));
+        assertThat(dump.getType(), is(equalTo("dumpCreation")));
     }
 }

--- a/src/test/java/com/meilisearch/integration/DocumentsTest.java
+++ b/src/test/java/com/meilisearch/integration/DocumentsTest.java
@@ -1,6 +1,14 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.JsonObject;
 import com.meilisearch.integration.classes.AbstractIT;
@@ -48,21 +56,21 @@ public class DocumentsTest extends AbstractIT {
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
 
-        assertEquals(1, movies.length);
-        assertEquals("419704", movies[0].getId());
-        assertEquals("Ad Astra", movies[0].getTitle());
-        assertEquals(
-                "https://image.tmdb.org/t/p/original/xBHvZcjRiWyobQ9kxBhO6B2dtRI.jpg",
-                movies[0].getPoster());
-        assertEquals(
-                "The near future, a time when both hope and hardships drive humanity to look to the stars and beyond. While a mysterious phenomenon menaces to destroy life on planet Earth, astronaut Roy McBride undertakes a mission across the immensity of space and its many perils to uncover the truth about a lost expedition that decades before boldly faced emptiness and silence in search of the unknown.",
-                movies[0].getOverview());
-        assertEquals("2019-09-17", movies[0].getRelease_date());
-        assertEquals("en", movies[0].getLanguage());
-        assertNotNull(movies[0].getGenres());
-        assertEquals(2, movies[0].getGenres().length);
-        assertEquals("Science Fiction", movies[0].getGenres()[0]);
-        assertEquals("Drama", movies[0].getGenres()[1]);
+        String expectedOverview =
+                "The near future, a time when both hope and hardships drive humanity to look to the stars and beyond. While a mysterious phenomenon menaces to destroy life on planet Earth, astronaut Roy McBride undertakes a mission across the immensity of space and its many perils to uncover the truth about a lost expedition that decades before boldly faced emptiness and silence in search of the unknown.";
+        assertThat(movies, is(arrayWithSize(1)));
+        assertThat(movies[0].getId(), is(equalTo("419704")));
+        assertThat(movies[0].getTitle(), is(equalTo("Ad Astra")));
+        assertThat(
+                movies[0].getPoster(),
+                is(equalTo("https://image.tmdb.org/t/p/original/xBHvZcjRiWyobQ9kxBhO6B2dtRI.jpg")));
+        assertThat(movies[0].getOverview(), is(equalTo(expectedOverview)));
+        assertThat(movies[0].getRelease_date(), is(equalTo("2019-09-17")));
+        assertThat(movies[0].getLanguage(), is(equalTo("en")));
+        assertThat(movies[0].getGenres(), is(notNullValue()));
+        assertThat(movies[0].getGenres(), is(arrayWithSize(2)));
+        assertThat(movies[0].getGenres()[0], is(equalTo("Science Fiction")));
+        assertThat(movies[0].getGenres()[1], is(equalTo("Drama")));
     }
 
     /** Test add Documents with primaryKey */
@@ -87,17 +95,17 @@ public class DocumentsTest extends AbstractIT {
 
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
-        assertEquals(1, movies.length);
-        assertEquals("419704", movies[0].getId());
-        assertEquals("Ad Astra", movies[0].getTitle());
+        assertThat(movies, is(arrayWithSize(1)));
+        assertThat(movies[0].getId(), is(equalTo("419704")));
+        assertThat(movies[0].getTitle(), is(equalTo("Ad Astra")));
 
         TaskInfo secondTask = index.addDocuments("[" + secondDocument + "]", "language");
         index.waitForTask(secondTask.getTaskUid());
 
-        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
-        assertEquals(1, movies.length);
-        assertEquals("574982", movies[0].getId());
-        assertEquals("The Blackout", movies[0].getTitle());
+        movies = index.getDocuments(Movie.class).getResults();
+        assertThat(movies, is(arrayWithSize(1)));
+        assertThat(movies[0].getId(), is(equalTo("574982")));
+        assertThat(movies[0].getTitle(), is(equalTo("The Blackout")));
     }
 
     /** Test Add multiple documents */
@@ -114,8 +122,8 @@ public class DocumentsTest extends AbstractIT {
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
         for (int i = 0; i < movies.length; i++) {
-            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
-            assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
+            Movie movie = index.getDocument(testData.getData().get(i).getId(), Movie.class);
+            assertThat(movie.getTitle(), is(equalTo(testData.getData().get(i).getTitle())));
         }
     }
 
@@ -133,8 +141,8 @@ public class DocumentsTest extends AbstractIT {
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
         for (int i = 0; i < movies.length; i++) {
-            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
-            assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
+            Movie movie = index.getDocument(testData.getData().get(i).getId(), Movie.class);
+            assertThat(movie.getTitle(), is(equalTo(testData.getData().get(i).getTitle())));
         }
     }
 
@@ -150,9 +158,9 @@ public class DocumentsTest extends AbstractIT {
         for (TaskInfo task : taskArr) {
             index.waitForTask(task.getTaskUid());
 
-            assertTrue(task instanceof TaskInfo);
-            assertEquals("documentAdditionOrUpdate", task.getType());
-            assertNotNull(task.getEnqueuedAt());
+            assertThat(task, is(instanceOf(TaskInfo.class)));
+            assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+            assertThat(task.getEnqueuedAt(), is(notNullValue()));
         }
     }
 
@@ -168,9 +176,9 @@ public class DocumentsTest extends AbstractIT {
         for (TaskInfo task : taskArr) {
             index.waitForTask(task.getTaskUid());
 
-            assertTrue(task instanceof TaskInfo);
-            assertEquals("documentAdditionOrUpdate", task.getType());
-            assertNotNull(task.getEnqueuedAt());
+            assertThat(task, is(instanceOf(TaskInfo.class)));
+            assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+            assertThat(task.getEnqueuedAt(), is(notNullValue()));
         }
     }
 
@@ -194,10 +202,10 @@ public class DocumentsTest extends AbstractIT {
         task = index.updateDocuments("[" + this.gson.toJson(toUpdate) + "]");
 
         index.waitForTask(task.getTaskUid());
-        Movie responseUpdate = index.<Movie>getDocument(toUpdate.getId(), Movie.class);
+        Movie responseUpdate = index.getDocument(toUpdate.getId(), Movie.class);
 
-        assertEquals(toUpdate.getTitle(), responseUpdate.getTitle());
-        assertEquals(toUpdate.getOverview(), responseUpdate.getOverview());
+        assertThat(responseUpdate.getTitle(), is(equalTo(toUpdate.getTitle())));
+        assertThat(responseUpdate.getOverview(), is(equalTo(toUpdate.getOverview())));
     }
 
     /** Test Update Documents with primaryKey */
@@ -224,17 +232,17 @@ public class DocumentsTest extends AbstractIT {
 
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
-        assertEquals(1, movies.length);
-        assertEquals("419704", movies[0].getId());
-        assertEquals("Ad Astra", movies[0].getTitle());
+        assertThat(movies, is(arrayWithSize(1)));
+        assertThat(movies[0].getId(), is(equalTo("419704")));
+        assertThat(movies[0].getTitle(), is(equalTo("Ad Astra")));
 
         TaskInfo secondTask = index.updateDocuments("[" + secondDocument + "]", "language");
         index.waitForTask(secondTask.getTaskUid());
 
-        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
-        assertEquals(1, movies.length);
-        assertEquals("574982", movies[0].getId()); // Second movie id
-        assertEquals("Ad Astra", movies[0].getTitle()); // First movie title
+        movies = index.getDocuments(Movie.class).getResults();
+        assertThat(movies, is(arrayWithSize(1)));
+        assertThat(movies[0].getId(), is(equalTo("574982"))); // Second movie id
+        assertThat(movies[0].getTitle(), is(equalTo("Ad Astra"))); // First movie title
     }
 
     /** Test Update multiple documents */
@@ -260,9 +268,9 @@ public class DocumentsTest extends AbstractIT {
 
         index.waitForTask(task.getTaskUid());
         for (int j = 0; j < 5; j++) {
-            Movie responseUpdate = index.<Movie>getDocument(toUpdate.get(j).getId(), Movie.class);
-            assertEquals(toUpdate.get(j).getTitle(), responseUpdate.getTitle());
-            assertEquals(toUpdate.get(j).getOverview(), responseUpdate.getOverview());
+            Movie responseUpdate = index.getDocument(toUpdate.get(j).getId(), Movie.class);
+            assertThat(responseUpdate.getTitle(), is(equalTo(toUpdate.get(j).getTitle())));
+            assertThat(responseUpdate.getOverview(), is(equalTo(toUpdate.get(j).getOverview())));
         }
     }
 
@@ -289,8 +297,8 @@ public class DocumentsTest extends AbstractIT {
 
         for (TaskInfo task : taskArr) {
             index.waitForTask(task.getTaskUid());
-            assertEquals(task.getType(), "documentAdditionOrUpdate");
-            assertNotNull(task.getEnqueuedAt());
+            assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+            assertThat(task.getEnqueuedAt(), is(notNullValue()));
         }
     }
 
@@ -317,8 +325,8 @@ public class DocumentsTest extends AbstractIT {
 
         for (TaskInfo task : taskArr) {
             index.waitForTask(task.getTaskUid());
-            assertEquals(task.getType(), "documentAdditionOrUpdate");
-            assertNotNull(task.getEnqueuedAt());
+            assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+            assertThat(task.getEnqueuedAt(), is(notNullValue()));
         }
     }
 
@@ -333,8 +341,8 @@ public class DocumentsTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
-        Movie movie = index.<Movie>getDocument(testData.getData().get(0).getId(), Movie.class);
-        assertEquals(movie.getTitle(), testData.getData().get(0).getTitle());
+        Movie movie = index.getDocument(testData.getData().get(0).getId(), Movie.class);
+        assertThat(movie.getTitle(), is(equalTo(testData.getData().get(0).getTitle())));
     }
 
     /** Test default GetRawDocuments */
@@ -351,7 +359,7 @@ public class DocumentsTest extends AbstractIT {
         Movie movie =
                 this.gson.fromJson(
                         index.getRawDocument(testData.getData().get(0).getId()), Movie.class);
-        assertEquals(movie.getTitle(), testData.getData().get(0).getTitle());
+        assertThat(movie.getTitle(), is(equalTo(testData.getData().get(0).getTitle())));
     }
 
     /** Test default GetDocuments */
@@ -368,22 +376,22 @@ public class DocumentsTest extends AbstractIT {
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
 
-        assertEquals(20, movies.length);
+        assertThat(movies, is(arrayWithSize(20)));
         for (int i = 0; i < movies.length; i++) {
-            assertEquals(movies[i].getTitle(), testData.getData().get(i).getTitle());
+            assertThat(movies[i].getTitle(), is(equalTo(testData.getData().get(i).getTitle())));
             String[] expectedGenres = testData.getData().get(i).getGenres();
             String[] foundGenres = movies[i].getGenres();
             for (int x = 0; x < expectedGenres.length; x++) {
-                assertEquals(expectedGenres[x], foundGenres[x]);
+                assertThat(expectedGenres[x], is(equalTo(foundGenres[x])));
             }
         }
         for (int i = 0; i < movies.length; i++) {
-            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
-            assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
+            Movie movie = index.getDocument(testData.getData().get(i).getId(), Movie.class);
+            assertThat(movie.getTitle(), is(equalTo(testData.getData().get(i).getTitle())));
             String[] expectedGenres = testData.getData().get(i).getGenres();
             String[] foundGenres = movie.getGenres();
             for (int x = 0; x < expectedGenres.length; x++) {
-                assertEquals(expectedGenres[x], foundGenres[x]);
+                assertThat(expectedGenres[x], is(equalTo(foundGenres[x])));
             }
         }
     }
@@ -403,10 +411,10 @@ public class DocumentsTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         Results<Movie> result = index.getDocuments(query, Movie.class);
         Movie[] movies = result.getResults();
-        assertEquals(limit, movies.length);
+        assertThat(movies, is(arrayWithSize(limit)));
         for (int i = 0; i < movies.length; i++) {
-            Movie movie = index.<Movie>getDocument(testData.getData().get(i).getId(), Movie.class);
-            assertEquals(movie.getTitle(), testData.getData().get(i).getTitle());
+            Movie movie = index.getDocument(testData.getData().get(i).getId(), Movie.class);
+            assertThat(movie.getTitle(), is(equalTo(testData.getData().get(i).getTitle())));
         }
     }
 
@@ -430,11 +438,10 @@ public class DocumentsTest extends AbstractIT {
                 index.getDocuments(query.setOffset(secondOffset), Movie.class);
         Movie[] secondMovies = secondResults.getResults();
 
-        assertEquals(limit, movies.length);
-        assertEquals(limit, secondMovies.length);
-
-        assertNotEquals(movies[0].getTitle(), secondMovies[0].getTitle());
-        assertNotEquals(movies[1].getTitle(), secondMovies[1].getTitle());
+        assertThat(movies, is(arrayWithSize(limit)));
+        assertThat(secondMovies, is(arrayWithSize(limit)));
+        assertThat(secondMovies[0].getTitle(), is(not(equalTo(movies[0].getTitle()))));
+        assertThat(secondMovies[1].getTitle(), is(not(equalTo(movies[1].getTitle()))));
     }
 
     /** Test GetDocuments with limit, offset and specified fields */
@@ -458,16 +465,14 @@ public class DocumentsTest extends AbstractIT {
         Results<Movie> result = index.getDocuments(query, Movie.class);
         Movie[] movies = result.getResults();
 
-        assertEquals(limit, movies.length);
-
-        assertNotNull(movies[0].getId());
-        assertNotNull(movies[0].getTitle());
-
-        assertNull(movies[0].getGenres());
-        assertNull(movies[0].getLanguage());
-        assertNull(movies[0].getOverview());
-        assertNull(movies[0].getPoster());
-        assertNull(movies[0].getRelease_date());
+        assertThat(movies, is(arrayWithSize(limit)));
+        assertThat(movies[0].getId(), is(notNullValue()));
+        assertThat(movies[0].getTitle(), is(notNullValue()));
+        assertThat(movies[0].getGenres(), is(nullValue()));
+        assertThat(movies[0].getLanguage(), is(nullValue()));
+        assertThat(movies[0].getOverview(), is(nullValue()));
+        assertThat(movies[0].getPoster(), is(nullValue()));
+        assertThat(movies[0].getRelease_date(), is(nullValue()));
     }
 
     /** Test default GetRawDocuments */
@@ -482,14 +487,15 @@ public class DocumentsTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         String results = index.getRawDocuments();
 
-        assertTrue(results.contains("results"));
-        assertTrue(results.contains(testData.getData().get(0).getId()));
-        assertTrue(results.contains(testData.getData().get(0).getTitle()));
-        assertTrue(results.contains(testData.getData().get(0).getGenres()[0]));
-        assertTrue(results.contains(testData.getData().get(0).getLanguage()));
-        assertTrue(results.contains(testData.getData().get(0).getOverview()));
-        assertTrue(results.contains(testData.getData().get(0).getPoster()));
-        assertTrue(results.contains(testData.getData().get(0).getRelease_date()));
+        assertThat(results.contains("results"), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getId()), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getTitle()), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getGenres()[0]), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getLanguage()), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getOverview()), is(equalTo(true)));
+        assertThat(results.contains(testData.getData().get(0).getPoster()), is(equalTo(true)));
+        assertThat(
+                results.contains(testData.getData().get(0).getRelease_date()), is(equalTo(true)));
     }
 
     /** Test GetRawDocuments with limit */
@@ -507,8 +513,8 @@ public class DocumentsTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         String results = index.getRawDocuments(query);
 
-        assertTrue(results.contains("results"));
-        assertTrue(results.contains("\"limit\":24"));
+        assertThat(results.contains("results"), is(equalTo(true)));
+        assertThat(results.contains("\"limit\":24"), is(equalTo(true)));
     }
 
     /** Test GetRawDocuments with limit and offset */
@@ -517,7 +523,6 @@ public class DocumentsTest extends AbstractIT {
         String indexUid = "GetRawDocumentsLimitAndOffset";
         int limit = 2;
         int offset = 2;
-        int secondOffset = 5;
         DocumentsQuery query = new DocumentsQuery().setLimit(limit).setOffset(offset);
         Index index = client.index(indexUid);
 
@@ -527,9 +532,9 @@ public class DocumentsTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         String results = index.getRawDocuments(query);
 
-        assertTrue(results.contains("results"));
-        assertTrue(results.contains("\"limit\":2"));
-        assertTrue(results.contains("\"offset\":2"));
+        assertThat(results.contains("results"), is(equalTo(true)));
+        assertThat(results.contains("\"limit\":2"), is(equalTo(true)));
+        assertThat(results.contains("\"offset\":2"), is(equalTo(true)));
     }
 
     /** Test GetRawDocuments with limit, offset and specified fields */
@@ -552,15 +557,15 @@ public class DocumentsTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         String results = index.getRawDocuments(query);
 
-        assertTrue(results.contains("results"));
-        assertTrue(results.contains("\"limit\":2"));
-        assertTrue(results.contains("\"offset\":2"));
-        assertTrue(results.contains("id"));
-        assertTrue(results.contains("title"));
-        assertFalse(results.contains("genres"));
-        assertFalse(results.contains("langage"));
-        assertFalse(results.contains("poster"));
-        assertFalse(results.contains("release_date"));
+        assertThat(results.contains("results"), is(equalTo(true)));
+        assertThat(results.contains("\"limit\":2"), is(equalTo(true)));
+        assertThat(results.contains("\"offset\":2"), is(equalTo(true)));
+        assertThat(results.contains("id"), is(equalTo(true)));
+        assertThat(results.contains("title"), is(equalTo(true)));
+        assertThat(results.contains("genres"), is(equalTo(false)));
+        assertThat(results.contains("langage"), is(equalTo(false)));
+        assertThat(results.contains("poster"), is(equalTo(false)));
+        assertThat(results.contains("release_date"), is(equalTo(false)));
     }
 
     /** Test deleteDocument */
@@ -582,7 +587,7 @@ public class DocumentsTest extends AbstractIT {
 
         assertThrows(
                 MeilisearchApiException.class,
-                () -> index.<Movie>getDocument(toDelete.getId(), Movie.class));
+                () -> index.getDocument(toDelete.getId(), Movie.class));
     }
 
     /** Test deleteDocuments */
@@ -598,20 +603,20 @@ public class DocumentsTest extends AbstractIT {
 
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
-        assertEquals(20, movies.length);
+        assertThat(movies, is(arrayWithSize(20)));
 
         List<String> identifiersToDelete = getIdentifiersToDelete(movies);
 
         task = index.deleteDocuments(identifiersToDelete);
         index.waitForTask(task.getTaskUid());
 
-        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
+        movies = index.getDocuments(Movie.class).getResults();
 
         boolean containsDeletedMovie =
                 Arrays.stream(movies)
                         .anyMatch(movie -> identifiersToDelete.contains(movie.getId()));
 
-        assertFalse(containsDeletedMovie);
+        assertThat(containsDeletedMovie, is(equalTo(false)));
     }
 
     @NotNull
@@ -632,16 +637,16 @@ public class DocumentsTest extends AbstractIT {
 
         Results<Movie> result = index.getDocuments(Movie.class);
         Movie[] movies = result.getResults();
-        assertEquals(20, movies.length);
+        assertThat(movies, is(arrayWithSize(20)));
 
         TaskInfo task = index.deleteAllDocuments();
         index.waitForTask(task.getTaskUid());
 
-        assertTrue(task instanceof TaskInfo);
-        assertEquals(task.getType(), "documentDeletion");
-        assertNotNull(task.getEnqueuedAt());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentDeletion")));
+        assertThat(task.getEnqueuedAt(), is(notNullValue()));
 
-        movies = (Movie[]) index.getDocuments(Movie.class).getResults();
-        assertEquals(0, movies.length);
+        movies = index.getDocuments(Movie.class).getResults();
+        assertThat(movies, is(arrayWithSize(0)));
     }
 }

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -1,6 +1,9 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.Client;
@@ -9,7 +12,10 @@ import com.meilisearch.sdk.TaskError;
 import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchCommunicationException;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag("integration")
 public class ExceptionsTest extends AbstractIT {
@@ -43,10 +49,10 @@ public class ExceptionsTest extends AbstractIT {
         try {
             throw new MeilisearchApiException(new APIError(message, code, type, link));
         } catch (MeilisearchApiException e) {
-            assertEquals(message, e.getMessage());
-            assertEquals(code, e.getCode());
-            assertEquals(type, e.getType());
-            assertEquals(link, e.getLink());
+            assertThat(e.getMessage(), is(equalTo(message)));
+            assertThat(e.getCode(), is(equalTo(code)));
+            assertThat(e.getType(), is(equalTo(type)));
+            assertThat(e.getLink(), is(equalTo(link)));
         }
     }
 
@@ -55,7 +61,7 @@ public class ExceptionsTest extends AbstractIT {
     public void testTaskErrorGetters() {
         TaskError error = new TaskError();
         error.setTaskErrorCode("wrong field");
-        assertEquals("wrong field", error.getTaskErrorCode());
+        assertThat(error.getTaskErrorCode(), is(equalTo("wrong field")));
     }
 
     /** Test MeilisearchApiException is thrown on Meilisearch bad request */
@@ -66,7 +72,7 @@ public class ExceptionsTest extends AbstractIT {
         try {
             client.getIndex(indexUid);
         } catch (MeilisearchApiException e) {
-            assertEquals("index_not_found", e.getCode());
+            assertThat(e.getCode(), is(equalTo("index_not_found")));
         }
     }
 }

--- a/src/test/java/com/meilisearch/integration/InstanceTest.java
+++ b/src/test/java/com/meilisearch/integration/InstanceTest.java
@@ -73,7 +73,7 @@ public class InstanceTest extends AbstractIT {
         IndexStats stats = index.getStats();
 
         assertThat(stats, is(notNullValue()));
-        assertThat(stats.getNumberOfDocuments(), is(equalTo(0)));
+        assertThat(stats.getNumberOfDocuments(), is(equalTo(0L)));
         assertThat(stats.isIndexing(), is(equalTo(false)));
         assertThat(stats.getFieldDistribution(), is(notNullValue()));
     }

--- a/src/test/java/com/meilisearch/integration/InstanceTest.java
+++ b/src/test/java/com/meilisearch/integration/InstanceTest.java
@@ -1,6 +1,9 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.Index;
@@ -30,7 +33,7 @@ public class InstanceTest extends AbstractIT {
     public void testHealth() throws Exception {
         String health = client.health();
 
-        assertEquals(health, "{\"status\":\"available\"}");
+        assertThat(health, is(equalTo("{\"status\":\"available\"}")));
     }
 
     /** Test Is Healthy */
@@ -38,7 +41,7 @@ public class InstanceTest extends AbstractIT {
     public void testIsHealthy() throws Exception {
         Boolean healthy = client.isHealthy();
 
-        assertTrue(healthy);
+        assertThat(healthy, is(equalTo(true)));
     }
 
     /** Test Get Version */
@@ -46,7 +49,7 @@ public class InstanceTest extends AbstractIT {
     public void testGetVersion() throws Exception {
         String version = client.getVersion();
 
-        assertNotNull(version);
+        assertThat(version, is(notNullValue()));
     }
 
     /** Test Get Stats */
@@ -54,9 +57,9 @@ public class InstanceTest extends AbstractIT {
     public void testGetStats() throws Exception {
         Stats stats = client.getStats();
 
-        assertNotNull(stats);
-        assertNotNull(stats.getDatabaseSize());
-        assertNotNull(stats.getIndexes());
+        assertThat(stats, is(notNullValue()));
+        assertThat(stats.getDatabaseSize(), is(notNullValue()));
+        assertThat(stats.getIndexes(), is(notNullValue()));
     }
 
     /** Test Get Index Stats */
@@ -69,9 +72,9 @@ public class InstanceTest extends AbstractIT {
         client.waitForTask(task.getTaskUid());
         IndexStats stats = index.getStats();
 
-        assertNotNull(stats);
-        assertEquals(0, stats.getNumberOfDocuments());
-        assertFalse(stats.isIndexing());
-        assertNotNull(stats.getFieldDistribution());
+        assertThat(stats, is(notNullValue()));
+        assertThat(stats.getNumberOfDocuments(), is(equalTo(0)));
+        assertThat(stats.isIndexing(), is(equalTo(false)));
+        assertThat(stats.getFieldDistribution(), is(notNullValue()));
     }
 }

--- a/src/test/java/com/meilisearch/integration/KeysTest.java
+++ b/src/test/java/com/meilisearch/integration/KeysTest.java
@@ -1,6 +1,13 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
@@ -38,17 +45,17 @@ public class KeysTest extends AbstractIT {
         Results<Key> result = client.getKeys();
         Key[] keys = result.getResults();
 
-        assertEquals(2, keys.length);
+        assertThat(keys, is(arrayWithSize(2)));
 
         for (Key key : keys) {
-            assertNotNull(key.getKey());
-            assertNotNull(key.getUid());
-            assertNotNull(key.getActions());
-            assertNotNull(key.getIndexes());
-            assertNotNull(key.getDescription());
-            assertNull(key.getExpiresAt());
-            assertNotNull(key.getCreatedAt());
-            assertNotNull(key.getUpdatedAt());
+            assertThat(key.getKey(), is(notNullValue()));
+            assertThat(key.getUid(), is(notNullValue()));
+            assertThat(key.getActions(), is(notNullValue()));
+            assertThat(key.getIndexes(), is(notNullValue()));
+            assertThat(key.getDescription(), is(notNullValue()));
+            assertThat(key.getExpiresAt(), is(nullValue()));
+            assertThat(key.getCreatedAt(), is(notNullValue()));
+            assertThat(key.getUpdatedAt(), is(notNullValue()));
         }
     }
 
@@ -58,14 +65,14 @@ public class KeysTest extends AbstractIT {
         Results<Key> result = clientJackson.getKeys();
         Key[] keys = result.getResults();
 
-        assertEquals(2, keys.length);
+        assertThat(keys, is(arrayWithSize(2)));
 
         for (Key key : keys) {
-            assertNotNull(key.getKey());
-            assertNotNull(key.getActions());
-            assertNotNull(key.getIndexes());
-            assertNotNull(key.getCreatedAt());
-            assertNotNull(key.getUpdatedAt());
+            assertThat(key.getKey(), is(notNullValue()));
+            assertThat(key.getActions(), is(notNullValue()));
+            assertThat(key.getIndexes(), is(notNullValue()));
+            assertThat(key.getCreatedAt(), is(notNullValue()));
+            assertThat(key.getUpdatedAt(), is(notNullValue()));
         }
     }
 
@@ -77,10 +84,10 @@ public class KeysTest extends AbstractIT {
 
         Results<Key> result = client.getKeys(query);
 
-        assertEquals(limit, result.getLimit());
-        assertNotNull(result.getOffset());
-        assertNotNull(result.getTotal());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(equalTo(limit)));
+        assertThat(result.getOffset(), is(notNullValue()));
+        assertThat(result.getTotal(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Keys With Limit and Offset */
@@ -92,10 +99,10 @@ public class KeysTest extends AbstractIT {
 
         Results<Key> result = client.getKeys(query);
 
-        assertEquals(limit, result.getLimit());
-        assertEquals(offset, result.getOffset());
-        assertNotNull(result.getTotal());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(equalTo(limit)));
+        assertThat(result.getOffset(), is(equalTo(offset)));
+        assertThat(result.getTotal(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Key */
@@ -106,13 +113,13 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.getKey(keys[0].getKey());
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertNotNull(key.getActions());
-        assertNotNull(key.getIndexes());
-        assertNotNull(key.getDescription());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions(), is(notNullValue()));
+        assertThat(key.getIndexes(), is(notNullValue()));
+        assertThat(key.getDescription(), is(notNullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Get Key With Uid */
@@ -123,13 +130,13 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.getKey(keys[0].getUid());
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertNotNull(key.getActions());
-        assertNotNull(key.getIndexes());
-        assertNotNull(key.getDescription());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions(), is(notNullValue()));
+        assertThat(key.getIndexes(), is(notNullValue()));
+        assertThat(key.getDescription(), is(notNullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Get Key when the key does not exist */
@@ -148,14 +155,14 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.createKey(keyInfo);
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertEquals("*", key.getActions()[0]);
-        assertEquals("*", key.getIndexes()[0]);
-        assertNull(key.getDescription());
-        assertNull(key.getExpiresAt());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions()[0], is(equalTo("*")));
+        assertThat(key.getIndexes()[0], is(equalTo("*")));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Create a simple API Key without description with Jackson Json Handler */
@@ -168,14 +175,14 @@ public class KeysTest extends AbstractIT {
 
         Key key = clientJackson.createKey(keyInfo);
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertEquals("*", key.getActions()[0]);
-        assertEquals("*", key.getIndexes()[0]);
-        assertNull(key.getDescription());
-        assertNull(key.getExpiresAt());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions()[0], is(equalTo("*")));
+        assertThat(key.getIndexes()[0], is(equalTo("*")));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Create an API Key with description */
@@ -189,14 +196,14 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.createKey(keyInfo);
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertEquals("*", key.getActions()[0]);
-        assertEquals("*", key.getIndexes()[0]);
-        assertEquals("testClientCreateKey", key.getDescription());
-        assertNull(key.getExpiresAt());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions()[0], is(equalTo("*")));
+        assertThat(key.getIndexes()[0], is(equalTo("*")));
+        assertThat(key.getDescription(), is(equalTo("testClientCreateKey")));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Create an API Key with expiresAt */
@@ -212,14 +219,14 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.createKey(keyInfo);
 
-        assertTrue(key instanceof Key);
-        assertNotNull(key.getKey());
-        assertEquals("*", key.getActions()[0]);
-        assertEquals("*", key.getIndexes()[0]);
-        assertNull(key.getDescription());
-        assertEquals("2042-01-30", format.format(key.getExpiresAt()));
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions()[0], is(equalTo("*")));
+        assertThat(key.getIndexes()[0], is(equalTo("*")));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(format.format(key.getExpiresAt()), is(equalTo("2042-01-30")));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Create an API Key with wildcarded action */
@@ -232,13 +239,13 @@ public class KeysTest extends AbstractIT {
 
         Key key = client.createKey(keyInfo);
 
-        assertNotNull(key.getKey());
-        assertEquals("documents.*", key.getActions()[0]);
-        assertEquals("*", key.getIndexes()[0]);
-        assertNull(key.getDescription());
-        assertNull(key.getExpiresAt());
-        assertNotNull(key.getCreatedAt());
-        assertNotNull(key.getUpdatedAt());
+        assertThat(key.getKey(), is(notNullValue()));
+        assertThat(key.getActions()[0], is(equalTo("documents.*")));
+        assertThat(key.getIndexes()[0], is(equalTo("*")));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(notNullValue()));
+        assertThat(key.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Update an API Key */
@@ -261,18 +268,18 @@ public class KeysTest extends AbstractIT {
         Key createKey = client.createKey(keyInfo);
         Key updateKey = client.updateKey(createKey.getKey(), keyChanges);
 
-        assertTrue(createKey instanceof Key);
-        assertTrue(updateKey instanceof Key);
-        assertNotNull(updateKey.getKey());
-        assertEquals("*", createKey.getIndexes()[0]);
-        assertEquals("search", createKey.getActions()[0]);
-        assertEquals("Key After Update", createKey.getName());
-        assertEquals("Description Key After Update - test", updateKey.getDescription());
-        assertEquals(createKey.getIndexes()[0], updateKey.getIndexes()[0]);
-        assertEquals(createKey.getActions()[0], updateKey.getActions()[0]);
-        assertEquals(dateParsed, updateKey.getExpiresAt());
-        assertNotNull(updateKey.getCreatedAt());
-        assertNotNull(updateKey.getUpdatedAt());
+        assertThat(createKey, is(instanceOf(Key.class)));
+        assertThat(updateKey, is(instanceOf(Key.class)));
+        assertThat(updateKey.getKey(), is(notNullValue()));
+        assertThat(createKey.getIndexes()[0], is(equalTo("*")));
+        assertThat(createKey.getActions()[0], is(equalTo("search")));
+        assertThat(createKey.getName(), is(equalTo("Key After Update")));
+        assertThat(updateKey.getDescription(), is(equalTo("Description Key After Update - test")));
+        assertThat(updateKey.getIndexes()[0], is(equalTo(createKey.getIndexes()[0])));
+        assertThat(updateKey.getActions()[0], is(equalTo(createKey.getActions()[0])));
+        assertThat(updateKey.getExpiresAt(), is(equalTo(dateParsed)));
+        assertThat(updateKey.getCreatedAt(), is(notNullValue()));
+        assertThat(updateKey.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Update an API Key with Jackson Json Handler */
@@ -295,18 +302,18 @@ public class KeysTest extends AbstractIT {
         Key createKey = clientJackson.createKey(keyInfo);
         Key updateKey = clientJackson.updateKey(createKey.getKey(), keyChanges);
 
-        assertTrue(createKey instanceof Key);
-        assertTrue(updateKey instanceof Key);
-        assertNotNull(updateKey.getKey());
-        assertEquals("*", createKey.getIndexes()[0]);
-        assertEquals("search", createKey.getActions()[0]);
-        assertEquals("Key After Update", createKey.getName());
-        assertEquals("Description Key After Update - test", updateKey.getDescription());
-        assertEquals(createKey.getIndexes()[0], updateKey.getIndexes()[0]);
-        assertEquals(createKey.getActions()[0], updateKey.getActions()[0]);
-        assertEquals(dateParsed, updateKey.getExpiresAt());
-        assertNotNull(updateKey.getCreatedAt());
-        assertNotNull(updateKey.getUpdatedAt());
+        assertThat(createKey, is(instanceOf(Key.class)));
+        assertThat(updateKey, is(instanceOf(Key.class)));
+        assertThat(updateKey.getKey(), is(notNullValue()));
+        assertThat(createKey.getIndexes()[0], is(equalTo("*")));
+        assertThat(createKey.getActions()[0], is(equalTo("search")));
+        assertThat(createKey.getName(), is(equalTo("Key After Update")));
+        assertThat(updateKey.getDescription(), is(equalTo("Description Key After Update - test")));
+        assertThat(updateKey.getIndexes()[0], is(equalTo(createKey.getIndexes()[0])));
+        assertThat(updateKey.getActions()[0], is(equalTo(createKey.getActions()[0])));
+        assertThat(updateKey.getExpiresAt(), is(equalTo(dateParsed)));
+        assertThat(updateKey.getCreatedAt(), is(notNullValue()));
+        assertThat(updateKey.getUpdatedAt(), is(notNullValue()));
     }
 
     /** Test Delete an API Key */

--- a/src/test/java/com/meilisearch/integration/SearchNestedTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchNestedTest.java
@@ -1,6 +1,9 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -47,8 +50,8 @@ public class SearchNestedTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         Results searchResultGson = jsonGson.decode(index.rawSearch("An awesome"), Results.class);
 
-        assertEquals(1, searchResultGson.hits.length);
-        assertEquals("5", searchResultGson.hits[0].getId());
+        assertThat(searchResultGson.hits, is(arrayWithSize(1)));
+        assertThat(searchResultGson.hits[0].getId(), is(equalTo("5")));
     }
 
     /** Test search on nested documents with searchable attributes */
@@ -69,8 +72,8 @@ public class SearchNestedTest extends AbstractIT {
 
         Results searchResultGson = jsonGson.decode(index.rawSearch("An awesome"), Results.class);
 
-        assertEquals(1, searchResultGson.hits.length);
-        assertEquals("5", searchResultGson.hits[0].getId());
+        assertThat(searchResultGson.hits, is(arrayWithSize(1)));
+        assertThat(searchResultGson.hits[0].getId(), is(equalTo("5")));
     }
 
     /** Test search on nested documents with sortable attributes */
@@ -94,8 +97,8 @@ public class SearchNestedTest extends AbstractIT {
 
         Results searchResultGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(1, searchResultGson.hits.length);
-        assertEquals("5", searchResultGson.hits[0].getId());
+        assertThat(searchResultGson.hits, is(arrayWithSize(1)));
+        assertThat(searchResultGson.hits[0].getId(), is(equalTo("5")));
     }
 
     /** Test search on nested documents with sortable and searchable attributes */
@@ -119,7 +122,7 @@ public class SearchNestedTest extends AbstractIT {
                         .build();
         Results searchResultGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(1, searchResultGson.hits.length);
-        assertEquals("5", searchResultGson.hits[0].getId());
+        assertThat(searchResultGson.hits, is(arrayWithSize(1)));
+        assertThat(searchResultGson.hits[0].getId(), is(equalTo("5")));
     }
 }

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -1,8 +1,14 @@
 package com.meilisearch.integration;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -61,11 +67,11 @@ public class SearchTest extends AbstractIT {
 
         SearchResult searchResult = index.search("batman");
 
-        assertNull(searchResult.getFacetDistribution());
-        assertEquals(1, searchResult.getHits().size());
-        assertEquals(0, searchResult.getOffset());
-        assertEquals(20, searchResult.getLimit());
-        assertEquals(1, searchResult.getEstimatedTotalHits());
+        assertThat(searchResult.getFacetDistribution(), is(nullValue()));
+        assertThat(searchResult.getHits(), hasSize(1));
+        assertThat(searchResult.getOffset(), is(equalTo(0)));
+        assertThat(searchResult.getLimit(), is(equalTo(20)));
+        assertThat(searchResult.getEstimatedTotalHits(), is(equalTo(1)));
     }
 
     /** Test search offset */
@@ -82,8 +88,8 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest = SearchRequest.builder().q("a").offset(20).build();
         SearchResult searchResult = (SearchResult) index.search(searchRequest);
 
-        assertEquals(10, searchResult.getHits().size());
-        assertEquals(30, searchResult.getEstimatedTotalHits());
+        assertThat(searchResult.getHits(), hasSize(10));
+        assertThat(searchResult.getEstimatedTotalHits(), is(equalTo(30)));
     }
 
     /** Test search limit */
@@ -100,8 +106,8 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest = SearchRequest.builder().q("a").limit(2).build();
         SearchResult searchResult = (SearchResult) index.search(searchRequest);
 
-        assertEquals(2, searchResult.getHits().size());
-        assertEquals(30, searchResult.getEstimatedTotalHits());
+        assertThat(searchResult.getHits(), hasSize(2));
+        assertThat(searchResult.getEstimatedTotalHits(), is(equalTo(30)));
     }
 
     /** Test search attributesToRetrieve */
@@ -124,14 +130,14 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
+        assertThat(resGson.hits, is(arrayWithSize(20)));
         assertThat(resGson.hits[0].getId(), instanceOf(String.class));
         assertThat(resGson.hits[0].getTitle(), instanceOf(String.class));
-        assertNull(resGson.hits[0].getPoster());
-        assertNull(resGson.hits[0].getOverview());
-        assertNull(resGson.hits[0].getRelease_date());
-        assertNull(resGson.hits[0].getLanguage());
-        assertNull(resGson.hits[0].getGenres());
+        assertThat(resGson.hits[0].getPoster(), is(nullValue()));
+        assertThat(resGson.hits[0].getOverview(), is(nullValue()));
+        assertThat(resGson.hits[0].getRelease_date(), is(nullValue()));
+        assertThat(resGson.hits[0].getLanguage(), is(nullValue()));
+        assertThat(resGson.hits[0].getGenres(), is(nullValue()));
     }
 
     /** Test search crop */
@@ -155,9 +161,9 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals(5, resGson.hits[0].getFormatted().getOverview().length());
-        assertEquals("…and…", resGson.hits[0].getFormatted().getOverview());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(resGson.hits[0].getFormatted().getOverview(), hasLength(5));
+        assertThat(resGson.hits[0].getFormatted().getOverview(), is(equalTo("…and…")));
     }
 
     /** Test search with customized crop marker */
@@ -182,8 +188,8 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals("(ꈍᴗꈍ)and(ꈍᴗꈍ)", resGson.hits[0].getFormatted().getOverview());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(resGson.hits[0].getFormatted().getOverview(), is(equalTo("(ꈍᴗꈍ)and(ꈍᴗꈍ)")));
     }
 
     /** Test search highlight */
@@ -206,10 +212,12 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals(
-                "Birds of Prey (<em>and</em> the Fantabulous Emancipation of One Harley Quinn)",
-                resGson.hits[0].getFormatted().getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(
+                resGson.hits[0].getFormatted().getTitle(),
+                is(
+                        equalTo(
+                                "Birds of Prey (<em>and</em> the Fantabulous Emancipation of One Harley Quinn)")));
     }
 
     /** Test search with customized highlight */
@@ -234,10 +242,12 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals(
-                "Birds of Prey ((⊃｡•́‿•̀｡)⊃ and ⊂(´• ω •`⊂) the Fantabulous Emancipation of One Harley Quinn)",
-                resGson.hits[0].getFormatted().getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(
+                resGson.hits[0].getFormatted().getTitle(),
+                is(
+                        equalTo(
+                                "Birds of Prey ((⊃｡•́‿•̀｡)⊃ and ⊂(´• ω •`⊂) the Fantabulous Emancipation of One Harley Quinn)")));
     }
 
     /** Test search with customized highlight */
@@ -256,8 +266,8 @@ public class SearchTest extends AbstractIT {
 
         SearchResult searchResult = (SearchResult) index.search(searchRequest);
 
-        assertEquals(20, searchResult.getHits().size());
-        assertEquals(21, searchResult.getEstimatedTotalHits());
+        assertThat(searchResult.getHits(), hasSize(20));
+        assertThat(searchResult.getEstimatedTotalHits(), is(equalTo(21)));
     }
 
     /** Test search with phrase */
@@ -274,9 +284,11 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch("coco \"harry\""), Results.class);
 
-        assertEquals(1, resGson.hits.length);
-        assertEquals("671", resGson.hits[0].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[0].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(1)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("671")));
+        assertThat(
+                resGson.hits[0].getTitle(),
+                is(equalTo("Harry Potter and the Philosopher's Stone")));
     }
 
     /** Test search filter */
@@ -304,9 +316,9 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(1, resGson.hits.length);
-        assertEquals("155", resGson.hits[0].getId());
-        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(1)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("155")));
+        assertThat(resGson.hits[0].getTitle(), is(equalTo("The Dark Knight")));
     }
 
     /** Test search filter complex */
@@ -334,9 +346,9 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(2, resGson.hits.length);
-        assertEquals("155", resGson.hits[0].getId());
-        assertEquals("290859", resGson.hits[1].getId());
+        assertThat(resGson.hits, is(arrayWithSize(2)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("155")));
+        assertThat(resGson.hits[1].getId(), is(equalTo("290859")));
     }
 
     /** Test search facet distribution */
@@ -360,8 +372,8 @@ public class SearchTest extends AbstractIT {
 
         Searchable searchResult = index.search(searchRequest);
 
-        assertEquals(1, searchResult.getHits().size());
-        assertNotNull(searchResult.getFacetDistribution());
+        assertThat(searchResult.getHits(), hasSize(1));
+        assertThat(searchResult.getFacetDistribution(), is(not(nullValue())));
     }
 
     /** Test search sort */
@@ -386,13 +398,17 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals("495764", resGson.hits[0].getId());
-        assertEquals(
-                "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)",
-                resGson.hits[0].getTitle());
-        assertEquals("671", resGson.hits[1].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[1].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("495764")));
+        assertThat(
+                resGson.hits[0].getTitle(),
+                is(
+                        equalTo(
+                                "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)")));
+        assertThat(resGson.hits[1].getId(), is(equalTo("671")));
+        assertThat(
+                resGson.hits[1].getTitle(),
+                is(equalTo("Harry Potter and the Philosopher's Stone")));
     }
 
     /** Test search sort */
@@ -417,13 +433,17 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals("671", resGson.hits[0].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[0].getTitle());
-        assertEquals("495764", resGson.hits[1].getId());
-        assertEquals(
-                "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)",
-                resGson.hits[1].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("671")));
+        assertThat(
+                resGson.hits[0].getTitle(),
+                is(equalTo("Harry Potter and the Philosopher's Stone")));
+        assertThat(resGson.hits[1].getId(), is(equalTo("495764")));
+        assertThat(
+                resGson.hits[1].getTitle(),
+                is(
+                        equalTo(
+                                "Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn)")));
     }
 
     /** Test search sort */
@@ -451,11 +471,11 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(3, resGson.hits.length);
-        assertEquals("155", resGson.hits[0].getId());
-        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
-        assertEquals("290859", resGson.hits[1].getId());
-        assertEquals("Terminator: Dark Fate", resGson.hits[1].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(3)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("155")));
+        assertThat(resGson.hits[0].getTitle(), is(equalTo("The Dark Knight")));
+        assertThat(resGson.hits[1].getId(), is(equalTo("290859")));
+        assertThat(resGson.hits[1].getTitle(), is(equalTo("Terminator: Dark Fate")));
     }
 
     /** Test search sort */
@@ -480,11 +500,13 @@ public class SearchTest extends AbstractIT {
 
         Results resGson = jsonGson.decode(index.rawSearch(searchRequest), Results.class);
 
-        assertEquals(20, resGson.hits.length);
-        assertEquals("155", resGson.hits[0].getId());
-        assertEquals("The Dark Knight", resGson.hits[0].getTitle());
-        assertEquals("671", resGson.hits[1].getId());
-        assertEquals("Harry Potter and the Philosopher's Stone", resGson.hits[1].getTitle());
+        assertThat(resGson.hits, is(arrayWithSize(20)));
+        assertThat(resGson.hits[0].getId(), is(equalTo("155")));
+        assertThat(resGson.hits[0].getTitle(), is(equalTo("The Dark Knight")));
+        assertThat(resGson.hits[1].getId(), is(equalTo("671")));
+        assertThat(
+                resGson.hits[1].getTitle(),
+                is(equalTo("Harry Potter and the Philosopher's Stone")));
     }
 
     /** Test search matches */
@@ -502,7 +524,7 @@ public class SearchTest extends AbstractIT {
                 SearchRequest.builder().q("and").showMatchesPosition(true).build();
         Searchable searchResult = index.search(searchRequest);
 
-        assertEquals(20, searchResult.getHits().size());
+        assertThat(searchResult.getHits(), hasSize(20));
     }
 
     /** Test search page */
@@ -519,11 +541,11 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest = SearchRequest.builder().q("a").page(1).build();
         SearchResultPaginated searchResult = (SearchResultPaginated) index.search(searchRequest);
 
-        assertEquals(20, searchResult.getHits().size());
-        assertEquals(1, searchResult.getPage());
-        assertEquals(20, searchResult.getHitsPerPage());
-        assertEquals(30, searchResult.getTotalHits());
-        assertEquals(2, searchResult.getTotalPages());
+        assertThat(searchResult.getHits(), hasSize(20));
+        assertThat(searchResult.getPage(), is(equalTo(1)));
+        assertThat(searchResult.getHitsPerPage(), is(equalTo(20)));
+        assertThat(searchResult.getTotalHits(), is(equalTo(30)));
+        assertThat(searchResult.getTotalPages(), is(equalTo(2)));
     }
 
     /** Test search pagination */
@@ -540,11 +562,11 @@ public class SearchTest extends AbstractIT {
         SearchRequest searchRequest = SearchRequest.builder().q("a").page(2).hitsPerPage(2).build();
         SearchResultPaginated searchResult = (SearchResultPaginated) index.search(searchRequest);
 
-        assertEquals(2, searchResult.getHits().size());
-        assertEquals(2, searchResult.getPage());
-        assertEquals(2, searchResult.getHitsPerPage());
-        assertEquals(30, searchResult.getTotalHits());
-        assertEquals(15, searchResult.getTotalPages());
+        assertThat(searchResult.getHits(), hasSize(2));
+        assertThat(searchResult.getPage(), is(equalTo(2)));
+        assertThat(searchResult.getHitsPerPage(), is(equalTo(2)));
+        assertThat(searchResult.getTotalHits(), is(equalTo(30)));
+        assertThat(searchResult.getTotalPages(), is(equalTo(15)));
     }
 
     /** Test place holder search */
@@ -557,9 +579,9 @@ public class SearchTest extends AbstractIT {
         TaskInfo task = index.addDocuments(testData.getRaw());
 
         index.waitForTask(task.getTaskUid());
-        SearchResult result = (SearchResult) index.search("");
+        SearchResult result = index.search("");
 
-        assertEquals(20, result.getLimit());
+        assertThat(result.getLimit(), is(equalTo(20)));
     }
 
     /** Test place holder search */
@@ -574,6 +596,6 @@ public class SearchTest extends AbstractIT {
         index.waitForTask(task.getTaskUid());
         Searchable searchResult = index.search(SearchRequest.builder().q(null).limit(10).build());
 
-        assertEquals(10, searchResult.getHits().size());
+        assertThat(searchResult.getHits(), hasSize(10));
     }
 }

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -292,7 +292,7 @@ public class SettingsTest extends AbstractIT {
         Map<String, String[]> updatedSynonymsSettings = index.getSynonymsSettings();
 
         assertThat(updatedSynonymsSettings, is(aMapWithSize(newSynonymsSettings.size())));
-        assertThat(updatedSynonymsSettings, is(equalTo(newSynonymsSettings.keySet())));
+        assertThat(updatedSynonymsSettings.keySet(), is(equalTo(newSynonymsSettings.keySet())));
         assertThat(updatedSynonymsSettings, is(not(aMapWithSize(synonymsSettings.size()))));
         assertThat(updatedSynonymsSettings.keySet(), is(not(equalTo(synonymsSettings.keySet()))));
     }
@@ -314,13 +314,13 @@ public class SettingsTest extends AbstractIT {
         Map<String, String[]> synonymsSettingsAfterReset = index.getSynonymsSettings();
 
         assertThat(updatedSynonymsSettings, is(aMapWithSize(newSynonymsSettings.size())));
-        assertThat(updatedSynonymsSettings, is(equalTo(newSynonymsSettings.keySet())));
+        assertThat(updatedSynonymsSettings.keySet(), is(equalTo(newSynonymsSettings.keySet())));
         assertThat(updatedSynonymsSettings, is(not(aMapWithSize(synonymsSettings.size()))));
         assertThat(updatedSynonymsSettings.keySet(), is(not(equalTo(synonymsSettings.keySet()))));
         assertThat(
                 synonymsSettingsAfterReset, is(not(aMapWithSize(updatedSynonymsSettings.size()))));
         assertThat(synonymsSettingsAfterReset, is(aMapWithSize(synonymsSettings.size())));
-        assertThat(synonymsSettingsAfterReset, is(equalTo(synonymsSettings.keySet())));
+        assertThat(synonymsSettingsAfterReset.keySet(), is(equalTo(synonymsSettings.keySet())));
     }
 
     /** Tests of the stop words setting methods */
@@ -723,7 +723,7 @@ public class SettingsTest extends AbstractIT {
         assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("oneTypo"));
         assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(equalTo(7)));
         assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("twoTypos"));
-        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(equalTo(10)));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("twoTypos"), is(equalTo(10)));
     }
 
     @Test

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -1,12 +1,16 @@
 package com.meilisearch.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -49,7 +53,7 @@ public class SettingsTest extends AbstractIT {
         Index index = createIndex("getSettings");
         Settings settings = index.getSettings();
 
-        assertEquals(6, settings.getRankingRules().length);
+        assertThat(settings.getRankingRules(), is(arrayWithSize(6)));
     }
 
     @Test
@@ -70,7 +74,7 @@ public class SettingsTest extends AbstractIT {
                 });
         index.waitForTask(index.updateSettings(settings).getTaskUid());
         Settings newSettings = index.getSettings();
-        assertEquals(8, newSettings.getRankingRules().length);
+        assertThat(newSettings.getRankingRules(), is(arrayWithSize(8)));
     }
 
     @Test
@@ -88,7 +92,7 @@ public class SettingsTest extends AbstractIT {
 
         Settings newSettings = index.getSettings();
 
-        assertEquals(2, newSettings.getSynonyms().size());
+        assertThat(newSettings.getSynonyms(), is(aMapWithSize(2)));
     }
 
     @Test
@@ -102,7 +106,7 @@ public class SettingsTest extends AbstractIT {
 
         Settings newSettings = index.getSettings();
 
-        assertEquals(2, newSettings.getSortableAttributes().length);
+        assertThat(newSettings.getSortableAttributes(), is(arrayWithSize(2)));
     }
 
     @Test
@@ -120,9 +124,9 @@ public class SettingsTest extends AbstractIT {
 
         Settings newSettings = index.getSettings();
 
-        assertEquals(1, newSettings.getTypoTolerance().getDisableOnWords().length);
-        assertEquals(1, newSettings.getTypoTolerance().getDisableOnAttributes().length);
-        assertTrue(newSettings.getTypoTolerance().isEnabled());
+        assertThat(newSettings.getTypoTolerance().getDisableOnWords(), is(arrayWithSize(1)));
+        assertThat(newSettings.getTypoTolerance().getDisableOnAttributes(), is(arrayWithSize(1)));
+        assertThat(newSettings.getTypoTolerance().isEnabled(), is(equalTo(true)));
     }
 
     @Test
@@ -158,15 +162,15 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateSettings(settingsSynonyms).getTaskUid());
         Settings newSettingsSynonyms = index.getSettings();
 
-        assertEquals(4, newSettingsDisplayedAttr.getDisplayedAttributes().length);
-        assertEquals(6, newSettingsDisplayedAttr.getRankingRules().length);
-        assertEquals(0, newSettingsDisplayedAttr.getSynonyms().size());
-        assertEquals(4, newSettingsRankingRules.getDisplayedAttributes().length);
-        assertEquals(8, newSettingsRankingRules.getRankingRules().length);
-        assertEquals(0, newSettingsRankingRules.getSynonyms().size());
-        assertEquals(4, newSettingsSynonyms.getDisplayedAttributes().length);
-        assertEquals(2, newSettingsSynonyms.getSynonyms().size());
-        assertEquals(8, newSettingsSynonyms.getRankingRules().length);
+        assertThat(newSettingsDisplayedAttr.getDisplayedAttributes(), is(arrayWithSize(4)));
+        assertThat(newSettingsDisplayedAttr.getRankingRules(), is(arrayWithSize(6)));
+        assertThat(newSettingsDisplayedAttr.getSynonyms(), is(anEmptyMap()));
+        assertThat(newSettingsRankingRules.getDisplayedAttributes(), is(arrayWithSize(4)));
+        assertThat(newSettingsRankingRules.getRankingRules(), is(arrayWithSize(8)));
+        assertThat(newSettingsRankingRules.getSynonyms(), is(anEmptyMap()));
+        assertThat(newSettingsSynonyms.getDisplayedAttributes(), is(arrayWithSize(4)));
+        assertThat(newSettingsSynonyms.getSynonyms(), is(aMapWithSize(2)));
+        assertThat(newSettingsSynonyms.getRankingRules(), is(arrayWithSize(8)));
     }
 
     @Test
@@ -183,11 +187,13 @@ public class SettingsTest extends AbstractIT {
 
         index.waitForTask(index.updateSettings(settingsWithSynonyms).getTaskUid());
         settingsWithSynonyms = index.getSettings();
-        assertEquals(2, settingsWithSynonyms.getSynonyms().size());
+        assertThat(settingsWithSynonyms.getSynonyms(), is(aMapWithSize(2)));
 
         index.waitForTask(index.resetSettings().getTaskUid());
         Settings settingsAfterReset = index.getSettings();
-        assertEquals(initialSettings.getSynonyms().size(), settingsAfterReset.getSynonyms().size());
+        assertThat(
+                settingsAfterReset.getSynonyms().size(),
+                equalTo(initialSettings.getSynonyms().size()));
     }
 
     /** Tests of the ranking rules setting methods */
@@ -198,8 +204,9 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialRankingRules = index.getRankingRulesSettings();
 
-        assertEquals(initialSettings.getRankingRules().length, initialRankingRules.length);
-        assertArrayEquals(initialSettings.getRankingRules(), initialRankingRules);
+        assertThat(
+                initialRankingRules, is(arrayWithSize(initialSettings.getRankingRules().length)));
+        assertThat(initialRankingRules, is(equalTo(initialSettings.getRankingRules())));
     }
 
     @Test
@@ -221,9 +228,10 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateRankingRulesSettings(newRankingRules).getTaskUid());
         String[] updatedRankingRulesSettings = index.getRankingRulesSettings();
 
-        assertEquals(newRankingRules.length, updatedRankingRulesSettings.length);
-        assertArrayEquals(newRankingRules, updatedRankingRulesSettings);
-        assertNotEquals(initialRulesSettings.length, updatedRankingRulesSettings.length);
+        assertThat(updatedRankingRulesSettings, is(arrayWithSize(newRankingRules.length)));
+        assertThat(updatedRankingRulesSettings, is(equalTo(newRankingRules)));
+        assertThat(
+                updatedRankingRulesSettings, is(not(arrayWithSize(initialRulesSettings.length))));
     }
 
     @Test
@@ -248,13 +256,14 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetRankingRulesSettings().getTaskUid());
         String[] rankingRulesAfterReset = index.getRankingRulesSettings();
 
-        assertEquals(newRankingRules.length, updatedRankingRulesSettings.length);
-        assertArrayEquals(newRankingRules, updatedRankingRulesSettings);
-        assertNotEquals(initialRulesSettings.length, updatedRankingRulesSettings.length);
-
-        assertNotEquals(updatedRankingRulesSettings.length, rankingRulesAfterReset.length);
-        assertEquals(initialRulesSettings.length, rankingRulesAfterReset.length);
-        assertArrayEquals(initialRulesSettings, rankingRulesAfterReset);
+        assertThat(updatedRankingRulesSettings, is(arrayWithSize(newRankingRules.length)));
+        assertThat(updatedRankingRulesSettings, is(equalTo(newRankingRules)));
+        assertThat(
+                updatedRankingRulesSettings, is(not(arrayWithSize(initialRulesSettings.length))));
+        assertThat(
+                rankingRulesAfterReset, is(not(arrayWithSize(updatedRankingRulesSettings.length))));
+        assertThat(rankingRulesAfterReset, is(arrayWithSize(initialRulesSettings.length)));
+        assertThat(rankingRulesAfterReset, is(equalTo(initialRulesSettings)));
     }
 
     /** Tests of the synonyms setting methods */
@@ -265,8 +274,8 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         Map<String, String[]> synonymsSettings = index.getSynonymsSettings();
 
-        assertEquals(initialSettings.getSynonyms().size(), synonymsSettings.size());
-        assertEquals(initialSettings.getSynonyms(), synonymsSettings);
+        assertThat(synonymsSettings, is(aMapWithSize(initialSettings.getSynonyms().size())));
+        assertThat(synonymsSettings, is(equalTo(initialSettings.getSynonyms())));
     }
 
     @Test
@@ -282,10 +291,10 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateSynonymsSettings(newSynonymsSettings).getTaskUid());
         Map<String, String[]> updatedSynonymsSettings = index.getSynonymsSettings();
 
-        assertEquals(newSynonymsSettings.size(), updatedSynonymsSettings.size());
-        assertEquals(newSynonymsSettings.keySet(), updatedSynonymsSettings.keySet());
-        assertNotEquals(synonymsSettings.size(), updatedSynonymsSettings.size());
-        assertNotEquals(synonymsSettings.keySet(), updatedSynonymsSettings.keySet());
+        assertThat(updatedSynonymsSettings, is(aMapWithSize(newSynonymsSettings.size())));
+        assertThat(updatedSynonymsSettings, is(equalTo(newSynonymsSettings.keySet())));
+        assertThat(updatedSynonymsSettings, is(not(aMapWithSize(synonymsSettings.size()))));
+        assertThat(updatedSynonymsSettings.keySet(), is(not(equalTo(synonymsSettings.keySet()))));
     }
 
     @Test
@@ -304,14 +313,14 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetSynonymsSettings().getTaskUid());
         Map<String, String[]> synonymsSettingsAfterReset = index.getSynonymsSettings();
 
-        assertEquals(newSynonymsSettings.size(), updatedSynonymsSettings.size());
-        assertEquals(newSynonymsSettings.keySet(), updatedSynonymsSettings.keySet());
-        assertNotEquals(synonymsSettings.size(), updatedSynonymsSettings.size());
-        assertNotEquals(synonymsSettings.keySet(), updatedSynonymsSettings.keySet());
-
-        assertNotEquals(updatedSynonymsSettings.size(), synonymsSettingsAfterReset.size());
-        assertEquals(synonymsSettings.size(), synonymsSettingsAfterReset.size());
-        assertEquals(synonymsSettings.keySet(), synonymsSettingsAfterReset.keySet());
+        assertThat(updatedSynonymsSettings, is(aMapWithSize(newSynonymsSettings.size())));
+        assertThat(updatedSynonymsSettings, is(equalTo(newSynonymsSettings.keySet())));
+        assertThat(updatedSynonymsSettings, is(not(aMapWithSize(synonymsSettings.size()))));
+        assertThat(updatedSynonymsSettings.keySet(), is(not(equalTo(synonymsSettings.keySet()))));
+        assertThat(
+                synonymsSettingsAfterReset, is(not(aMapWithSize(updatedSynonymsSettings.size()))));
+        assertThat(synonymsSettingsAfterReset, is(aMapWithSize(synonymsSettings.size())));
+        assertThat(synonymsSettingsAfterReset, is(equalTo(synonymsSettings.keySet())));
     }
 
     /** Tests of the stop words setting methods */
@@ -322,8 +331,8 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialStopWords = index.getStopWordsSettings();
 
-        assertEquals(initialSettings.getStopWords().length, initialStopWords.length);
-        assertArrayEquals(initialSettings.getStopWords(), initialStopWords);
+        assertThat(initialStopWords, is(arrayWithSize(initialSettings.getStopWords().length)));
+        assertThat(initialStopWords, is(equalTo(initialSettings.getStopWords())));
     }
 
     @Test
@@ -336,9 +345,9 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateStopWordsSettings(newStopWords).getTaskUid());
         String[] updatedStopWordsSettings = index.getStopWordsSettings();
 
-        assertEquals(newStopWords.length, updatedStopWordsSettings.length);
-        assertArrayEquals(newStopWords, updatedStopWordsSettings);
-        assertNotEquals(initialStopWords.length, updatedStopWordsSettings.length);
+        assertThat(updatedStopWordsSettings, is(arrayWithSize(newStopWords.length)));
+        assertThat(updatedStopWordsSettings, is(equalTo(newStopWords)));
+        assertThat(updatedStopWordsSettings, is(not(arrayWithSize(initialStopWords.length))));
     }
 
     @Test
@@ -354,13 +363,12 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetStopWordsSettings().getTaskUid());
         String[] stopWordsAfterReset = index.getStopWordsSettings();
 
-        assertEquals(newStopWords.length, updatedStopWordsSettings.length);
-        assertArrayEquals(newStopWords, updatedStopWordsSettings);
-        assertNotEquals(initialStopWords.length, updatedStopWordsSettings.length);
-
-        assertNotEquals(updatedStopWordsSettings.length, stopWordsAfterReset.length);
-        assertEquals(initialStopWords.length, stopWordsAfterReset.length);
-        assertArrayEquals(initialStopWords, stopWordsAfterReset);
+        assertThat(updatedStopWordsSettings, is(arrayWithSize(newStopWords.length)));
+        assertThat(updatedStopWordsSettings, is(equalTo(newStopWords)));
+        assertThat(updatedStopWordsSettings, is(not(arrayWithSize(initialStopWords.length))));
+        assertThat(stopWordsAfterReset, is(not(arrayWithSize(updatedStopWordsSettings.length))));
+        assertThat(stopWordsAfterReset, is(arrayWithSize(initialStopWords.length)));
+        assertThat(stopWordsAfterReset, is(equalTo(initialStopWords)));
     }
 
     /** Tests of the searchable attributes setting methods */
@@ -371,10 +379,12 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialSearchableAttributes = index.getSearchableAttributesSettings();
 
-        assertEquals(
-                initialSettings.getSearchableAttributes().length,
-                initialSearchableAttributes.length);
-        assertArrayEquals(initialSettings.getSearchableAttributes(), initialSearchableAttributes);
+        assertThat(
+                initialSearchableAttributes,
+                is(arrayWithSize(initialSettings.getSearchableAttributes().length)));
+        assertThat(
+                initialSearchableAttributes,
+                is(equalTo(initialSettings.getSearchableAttributes())));
     }
 
     @Test
@@ -388,9 +398,11 @@ public class SettingsTest extends AbstractIT {
                 index.updateSearchableAttributesSettings(newSearchableAttributes).getTaskUid());
         String[] updatedSearchableAttributes = index.getSearchableAttributesSettings();
 
-        assertEquals(newSearchableAttributes.length, updatedSearchableAttributes.length);
-        assertArrayEquals(newSearchableAttributes, updatedSearchableAttributes);
-        assertNotEquals(initialSearchableAttributes.length, updatedSearchableAttributes.length);
+        assertThat(updatedSearchableAttributes, is(arrayWithSize(newSearchableAttributes.length)));
+        assertThat(updatedSearchableAttributes, is(equalTo(newSearchableAttributes)));
+        assertThat(
+                updatedSearchableAttributes,
+                is(not(arrayWithSize(initialSearchableAttributes.length))));
     }
 
     @Test
@@ -407,13 +419,18 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetSearchableAttributesSettings().getTaskUid());
         String[] searchableAttributesAfterReset = index.getSearchableAttributesSettings();
 
-        assertEquals(newSearchableAttributes.length, updatedSearchableAttributes.length);
-        assertArrayEquals(newSearchableAttributes, updatedSearchableAttributes);
-        assertNotEquals(initialSearchableAttributes.length, updatedSearchableAttributes.length);
-
-        assertNotEquals(updatedSearchableAttributes.length, searchableAttributesAfterReset.length);
-        assertEquals(initialSearchableAttributes.length, searchableAttributesAfterReset.length);
-        assertArrayEquals(initialSearchableAttributes, searchableAttributesAfterReset);
+        assertThat(updatedSearchableAttributes, is(arrayWithSize(newSearchableAttributes.length)));
+        assertThat(updatedSearchableAttributes, is(equalTo(newSearchableAttributes)));
+        assertThat(
+                updatedSearchableAttributes,
+                is(not(arrayWithSize(initialSearchableAttributes.length))));
+        assertThat(
+                searchableAttributesAfterReset,
+                is(not(arrayWithSize(updatedSearchableAttributes.length))));
+        assertThat(
+                searchableAttributesAfterReset,
+                is(arrayWithSize(initialSearchableAttributes.length)));
+        assertThat(searchableAttributesAfterReset, is(equalTo(initialSearchableAttributes)));
     }
 
     /** Tests of the display attributes setting methods */
@@ -424,10 +441,11 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialDisplayedAttributes = index.getDisplayedAttributesSettings();
 
-        assertEquals(
-                initialSettings.getSearchableAttributes().length,
-                initialDisplayedAttributes.length);
-        assertArrayEquals(initialSettings.getDisplayedAttributes(), initialDisplayedAttributes);
+        assertThat(
+                initialDisplayedAttributes,
+                is(arrayWithSize(initialSettings.getSearchableAttributes().length)));
+        assertThat(
+                initialDisplayedAttributes, is(equalTo(initialSettings.getDisplayedAttributes())));
     }
 
     @Test
@@ -441,9 +459,11 @@ public class SettingsTest extends AbstractIT {
                 index.updateDisplayedAttributesSettings(newDisplayedAttributes).getTaskUid());
         String[] updatedDisplayedAttributes = index.getDisplayedAttributesSettings();
 
-        assertEquals(newDisplayedAttributes.length, updatedDisplayedAttributes.length);
-        assertArrayEquals(newDisplayedAttributes, updatedDisplayedAttributes);
-        assertNotEquals(initialDisplayedAttributes.length, updatedDisplayedAttributes.length);
+        assertThat(updatedDisplayedAttributes, is(arrayWithSize(newDisplayedAttributes.length)));
+        assertThat(updatedDisplayedAttributes, is(equalTo(newDisplayedAttributes)));
+        assertThat(
+                updatedDisplayedAttributes,
+                is(not(arrayWithSize(initialDisplayedAttributes.length))));
     }
 
     @Test
@@ -460,11 +480,14 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetDisplayedAttributesSettings().getTaskUid());
         String[] displayedAttributesAfterReset = index.getDisplayedAttributesSettings();
 
-        assertEquals(newDisplayedAttributes.length, updatedDisplayedAttributes.length);
-        assertArrayEquals(newDisplayedAttributes, updatedDisplayedAttributes);
-        assertNotEquals(initialDisplayedAttributes.length, updatedDisplayedAttributes.length);
-
-        assertNotEquals(updatedDisplayedAttributes.length, displayedAttributesAfterReset.length);
+        assertThat(updatedDisplayedAttributes, is(arrayWithSize(newDisplayedAttributes.length)));
+        assertThat(updatedDisplayedAttributes, is(equalTo(newDisplayedAttributes)));
+        assertThat(
+                updatedDisplayedAttributes,
+                is(not(arrayWithSize(initialDisplayedAttributes.length))));
+        assertThat(
+                displayedAttributesAfterReset,
+                is(not(arrayWithSize(updatedDisplayedAttributes.length))));
     }
 
     /** Tests of the filterable attributes setting methods */
@@ -475,10 +498,12 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialFilterableAttributes = index.getFilterableAttributesSettings();
 
-        assertEquals(
-                initialSettings.getFilterableAttributes().length,
-                initialFilterableAttributes.length);
-        assertArrayEquals(initialSettings.getFilterableAttributes(), initialFilterableAttributes);
+        assertThat(
+                initialFilterableAttributes,
+                is(arrayWithSize(initialSettings.getFilterableAttributes().length)));
+        assertThat(
+                initialFilterableAttributes,
+                is(equalTo(initialSettings.getFilterableAttributes())));
     }
 
     @Test
@@ -492,11 +517,13 @@ public class SettingsTest extends AbstractIT {
                 index.updateFilterableAttributesSettings(newFilterableAttributes).getTaskUid());
         String[] updatedFilterableAttributes = index.getFilterableAttributesSettings();
 
-        assertEquals(newFilterableAttributes.length, updatedFilterableAttributes.length);
+        assertThat(updatedFilterableAttributes, is(arrayWithSize(newFilterableAttributes.length)));
         assertThat(
                 Arrays.asList(newFilterableAttributes),
                 containsInAnyOrder(updatedFilterableAttributes));
-        assertNotEquals(initialFilterableAttributes.length, updatedFilterableAttributes.length);
+        assertThat(
+                updatedFilterableAttributes,
+                is(not(arrayWithSize(initialFilterableAttributes.length))));
     }
 
     @Test
@@ -515,14 +542,19 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetFilterableAttributesSettings().getTaskUid());
         String[] filterableAttributesAfterReset = index.getFilterableAttributesSettings();
 
-        assertEquals(newFilterableAttributes.length, updatedFilterableAttributes.length);
+        assertThat(updatedFilterableAttributes, is(arrayWithSize(newFilterableAttributes.length)));
         assertThat(
                 Arrays.asList(newFilterableAttributes),
                 containsInAnyOrder(updatedFilterableAttributes));
-        assertNotEquals(initialFilterableAttributes.length, updatedFilterableAttributes.length);
-
-        assertNotEquals(updatedFilterableAttributes.length, filterableAttributesAfterReset.length);
-        assertNotEquals(initialFilterableAttributes.length, updatedFilterableAttributes.length);
+        assertThat(
+                updatedFilterableAttributes,
+                is(not(arrayWithSize(initialFilterableAttributes.length))));
+        assertThat(
+                filterableAttributesAfterReset,
+                is(not(arrayWithSize(updatedFilterableAttributes.length))));
+        assertThat(
+                updatedFilterableAttributes,
+                is(not(arrayWithSize(initialFilterableAttributes.length))));
     }
 
     /** Tests of the sortable attributes setting methods* */
@@ -533,9 +565,10 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String[] initialSortableAttributes = index.getSortableAttributesSettings();
 
-        assertEquals(
-                initialSettings.getSortableAttributes().length, initialSortableAttributes.length);
-        assertArrayEquals(initialSettings.getSortableAttributes(), initialSortableAttributes);
+        assertThat(
+                initialSortableAttributes,
+                is(arrayWithSize(initialSettings.getSortableAttributes().length)));
+        assertThat(initialSortableAttributes, is(equalTo(initialSettings.getSortableAttributes())));
     }
 
     @Test
@@ -549,11 +582,13 @@ public class SettingsTest extends AbstractIT {
                 index.updateSortableAttributesSettings(newSortableAttributes).getTaskUid());
         String[] updatedSortableAttributes = index.getSortableAttributesSettings();
 
-        assertEquals(newSortableAttributes.length, updatedSortableAttributes.length);
+        assertThat(updatedSortableAttributes, is(arrayWithSize(newSortableAttributes.length)));
         assertThat(
                 Arrays.asList(newSortableAttributes),
                 containsInAnyOrder(updatedSortableAttributes));
-        assertNotEquals(initialSortableAttributes.length, updatedSortableAttributes.length);
+        assertThat(
+                updatedSortableAttributes,
+                is(not(arrayWithSize(initialSortableAttributes.length))));
     }
 
     @Test
@@ -572,14 +607,19 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetFilterableAttributesSettings().getTaskUid());
         String[] filterableAttributesAfterReset = index.getFilterableAttributesSettings();
 
-        assertEquals(newSortableAttributes.length, updatedSortableAttributes.length);
+        assertThat(updatedSortableAttributes, is(arrayWithSize(newSortableAttributes.length)));
         assertThat(
                 Arrays.asList(newSortableAttributes),
                 containsInAnyOrder(updatedSortableAttributes));
-        assertNotEquals(initialSortableAttributes.length, updatedSortableAttributes.length);
-
-        assertNotEquals(updatedSortableAttributes.length, filterableAttributesAfterReset.length);
-        assertNotEquals(initialSortableAttributes.length, updatedSortableAttributes.length);
+        assertThat(
+                updatedSortableAttributes,
+                is(not(arrayWithSize(initialSortableAttributes.length))));
+        assertThat(
+                filterableAttributesAfterReset,
+                is(not(arrayWithSize(updatedSortableAttributes.length))));
+        assertThat(
+                updatedSortableAttributes,
+                is(not(arrayWithSize(initialSortableAttributes.length))));
     }
 
     /** Tests of the distinct attributes setting methods */
@@ -590,7 +630,7 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         String initialDistinctAttribute = index.getDistinctAttributeSettings();
 
-        assertEquals(initialSettings.getDistinctAttribute(), initialDistinctAttribute);
+        assertThat(initialDistinctAttribute, is(equalTo(initialSettings.getDistinctAttribute())));
     }
 
     @Test
@@ -603,8 +643,8 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateDistinctAttributeSettings(newDistinctAttribute).getTaskUid());
         String updatedDistinctAttribute = index.getDistinctAttributeSettings();
 
-        assertEquals(newDistinctAttribute, updatedDistinctAttribute);
-        assertNotEquals(initialDistinctAttribute, updatedDistinctAttribute);
+        assertThat(updatedDistinctAttribute, is(equalTo(newDistinctAttribute)));
+        assertThat(updatedDistinctAttribute, is(not(equalTo(initialDistinctAttribute))));
     }
 
     @Test
@@ -620,11 +660,10 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetDistinctAttributeSettings().getTaskUid());
         String distinctAttributeAfterReset = index.getDistinctAttributeSettings();
 
-        assertEquals(newDistinctAttribute, updatedDistinctAttribute);
-        assertNotEquals(initialDistinctAttribute, updatedDistinctAttribute);
-
-        assertNotEquals(updatedDistinctAttribute, distinctAttributeAfterReset);
-        assertNotEquals(initialDistinctAttribute, updatedDistinctAttribute);
+        assertThat(updatedDistinctAttribute, is(equalTo(newDistinctAttribute)));
+        assertThat(updatedDistinctAttribute, is(not(equalTo(initialDistinctAttribute))));
+        assertThat(distinctAttributeAfterReset, is(not(equalTo(updatedDistinctAttribute))));
+        assertThat(updatedDistinctAttribute, is(not(equalTo(initialDistinctAttribute))));
     }
 
     /** Tests of the typo tolerance setting methods */
@@ -635,16 +674,23 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         TypoTolerance initialTypoTolerance = index.getTypoToleranceSettings();
 
-        assertEquals(initialSettings.getTypoTolerance().getDisableOnWords().length, 0);
-        assertEquals(initialTypoTolerance.getDisableOnWords().length, 0);
-        assertEquals(initialSettings.getTypoTolerance().getDisableOnAttributes().length, 0);
-        assertEquals(initialTypoTolerance.getDisableOnAttributes().length, 0);
-        assertEquals(
-                initialSettings.getTypoTolerance().isEnabled(), initialTypoTolerance.isEnabled());
-        assertNotNull(initialTypoTolerance.getMinWordSizeForTypos().containsKey("oneTypo"));
-        assertNotNull(initialTypoTolerance.getMinWordSizeForTypos().get("oneTypo"));
-        assertNotNull(initialTypoTolerance.getMinWordSizeForTypos().containsKey("twoTypos"));
-        assertNotNull(initialTypoTolerance.getMinWordSizeForTypos().get("twoTypos"));
+        assertThat(initialSettings.getTypoTolerance().getDisableOnWords(), is(emptyArray()));
+        assertThat(initialTypoTolerance.getDisableOnWords(), is(emptyArray()));
+        assertThat(initialSettings.getTypoTolerance().getDisableOnAttributes(), is(emptyArray()));
+        assertThat(initialTypoTolerance.getDisableOnAttributes(), is(emptyArray()));
+        assertThat(
+                initialTypoTolerance.isEnabled(),
+                is(equalTo(initialSettings.getTypoTolerance().isEnabled())));
+        assertThat(
+                initialTypoTolerance.getMinWordSizeForTypos().containsKey("oneTypo"),
+                is(notNullValue()));
+        assertThat(
+                initialTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(notNullValue()));
+        assertThat(
+                initialTypoTolerance.getMinWordSizeForTypos().containsKey("twoTypos"),
+                is(notNullValue()));
+        assertThat(
+                initialTypoTolerance.getMinWordSizeForTypos().get("twoTypos"), is(notNullValue()));
     }
 
     @Test
@@ -667,19 +713,17 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateTypoToleranceSettings(newTypoTolerance).getTaskUid());
         TypoTolerance updatedTypoTolerance = index.getTypoToleranceSettings();
 
-        assertEquals(
-                newTypoTolerance.getDisableOnWords()[0],
-                updatedTypoTolerance.getDisableOnWords()[0]);
-        assertEquals(
-                newTypoTolerance.getDisableOnAttributes()[0],
-                updatedTypoTolerance.getDisableOnAttributes()[0]);
-        assertTrue(updatedTypoTolerance.isEnabled());
-        assertTrue(
-                updatedTypoTolerance.getMinWordSizeForTypos().containsKey("oneTypo")
-                        && updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo") == 7);
-        assertTrue(
-                updatedTypoTolerance.getMinWordSizeForTypos().containsKey("twoTypos")
-                        && updatedTypoTolerance.getMinWordSizeForTypos().get("twoTypos") == 10);
+        assertThat(
+                updatedTypoTolerance.getDisableOnWords()[0],
+                is(equalTo(newTypoTolerance.getDisableOnWords()[0])));
+        assertThat(
+                updatedTypoTolerance.getDisableOnAttributes()[0],
+                is(equalTo(newTypoTolerance.getDisableOnAttributes()[0])));
+        assertThat(updatedTypoTolerance.isEnabled(), is(equalTo(true)));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("oneTypo"));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(equalTo(7)));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("twoTypos"));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(equalTo(10)));
     }
 
     @Test
@@ -693,19 +737,17 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateTypoToleranceSettings(newTypoTolerance).getTaskUid());
         TypoTolerance updatedTypoTolerance = index.getTypoToleranceSettings();
 
-        assertEquals(
-                newTypoTolerance.getDisableOnWords()[0],
-                updatedTypoTolerance.getDisableOnWords()[0]);
-        assertEquals(
-                newTypoTolerance.getDisableOnAttributes()[0],
-                updatedTypoTolerance.getDisableOnAttributes()[0]);
-        assertTrue(updatedTypoTolerance.isEnabled());
-        assertTrue(
-                updatedTypoTolerance.getMinWordSizeForTypos().containsKey("oneTypo")
-                        && updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo") == 5);
-        assertTrue(
-                updatedTypoTolerance.getMinWordSizeForTypos().containsKey("twoTypos")
-                        && updatedTypoTolerance.getMinWordSizeForTypos().get("twoTypos") == 9);
+        assertThat(
+                updatedTypoTolerance.getDisableOnWords()[0],
+                is(equalTo(newTypoTolerance.getDisableOnWords()[0])));
+        assertThat(
+                updatedTypoTolerance.getDisableOnAttributes()[0],
+                is(equalTo(newTypoTolerance.getDisableOnAttributes()[0])));
+        assertThat(updatedTypoTolerance.isEnabled(), is(equalTo(true)));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("oneTypo"));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("oneTypo"), is(equalTo(5)));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos(), hasKey("twoTypos"));
+        assertThat(updatedTypoTolerance.getMinWordSizeForTypos().get("twoTypos"), is(equalTo(9)));
     }
 
     @Test
@@ -733,28 +775,30 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetTypoToleranceSettings().getTaskUid());
         TypoTolerance typoToleranceAfterReset = index.getTypoToleranceSettings();
 
-        assertEquals(
-                newTypoTolerance.getDisableOnWords().length,
-                updatedTypoTolerance.getDisableOnWords().length);
-        assertEquals(
-                newTypoTolerance.getDisableOnAttributes().length,
-                updatedTypoTolerance.getDisableOnAttributes().length);
-        assertEquals(newTypoTolerance.isEnabled(), updatedTypoTolerance.isEnabled());
+        assertThat(
+                updatedTypoTolerance.getDisableOnWords(),
+                is(arrayWithSize(newTypoTolerance.getDisableOnWords().length)));
+        assertThat(
+                updatedTypoTolerance.getDisableOnAttributes(),
+                is(arrayWithSize(newTypoTolerance.getDisableOnAttributes().length)));
+        assertThat(updatedTypoTolerance.isEnabled(), is(equalTo(newTypoTolerance.isEnabled())));
 
-        assertEquals(
-                initialTypoTolerance.getDisableOnWords().length,
-                typoToleranceAfterReset.getDisableOnWords().length);
-        assertEquals(
-                initialTypoTolerance.getDisableOnAttributes().length,
-                typoToleranceAfterReset.getDisableOnAttributes().length);
-        assertEquals(initialTypoTolerance.isEnabled(), typoToleranceAfterReset.isEnabled());
-        assertTrue(
-                typoToleranceAfterReset.getMinWordSizeForTypos().containsKey("oneTypo")
-                        && typoToleranceAfterReset.getMinWordSizeForTypos().get("oneTypo") != null);
-        assertTrue(
-                typoToleranceAfterReset.getMinWordSizeForTypos().containsKey("twoTypos")
-                        && typoToleranceAfterReset.getMinWordSizeForTypos().get("twoTypos")
-                                != null);
+        assertThat(
+                typoToleranceAfterReset.getDisableOnWords(),
+                is(arrayWithSize(initialTypoTolerance.getDisableOnWords().length)));
+        assertThat(
+                typoToleranceAfterReset.getDisableOnAttributes(),
+                is(arrayWithSize(initialTypoTolerance.getDisableOnAttributes().length)));
+        assertThat(
+                typoToleranceAfterReset.isEnabled(), is(equalTo(initialTypoTolerance.isEnabled())));
+        assertThat(typoToleranceAfterReset.getMinWordSizeForTypos(), hasKey("oneTypo"));
+        assertThat(
+                typoToleranceAfterReset.getMinWordSizeForTypos().get("oneTypo"),
+                is(notNullValue()));
+        assertThat(typoToleranceAfterReset.getMinWordSizeForTypos(), hasKey("twoTypos"));
+        assertThat(
+                typoToleranceAfterReset.getMinWordSizeForTypos().get("twoTypos"),
+                is(notNullValue()));
     }
 
     /** Tests of all the specifics setting methods when null is passed */
@@ -773,10 +817,10 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateSynonymsSettings(null).getTaskUid());
         Map<String, String[]> resetSynonymsSettings = index.getSynonymsSettings();
 
-        assertNotEquals(initialSynonymsSettings.size(), updatedSynonymsSettings.size());
-        assertNotEquals(updatedSynonymsSettings.size(), resetSynonymsSettings.size());
-        assertEquals(initialSynonymsSettings.size(), resetSynonymsSettings.size());
-        assertEquals(initialSynonymsSettings.keySet(), resetSynonymsSettings.keySet());
+        assertThat(updatedSynonymsSettings, is(not(aMapWithSize(initialSynonymsSettings.size()))));
+        assertThat(resetSynonymsSettings, is(not(aMapWithSize(updatedSynonymsSettings.size()))));
+        assertThat(resetSynonymsSettings, is(aMapWithSize(initialSynonymsSettings.size())));
+        assertThat(resetSynonymsSettings.keySet(), is(equalTo(initialSynonymsSettings.keySet())));
     }
 
     @Test
@@ -792,10 +836,10 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateStopWordsSettings(null).getTaskUid());
         String[] resetStopWords = index.getStopWordsSettings();
 
-        assertNotEquals(initialStopWords.length, updatedStopWords.length);
-        assertNotEquals(updatedStopWords.length, resetStopWords.length);
-        assertEquals(initialStopWords.length, resetStopWords.length);
-        assertArrayEquals(initialStopWords, resetStopWords);
+        assertThat(updatedStopWords, is(not(arrayWithSize(initialStopWords.length))));
+        assertThat(resetStopWords, is(not(arrayWithSize(updatedStopWords.length))));
+        assertThat(resetStopWords, is(arrayWithSize(initialStopWords.length)));
+        assertThat(resetStopWords, is(equalTo(initialStopWords)));
     }
 
     @Test
@@ -820,9 +864,9 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateRankingRulesSettings(null).getTaskUid());
         String[] resetRankingRule = index.getRankingRulesSettings();
 
-        assertNotEquals(newRankingRule.length, resetRankingRule.length);
-        assertEquals(initialRankingRule.length, resetRankingRule.length);
-        assertArrayEquals(initialRankingRule, resetRankingRule);
+        assertThat(resetRankingRule, is(not(arrayWithSize(newRankingRule.length))));
+        assertThat(resetRankingRule, is(arrayWithSize(initialRankingRule.length)));
+        assertThat(resetRankingRule, is(equalTo(initialRankingRule)));
     }
 
     @Test
@@ -839,10 +883,15 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateSearchableAttributesSettings(null).getTaskUid());
         String[] resetSearchableAttributes = index.getSearchableAttributesSettings();
 
-        assertNotEquals(initialSearchableAttributes.length, updatedSearchableAttributes.length);
-        assertNotEquals(updatedSearchableAttributes.length, resetSearchableAttributes.length);
-        assertEquals(initialSearchableAttributes.length, resetSearchableAttributes.length);
-        assertArrayEquals(initialSearchableAttributes, resetSearchableAttributes);
+        assertThat(
+                updatedSearchableAttributes,
+                is(not(arrayWithSize(initialSearchableAttributes.length))));
+        assertThat(
+                resetSearchableAttributes,
+                is(not(arrayWithSize(updatedSearchableAttributes.length))));
+        assertThat(
+                resetSearchableAttributes, is(arrayWithSize(initialSearchableAttributes.length)));
+        assertThat(resetSearchableAttributes, is(equalTo(initialSearchableAttributes)));
     }
 
     @Test
@@ -859,10 +908,14 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateDisplayedAttributesSettings(null).getTaskUid());
         String[] resetDisplayedAttributes = index.getDisplayedAttributesSettings();
 
-        assertNotEquals(initialDisplayedAttributes.length, updatedDisplayedAttributes.length);
-        assertNotEquals(updatedDisplayedAttributes.length, resetDisplayedAttributes.length);
-        assertEquals(initialDisplayedAttributes.length, resetDisplayedAttributes.length);
-        assertArrayEquals(initialDisplayedAttributes, resetDisplayedAttributes);
+        assertThat(
+                updatedDisplayedAttributes,
+                is(not(arrayWithSize(initialDisplayedAttributes.length))));
+        assertThat(
+                resetDisplayedAttributes,
+                is(not(arrayWithSize(updatedDisplayedAttributes.length))));
+        assertThat(resetDisplayedAttributes, is(arrayWithSize(initialDisplayedAttributes.length)));
+        assertThat(resetDisplayedAttributes, is(equalTo(initialDisplayedAttributes)));
     }
 
     @Test
@@ -879,10 +932,15 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateFilterableAttributesSettings(null).getTaskUid());
         String[] resetFilterableAttributes = index.getFilterableAttributesSettings();
 
-        assertNotEquals(updatedFilterableAttributes.length, resetFilterableAttributes.length);
-        assertNotEquals(initialFilterableAttributes.length, updatedFilterableAttributes.length);
-        assertEquals(initialFilterableAttributes.length, resetFilterableAttributes.length);
-        assertArrayEquals(initialFilterableAttributes, resetFilterableAttributes);
+        assertThat(
+                resetFilterableAttributes,
+                is(not(arrayWithSize(updatedFilterableAttributes.length))));
+        assertThat(
+                updatedFilterableAttributes,
+                is(not(arrayWithSize(initialFilterableAttributes.length))));
+        assertThat(
+                resetFilterableAttributes, is(arrayWithSize(initialFilterableAttributes.length)));
+        assertThat(resetFilterableAttributes, is(equalTo(initialFilterableAttributes)));
     }
 
     @Test
@@ -898,9 +956,9 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.updateDistinctAttributeSettings(null).getTaskUid());
         String resetDistinctAttribute = index.getDistinctAttributeSettings();
 
-        assertNotEquals(updatedDistinctAttribute, resetDistinctAttribute);
-        assertNotEquals(initialDistinctAttribute, updatedDistinctAttribute);
-        assertEquals(initialDistinctAttribute, resetDistinctAttribute);
+        assertThat(resetDistinctAttribute, is(not(equalTo(updatedDistinctAttribute))));
+        assertThat(updatedDistinctAttribute, is(not(equalTo(initialDistinctAttribute))));
+        assertThat(resetDistinctAttribute, is(equalTo(initialDistinctAttribute)));
     }
 
     /** Tests of the pagination setting methods */
@@ -911,8 +969,8 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         Pagination initialPagination = index.getPaginationSettings();
 
-        assertEquals(initialSettings.getPagination().getMaxTotalHits(), 1000);
-        assertNotNull(initialPagination.getMaxTotalHits());
+        assertThat(initialSettings.getPagination().getMaxTotalHits(), is(equalTo(1000)));
+        assertThat(initialPagination.getMaxTotalHits(), is(notNullValue()));
     }
 
     @Test
@@ -921,13 +979,13 @@ public class SettingsTest extends AbstractIT {
         Index index = createIndex("testUpdatePaginationSettings");
         Pagination newPagination = new Pagination();
 
-        Integer MaxTotalHitsTypos = 100;
+        int MaxTotalHitsTypos = 100;
 
         newPagination.setMaxTotalHits(MaxTotalHitsTypos);
         index.waitForTask(index.updatePaginationSettings(newPagination).getTaskUid());
         Pagination updatedPagination = index.getPaginationSettings();
 
-        assertEquals(100, updatedPagination.getMaxTotalHits());
+        assertThat(updatedPagination.getMaxTotalHits(), is(equalTo(100)));
     }
 
     @Test
@@ -938,7 +996,7 @@ public class SettingsTest extends AbstractIT {
         Pagination initialPagination = index.getPaginationSettings();
         Pagination newPagination = new Pagination();
 
-        Integer MaxTotalHitsTypos = 100;
+        int MaxTotalHitsTypos = 100;
         newPagination.setMaxTotalHits(MaxTotalHitsTypos);
         index.waitForTask(index.updatePaginationSettings(newPagination).getTaskUid());
         Pagination updatedPagination = index.getPaginationSettings();
@@ -946,9 +1004,9 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetPaginationSettings().getTaskUid());
         Pagination paginationAfterReset = index.getPaginationSettings();
 
-        assertEquals(1000, initialPagination.getMaxTotalHits());
-        assertEquals(100, updatedPagination.getMaxTotalHits());
-        assertEquals(1000, paginationAfterReset.getMaxTotalHits());
+        assertThat(initialPagination.getMaxTotalHits(), is(equalTo(1000)));
+        assertThat(updatedPagination.getMaxTotalHits(), is(equalTo(100)));
+        assertThat(paginationAfterReset.getMaxTotalHits(), is(equalTo(1000)));
     }
 
     /** Tests of the faceting setting methods */
@@ -959,8 +1017,8 @@ public class SettingsTest extends AbstractIT {
         Settings initialSettings = index.getSettings();
         Faceting initialFaceting = index.getFacetingSettings();
 
-        assertEquals(initialSettings.getFaceting().getMaxValuesPerFacet(), 100);
-        assertNotNull(initialFaceting.getMaxValuesPerFacet());
+        assertThat(initialSettings.getFaceting().getMaxValuesPerFacet(), is(equalTo(100)));
+        assertThat(initialFaceting.getMaxValuesPerFacet(), is(notNullValue()));
     }
 
     @Test
@@ -969,13 +1027,13 @@ public class SettingsTest extends AbstractIT {
         Index index = createIndex("testUpdateFacetingSettings");
         Faceting newFaceting = new Faceting();
 
-        Integer MaxValuesPerFacetTypos = 200;
+        int MaxValuesPerFacetTypos = 200;
 
         newFaceting.setMaxValuesPerFacet(MaxValuesPerFacetTypos);
         index.waitForTask(index.updateFacetingSettings(newFaceting).getTaskUid());
         Faceting updatedFaceting = index.getFacetingSettings();
 
-        assertEquals(200, updatedFaceting.getMaxValuesPerFacet());
+        assertThat(updatedFaceting.getMaxValuesPerFacet(), is(equalTo(200)));
     }
 
     @Test
@@ -986,7 +1044,7 @@ public class SettingsTest extends AbstractIT {
         Faceting initialFaceting = index.getFacetingSettings();
         Faceting newFaceting = new Faceting();
 
-        Integer MaxValuesPerFacetTypos = 200;
+        int MaxValuesPerFacetTypos = 200;
         newFaceting.setMaxValuesPerFacet(MaxValuesPerFacetTypos);
         index.waitForTask(index.updateFacetingSettings(newFaceting).getTaskUid());
         Faceting updatedFaceting = index.getFacetingSettings();
@@ -994,9 +1052,9 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(index.resetFacetingSettings().getTaskUid());
         Faceting facetingAfterReset = index.getFacetingSettings();
 
-        assertEquals(100, initialFaceting.getMaxValuesPerFacet());
-        assertEquals(200, updatedFaceting.getMaxValuesPerFacet());
-        assertEquals(100, facetingAfterReset.getMaxValuesPerFacet());
+        assertThat(initialFaceting.getMaxValuesPerFacet(), is(equalTo(100)));
+        assertThat(updatedFaceting.getMaxValuesPerFacet(), is(equalTo(200)));
+        assertThat(facetingAfterReset.getMaxValuesPerFacet(), is(equalTo(100)));
     }
 
     private Index createIndex(String indexUid) throws Exception {

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -1,6 +1,13 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -39,15 +46,15 @@ public class TasksTest extends AbstractIT {
 
         Task task = client.getTask(response.getTaskUid());
 
-        assertTrue(task instanceof Task);
-        assertNotNull(task.getStatus());
-        assertNotNull(task.getStatus());
-        assertNotNull(task.getStartedAt());
-        assertNotNull(task.getEnqueuedAt());
-        assertNotNull(task.getFinishedAt());
-        assertTrue(task.getUid() >= 0);
-        assertNotNull(task.getDetails());
-        assertNull(task.getDetails().getPrimaryKey());
+        assertThat(task, is(instanceOf(Task.class)));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getStartedAt(), is(notNullValue()));
+        assertThat(task.getEnqueuedAt(), is(notNullValue()));
+        assertThat(task.getFinishedAt(), is(notNullValue()));
+        assertThat(task.getUid(), is(greaterThanOrEqualTo(0)));
+        assertThat(task.getDetails(), is(notNullValue()));
+        assertThat(task.getDetails().getPrimaryKey(), is(nullValue()));
     }
 
     /** Test Get Tasks */
@@ -63,9 +70,9 @@ public class TasksTest extends AbstractIT {
         Task task = tasks[0];
         client.waitForTask(task.getUid());
 
-        assertNotNull(task.getStatus());
-        assertTrue(task.getUid() >= 0);
-        assertNotNull(task.getDetails());
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getUid(), is(greaterThanOrEqualTo(0)));
+        assertThat(task.getDetails(), is(notNullValue()));
     }
 
     /** Test Get Tasks with limit */
@@ -75,10 +82,10 @@ public class TasksTest extends AbstractIT {
         TasksQuery query = new TasksQuery().setLimit(limit);
         TasksResults result = client.getTasks(query);
 
-        assertEquals(limit, result.getLimit());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(equalTo(limit)));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Tasks with limit and from */
@@ -89,11 +96,11 @@ public class TasksTest extends AbstractIT {
         TasksQuery query = new TasksQuery().setLimit(limit).setFrom(from);
         TasksResults result = client.getTasks(query);
 
-        assertEquals(limit, result.getLimit());
-        assertEquals(from, result.getFrom());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(equalTo(limit)));
+        assertThat(result.getFrom(), is(equalTo(from)));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Tasks with uid as filter */
@@ -102,10 +109,10 @@ public class TasksTest extends AbstractIT {
         TasksQuery query = new TasksQuery().setUids(new int[] {1});
         TasksResults result = client.getTasks(query);
 
-        assertNotNull(result.getLimit());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(notNullValue()));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Tasks with beforeEnqueuedAt as filter */
@@ -115,10 +122,10 @@ public class TasksTest extends AbstractIT {
         TasksQuery query = new TasksQuery().setBeforeEnqueuedAt(date);
         TasksResults result = client.getTasks(query);
 
-        assertNotNull(result.getLimit());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(notNullValue()));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Tasks with canceledBy as filter */
@@ -127,10 +134,10 @@ public class TasksTest extends AbstractIT {
         TasksQuery query = new TasksQuery().setCanceledBy(new int[] {1});
         TasksResults result = client.getTasks(query);
 
-        assertNotNull(result.getLimit());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(notNullValue()));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Get Tasks with all query parameters */
@@ -146,10 +153,10 @@ public class TasksTest extends AbstractIT {
                         .setTypes(new String[] {"indexDeletion"});
         TasksResults result = client.getTasks(query);
 
-        assertEquals(limit, result.getLimit());
-        assertNotNull(result.getFrom());
-        assertNotNull(result.getNext());
-        assertNotNull(result.getResults().length);
+        assertThat(result.getLimit(), is(equalTo(limit)));
+        assertThat(result.getFrom(), is(notNullValue()));
+        assertThat(result.getNext(), is(notNullValue()));
+        assertThat(result.getResults().length, is(notNullValue()));
     }
 
     /** Test Cancel Task */
@@ -160,11 +167,11 @@ public class TasksTest extends AbstractIT {
 
         TaskInfo task = client.cancelTasks(query);
 
-        assertTrue(task instanceof TaskInfo);
-        assertNotNull(task.getStatus());
-        assertNotNull(task.getStatus());
-        assertNull(task.getIndexUid());
-        assertEquals("taskCancelation", task.getType());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getIndexUid(), is(nullValue()));
+        assertThat(task.getType(), is(equalTo("taskCancelation")));
     }
 
     /** Test Cancel Task with multiple filters */
@@ -181,11 +188,11 @@ public class TasksTest extends AbstractIT {
 
         TaskInfo task = client.cancelTasks(query);
 
-        assertTrue(task instanceof TaskInfo);
-        assertNotNull(task.getStatus());
-        assertNotNull(task.getStatus());
-        assertNull(task.getIndexUid());
-        assertEquals("taskCancelation", task.getType());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getIndexUid(), is(nullValue()));
+        assertThat(task.getType(), is(equalTo("taskCancelation")));
     }
 
     /** Test Delete Task */
@@ -196,11 +203,11 @@ public class TasksTest extends AbstractIT {
 
         TaskInfo task = client.deleteTasks(query);
 
-        assertTrue(task instanceof TaskInfo);
-        assertNotNull(task.getStatus());
-        assertNotNull(task.getStatus());
-        assertNull(task.getIndexUid());
-        assertEquals("taskDeletion", task.getType());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getIndexUid(), is(nullValue()));
+        assertThat(task.getType(), is(equalTo("taskDeletion")));
     }
 
     /** Test Delete Task with multiple filters */
@@ -217,10 +224,10 @@ public class TasksTest extends AbstractIT {
 
         TaskInfo task = client.deleteTasks(query);
 
-        assertTrue(task instanceof TaskInfo);
-        assertNotNull(task.getStatus());
-        assertNull(task.getIndexUid());
-        assertEquals("taskDeletion", task.getType());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getStatus(), is(notNullValue()));
+        assertThat(task.getIndexUid(), is(nullValue()));
+        assertThat(task.getType(), is(equalTo("taskDeletion")));
     }
 
     /** Test waitForTask */
@@ -232,13 +239,13 @@ public class TasksTest extends AbstractIT {
 
         Task task = client.getTask(response.getTaskUid());
 
-        assertTrue(task.getUid() >= 0);
-        assertNotNull(task.getEnqueuedAt());
-        assertNotNull(task.getStartedAt());
-        assertNotNull(task.getFinishedAt());
-        assertEquals(TaskStatus.SUCCEEDED, task.getStatus());
-        assertNotNull(task.getDetails());
-        assertNull(task.getDetails().getPrimaryKey());
+        assertThat(task.getUid(), is(greaterThanOrEqualTo(0)));
+        assertThat(task.getEnqueuedAt(), is(notNullValue()));
+        assertThat(task.getStartedAt(), is(notNullValue()));
+        assertThat(task.getFinishedAt(), is(notNullValue()));
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.SUCCEEDED)));
+        assertThat(task.getDetails(), is(notNullValue()));
+        assertThat(task.getDetails().getPrimaryKey(), is(nullValue()));
 
         client.deleteIndex(task.getIndexUid());
     }
@@ -264,6 +271,6 @@ public class TasksTest extends AbstractIT {
         TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
         TaskInfo task = index.addDocuments(testData.getRaw());
 
-        assertEquals(TaskStatus.ENQUEUED, task.getStatus());
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.ENQUEUED)));
     }
 }

--- a/src/test/java/com/meilisearch/integration/TenantTokenTest.java
+++ b/src/test/java/com/meilisearch/integration/TenantTokenTest.java
@@ -1,6 +1,10 @@
 package com.meilisearch.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -45,7 +49,7 @@ public class TenantTokenTest extends AbstractIT {
 
         Client privateClient = new Client(new Config(getMeilisearchHost(), key.getKey()));
 
-        Map<String, Object> rules = new HashMap<String, Object>();
+        Map<String, Object> rules = new HashMap<>();
         rules.put("*", new HashMap<String, Object>());
 
         String jwtToken = privateClient.generateTenantToken(getPrivateKey().getUid(), rules);
@@ -64,7 +68,7 @@ public class TenantTokenTest extends AbstractIT {
 
         Client privateClient = new Client(new Config(getMeilisearchHost(), key.getKey()));
 
-        Map<String, Object> rules = new HashMap<String, Object>();
+        Map<String, Object> rules = new HashMap<>();
         rules.put(indexUid, new HashMap<String, Object>());
 
         String jwtToken = privateClient.generateTenantToken(getPrivateKey().getUid(), rules);
@@ -82,9 +86,9 @@ public class TenantTokenTest extends AbstractIT {
 
         Client privateClient = new Client(new Config(getMeilisearchHost(), key.getKey()));
 
-        Map<String, Object> filters = new HashMap<String, Object>();
+        Map<String, Object> filters = new HashMap<>();
         filters.put("filter", "id > 1");
-        Map<String, Object> rules = new HashMap<String, Object>();
+        Map<String, Object> rules = new HashMap<>();
         rules.put("GenerateTokenwithFilter", filters);
 
         String jwtToken = privateClient.generateTenantToken(getPrivateKey().getUid(), rules);
@@ -102,9 +106,9 @@ public class TenantTokenTest extends AbstractIT {
 
         SearchResult searchResult = tokenClient.index(indexUid).search("");
 
-        assertEquals(20, searchResult.getHits().size());
-        assertEquals(20, searchResult.getLimit());
-        assertEquals(30, searchResult.getEstimatedTotalHits());
+        assertThat(searchResult.getHits().size(), is(equalTo(20)));
+        assertThat(searchResult.getLimit(), is(equalTo(20)));
+        assertThat(searchResult.getEstimatedTotalHits(), is(equalTo(30)));
     }
 
     /** Test Create Tenant Token with expiration date */

--- a/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
@@ -1,6 +1,9 @@
 package com.meilisearch.sdk;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.meilisearch.sdk.model.MatchingStrategy;
 import org.junit.jupiter.api.Test;
@@ -11,14 +14,14 @@ class SearchRequestTest {
     void toStringSimpleQuery() {
         SearchRequest classToTest = new SearchRequest("This is a Test");
 
-        assertEquals("{\"q\":\"This is a Test\"}", classToTest.toString());
+        assertThat(classToTest.toString(), is(equalTo("{\"q\":\"This is a Test\"}")));
     }
 
     @Test
     void toStringSimpleQueryWithBuilder() {
         SearchRequest classToTest = SearchRequest.builder().q("This is a Test").build();
 
-        assertEquals("{\"q\":\"This is a Test\"}", classToTest.toString());
+        assertThat(classToTest.toString(), is(equalTo("{\"q\":\"This is a Test\"}")));
     }
 
     @Test
@@ -26,14 +29,16 @@ class SearchRequestTest {
         SearchRequest classToTest =
                 new SearchRequest("This is a Test").setQuery("This is a Test").setOffset(200);
 
-        assertEquals("{\"q\":\"This is a Test\",\"offset\":200}", classToTest.toString());
+        assertThat(
+                classToTest.toString(), is(equalTo("{\"q\":\"This is a Test\",\"offset\":200}")));
     }
 
     @Test
     void toStringQueryAndOffsetWithBuilder() {
         SearchRequest classToTest = SearchRequest.builder().q("This is a Test").offset(200).build();
 
-        assertEquals("{\"q\":\"This is a Test\",\"offset\":200}", classToTest.toString());
+        assertThat(
+                classToTest.toString(), is(equalTo("{\"q\":\"This is a Test\",\"offset\":200}")));
     }
 
     @Test
@@ -41,8 +46,9 @@ class SearchRequestTest {
         SearchRequest classToTest =
                 new SearchRequest("This is a Test").setOffset(200).setLimit(900);
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}", classToTest.toString());
+        assertThat(
+                classToTest.toString(),
+                is(equalTo("{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}")));
     }
 
     @Test
@@ -50,8 +56,9 @@ class SearchRequestTest {
         SearchRequest classToTest =
                 SearchRequest.builder().q("This is a Test").offset(200).limit(900).build();
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}", classToTest.toString());
+        assertThat(
+                classToTest.toString(),
+                is(equalTo("{\"q\":\"This is a Test\",\"offset\":200,\"limit\":900}")));
     }
 
     @Test
@@ -61,10 +68,10 @@ class SearchRequestTest {
                         .setOffset(200)
                         .setLimit(900)
                         .setAttributesToRetrieve(new String[] {"bubble"});
+        String expected =
+                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}";
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}",
-                classToTest.toString());
+        assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 
     @Test
@@ -76,10 +83,10 @@ class SearchRequestTest {
                         .limit(900)
                         .offset(200)
                         .build();
+        String expected =
+                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}";
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"limit\":900}",
-                classToTest.toString());
+        assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 
     @Test
@@ -92,10 +99,10 @@ class SearchRequestTest {
                         .page(10)
                         .hitsPerPage(2)
                         .build();
+        String expected =
+                "{\"q\":\"This is a Test\",\"offset\":0,\"hitsPerPage\":2,\"limit\":20,\"page\":10}";
 
-        assertEquals(
-                "{\"q\":\"This is a Test\",\"offset\":0,\"hitsPerPage\":2,\"limit\":20,\"page\":10}",
-                classToTest.toString());
+        assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 
     @Test
@@ -114,23 +121,23 @@ class SearchRequestTest {
                         .setPage(10)
                         .setHitsPerPage(2);
 
-        assertEquals("This is a Test", classToTest.getQ());
-        assertEquals(200, classToTest.getOffset());
-        assertEquals(900, classToTest.getLimit());
-        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
-        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
-        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
-        assertEquals(null, classToTest.getCropMarker());
-        assertEquals(null, classToTest.getHighlightPreTag());
-        assertEquals(null, classToTest.getHighlightPostTag());
-        assertEquals(null, classToTest.getFilterArray());
-        assertEquals(1, classToTest.getFilter().length);
-        assertEquals("test='test'", classToTest.getFilter()[0]);
-        assertEquals("facets", classToTest.getFacets()[0]);
-        assertEquals("sort", classToTest.getSort()[0]);
-        assertEquals(900, classToTest.getCropLength());
-        assertEquals(10, classToTest.getPage());
-        assertEquals(2, classToTest.getHitsPerPage());
+        assertThat(classToTest.getQ(), is(equalTo("This is a Test")));
+        assertThat(classToTest.getOffset(), is(equalTo(200)));
+        assertThat(classToTest.getLimit(), is(equalTo(900)));
+        assertThat(classToTest.getAttributesToRetrieve()[0], is(equalTo("bubble")));
+        assertThat(classToTest.getAttributesToHighlight()[0], is(equalTo("highlight")));
+        assertThat(classToTest.getAttributesToCrop()[0], is(equalTo("crop")));
+        assertThat(classToTest.getCropMarker(), is(nullValue()));
+        assertThat(classToTest.getHighlightPreTag(), is(nullValue()));
+        assertThat(classToTest.getHighlightPostTag(), is(nullValue()));
+        assertThat(classToTest.getFilterArray(), is(nullValue()));
+        assertThat(classToTest.getFilter().length, is(equalTo(1)));
+        assertThat(classToTest.getFilter()[0], is(equalTo("test='test'")));
+        assertThat(classToTest.getFacets()[0], is(equalTo("facets")));
+        assertThat(classToTest.getSort()[0], is(equalTo("sort")));
+        assertThat(classToTest.getCropLength(), is(equalTo(900)));
+        assertThat(classToTest.getPage(), is(equalTo(10)));
+        assertThat(classToTest.getHitsPerPage(), is(equalTo(2)));
     }
 
     @Test
@@ -151,23 +158,23 @@ class SearchRequestTest {
                         .hitsPerPage(2)
                         .build();
 
-        assertEquals("This is a Test", classToTest.getQ());
-        assertEquals(200, classToTest.getOffset());
-        assertEquals(900, classToTest.getLimit());
-        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
-        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
-        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
-        assertEquals(null, classToTest.getCropMarker());
-        assertEquals(null, classToTest.getHighlightPreTag());
-        assertEquals(null, classToTest.getHighlightPostTag());
-        assertEquals(null, classToTest.getFilterArray());
-        assertEquals(1, classToTest.getFilter().length);
-        assertEquals("test='test'", classToTest.getFilter()[0]);
-        assertEquals("facets", classToTest.getFacets()[0]);
-        assertEquals("sort", classToTest.getSort()[0]);
-        assertEquals(900, classToTest.getCropLength());
-        assertEquals(10, classToTest.getPage());
-        assertEquals(2, classToTest.getHitsPerPage());
+        assertThat(classToTest.getQ(), is(equalTo("This is a Test")));
+        assertThat(classToTest.getOffset(), is(equalTo(200)));
+        assertThat(classToTest.getLimit(), is(equalTo(900)));
+        assertThat(classToTest.getAttributesToRetrieve()[0], is(equalTo("bubble")));
+        assertThat(classToTest.getAttributesToHighlight()[0], is(equalTo("highlight")));
+        assertThat(classToTest.getAttributesToCrop()[0], is(equalTo("crop")));
+        assertThat(classToTest.getCropMarker(), is(nullValue()));
+        assertThat(classToTest.getHighlightPreTag(), is(nullValue()));
+        assertThat(classToTest.getHighlightPostTag(), is(nullValue()));
+        assertThat(classToTest.getFilterArray(), is(nullValue()));
+        assertThat(classToTest.getFilter().length, is(equalTo(1)));
+        assertThat(classToTest.getFilter()[0], is(equalTo("test='test'")));
+        assertThat(classToTest.getFacets()[0], is(equalTo("facets")));
+        assertThat(classToTest.getSort()[0], is(equalTo("sort")));
+        assertThat(classToTest.getCropLength(), is(equalTo(900)));
+        assertThat(classToTest.getPage(), is(equalTo(10)));
+        assertThat(classToTest.getHitsPerPage(), is(equalTo(2)));
     }
 
     @Test
@@ -193,29 +200,29 @@ class SearchRequestTest {
                         .setSort(new String[] {"sort"})
                         .setPage(0)
                         .setHitsPerPage(0);
+        String expectedToString =
+                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"matchingStrategy\":\"all\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}";
 
-        assertEquals("This is a Test", classToTest.getQ());
-        assertEquals(200, classToTest.getOffset());
-        assertEquals(900, classToTest.getLimit());
-        assertEquals("123", classToTest.getCropMarker());
-        assertEquals("abc", classToTest.getHighlightPreTag());
-        assertEquals(MatchingStrategy.ALL, classToTest.getMatchingStrategy());
-        assertEquals("zyx", classToTest.getHighlightPostTag());
-        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
-        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
-        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
-        assertEquals(null, classToTest.getFilter());
-        assertEquals(2, classToTest.getFilterArray().length);
-        assertEquals("test='test'", classToTest.getFilterArray()[0][0]);
-        assertEquals("test1='test1'", classToTest.getFilterArray()[1][0]);
-        assertEquals("facets", classToTest.getFacets()[0]);
-        assertEquals("sort", classToTest.getSort()[0]);
-        assertEquals(900, classToTest.getCropLength());
-        assertEquals(0, classToTest.getPage());
-        assertEquals(0, classToTest.getHitsPerPage());
-        assertEquals(
-                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"matchingStrategy\":\"all\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}",
-                classToTest.toString());
+        assertThat(classToTest.getQ(), is(equalTo("This is a Test")));
+        assertThat(classToTest.getOffset(), is(equalTo(200)));
+        assertThat(classToTest.getLimit(), is(equalTo(900)));
+        assertThat(classToTest.getCropMarker(), is(equalTo("123")));
+        assertThat(classToTest.getHighlightPreTag(), is(equalTo("abc")));
+        assertThat(classToTest.getMatchingStrategy(), is(equalTo(MatchingStrategy.ALL)));
+        assertThat(classToTest.getHighlightPostTag(), is(equalTo("zyx")));
+        assertThat(classToTest.getAttributesToRetrieve()[0], is(equalTo("bubble")));
+        assertThat(classToTest.getAttributesToHighlight()[0], is(equalTo("highlight")));
+        assertThat(classToTest.getAttributesToCrop()[0], is(equalTo("crop")));
+        assertThat(classToTest.getFilter(), is(nullValue()));
+        assertThat(classToTest.getFilterArray().length, is(equalTo(2)));
+        assertThat(classToTest.getFilterArray()[0][0], is(equalTo("test='test'")));
+        assertThat(classToTest.getFilterArray()[1][0], is(equalTo("test1='test1'")));
+        assertThat(classToTest.getFacets()[0], is(equalTo("facets")));
+        assertThat(classToTest.getSort()[0], is(equalTo("sort")));
+        assertThat(classToTest.getCropLength(), is(equalTo(900)));
+        assertThat(classToTest.getPage(), is(equalTo(0)));
+        assertThat(classToTest.getHitsPerPage(), is(equalTo(0)));
+        assertThat(classToTest.toString(), is(equalTo(expectedToString)));
     }
 
     @Test
@@ -243,29 +250,29 @@ class SearchRequestTest {
                         .page(0)
                         .hitsPerPage(0)
                         .build();
+        String expectedToString =
+                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"matchingStrategy\":\"all\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}";
 
-        assertEquals("This is a Test", classToTest.getQ());
-        assertEquals(200, classToTest.getOffset());
-        assertEquals(900, classToTest.getLimit());
-        assertEquals("123", classToTest.getCropMarker());
-        assertEquals("abc", classToTest.getHighlightPreTag());
-        assertEquals(MatchingStrategy.ALL, classToTest.getMatchingStrategy());
-        assertEquals("zyx", classToTest.getHighlightPostTag());
-        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
-        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
-        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
-        assertEquals(null, classToTest.getFilter());
-        assertEquals(2, classToTest.getFilterArray().length);
-        assertEquals("test='test'", classToTest.getFilterArray()[0][0]);
-        assertEquals("test1='test1'", classToTest.getFilterArray()[1][0]);
-        assertEquals("facets", classToTest.getFacets()[0]);
-        assertEquals("sort", classToTest.getSort()[0]);
-        assertEquals(900, classToTest.getCropLength());
-        assertEquals(0, classToTest.getPage());
-        assertEquals(0, classToTest.getHitsPerPage());
-        assertEquals(
-                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"matchingStrategy\":\"all\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}",
-                classToTest.toString());
+        assertThat(classToTest.getQ(), is(equalTo("This is a Test")));
+        assertThat(classToTest.getOffset(), is(equalTo(200)));
+        assertThat(classToTest.getLimit(), is(equalTo(900)));
+        assertThat(classToTest.getCropMarker(), is(equalTo("123")));
+        assertThat(classToTest.getHighlightPreTag(), is(equalTo("abc")));
+        assertThat(classToTest.getMatchingStrategy(), is(equalTo(MatchingStrategy.ALL)));
+        assertThat(classToTest.getHighlightPostTag(), is(equalTo("zyx")));
+        assertThat(classToTest.getAttributesToRetrieve()[0], is(equalTo("bubble")));
+        assertThat(classToTest.getAttributesToHighlight()[0], is(equalTo("highlight")));
+        assertThat(classToTest.getAttributesToCrop()[0], is(equalTo("crop")));
+        assertThat(classToTest.getFilter(), is(equalTo(null)));
+        assertThat(classToTest.getFilterArray().length, is(equalTo(2)));
+        assertThat(classToTest.getFilterArray()[0][0], is(equalTo("test='test'")));
+        assertThat(classToTest.getFilterArray()[1][0], is(equalTo("test1='test1'")));
+        assertThat(classToTest.getFacets()[0], is(equalTo("facets")));
+        assertThat(classToTest.getSort()[0], is(equalTo("sort")));
+        assertThat(classToTest.getCropLength(), is(equalTo(900)));
+        assertThat(classToTest.getPage(), is(equalTo(0)));
+        assertThat(classToTest.getHitsPerPage(), is(equalTo(0)));
+        assertThat(classToTest.toString(), is(equalTo(expectedToString)));
     }
 
     @Test
@@ -293,26 +300,26 @@ class SearchRequestTest {
                         .page(0)
                         .hitsPerPage(0)
                         .build();
+        String expectedToString =
+                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}";
 
-        assertEquals("This is a Test", classToTest.getQ());
-        assertEquals(200, classToTest.getOffset());
-        assertEquals(900, classToTest.getLimit());
-        assertEquals("123", classToTest.getCropMarker());
-        assertEquals("abc", classToTest.getHighlightPreTag());
-        assertEquals(null, classToTest.getMatchingStrategy());
-        assertEquals("zyx", classToTest.getHighlightPostTag());
-        assertEquals("bubble", classToTest.getAttributesToRetrieve()[0]);
-        assertEquals("highlight", classToTest.getAttributesToHighlight()[0]);
-        assertEquals("crop", classToTest.getAttributesToCrop()[0]);
-        assertEquals(null, classToTest.getFilter());
-        assertEquals(2, classToTest.getFilterArray().length);
-        assertEquals("test='test'", classToTest.getFilterArray()[0][0]);
-        assertEquals("test1='test1'", classToTest.getFilterArray()[1][0]);
-        assertEquals("facets", classToTest.getFacets()[0]);
-        assertEquals("sort", classToTest.getSort()[0]);
-        assertEquals(900, classToTest.getCropLength());
-        assertEquals(
-                "{\"attributesToRetrieve\":[\"bubble\"],\"offset\":200,\"cropMarker\":\"123\",\"hitsPerPage\":0,\"sort\":[\"sort\"],\"highlightPreTag\":\"abc\",\"facets\":[\"facets\"],\"filter\":[[\"test='test'\"],[\"test1='test1'\"]],\"q\":\"This is a Test\",\"showMatchesPosition\":true,\"limit\":900,\"cropLength\":900,\"highlightPostTag\":\"zyx\",\"attributesToHighlight\":[\"highlight\"],\"page\":0,\"attributesToCrop\":[\"crop\"]}",
-                classToTest.toString());
+        assertThat(classToTest.getQ(), is(equalTo("This is a Test")));
+        assertThat(classToTest.getOffset(), is(equalTo(200)));
+        assertThat(classToTest.getLimit(), is(equalTo(900)));
+        assertThat(classToTest.getCropMarker(), is(equalTo("123")));
+        assertThat(classToTest.getHighlightPreTag(), is(equalTo("abc")));
+        assertThat(classToTest.getMatchingStrategy(), is(equalTo(null)));
+        assertThat(classToTest.getHighlightPostTag(), is(equalTo("zyx")));
+        assertThat(classToTest.getAttributesToRetrieve()[0], is(equalTo("bubble")));
+        assertThat(classToTest.getAttributesToHighlight()[0], is(equalTo("highlight")));
+        assertThat(classToTest.getAttributesToCrop()[0], is(equalTo("crop")));
+        assertThat(classToTest.getFilter(), is(equalTo(null)));
+        assertThat(classToTest.getFilterArray().length, is(equalTo(2)));
+        assertThat(classToTest.getFilterArray()[0][0], is(equalTo("test='test'")));
+        assertThat(classToTest.getFilterArray()[1][0], is(equalTo("test1='test1'")));
+        assertThat(classToTest.getFacets()[0], is(equalTo("facets")));
+        assertThat(classToTest.getSort()[0], is(equalTo("sort")));
+        assertThat(classToTest.getCropLength(), is(equalTo(900)));
+        assertThat(classToTest.toString(), is(equalTo(expectedToString)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/TaskHandlerUtilsTest.java
+++ b/src/test/java/com/meilisearch/sdk/TaskHandlerUtilsTest.java
@@ -1,11 +1,13 @@
 package com.meilisearch.sdk;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import com.meilisearch.sdk.model.TasksQuery;
 import org.junit.jupiter.api.Test;
 
-class TasksHandlerUtilsTest {
+class TaskHandlerUtilsTest {
 
     @Test
     void addIndexUidToQueryWithParamNull() {
@@ -14,7 +16,7 @@ class TasksHandlerUtilsTest {
         TasksQuery param = null;
         TasksQuery query = classToTest.addIndexUidToQuery("indexName", param);
 
-        assertEquals("?indexUids=indexName", query.toQuery().toString());
+        assertThat(query.toQuery(), is(equalTo("?indexUids=indexName")));
     }
 
     @Test
@@ -24,7 +26,7 @@ class TasksHandlerUtilsTest {
         TasksQuery param = new TasksQuery().setIndexUids(new String[] {});
         TasksQuery query = classToTest.addIndexUidToQuery("indexName", param);
 
-        assertEquals("?indexUids=indexName", query.toQuery().toString());
+        assertThat(query.toQuery(), is(equalTo("?indexUids=indexName")));
     }
 
     @Test
@@ -34,7 +36,7 @@ class TasksHandlerUtilsTest {
         TasksQuery param = new TasksQuery().setIndexUids(new String[] {"indexName2"});
         TasksQuery query = classToTest.addIndexUidToQuery("indexName1", param);
 
-        assertEquals("?indexUids=indexName2,indexName1", query.toQuery().toString());
+        assertThat(query.toQuery(), is(equalTo("?indexUids=indexName2,indexName1")));
     }
 
     @Test
@@ -49,8 +51,8 @@ class TasksHandlerUtilsTest {
                                 });
         TasksQuery query = classToTest.addIndexUidToQuery("indexName1", param);
 
-        assertEquals(
-                "?indexUids=indexName2,indexName3,indexName4,indexName5,indexName1",
-                query.toQuery().toString());
+        assertThat(
+                query.toQuery(),
+                is(equalTo("?indexUids=indexName2,indexName3,indexName4,indexName5,indexName1")));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchApiExceptionTest.java
+++ b/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchApiExceptionTest.java
@@ -1,6 +1,8 @@
 package com.meilisearch.sdk.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,9 +11,9 @@ class MeilisearchApiExceptionTest {
     @Test
     void testToString() {
         MeilisearchApiException classToTest = new MeilisearchApiException(new APIError());
-        assertEquals(
-                "Meilisearch ApiException: {Error=APIError: {message='null', code='null', type='null', link='null'}}",
-                classToTest.toString());
+        String expected =
+                "Meilisearch ApiException: {Error=APIError: {message='null', code='null', type='null', link='null'}}";
+        assertThat(classToTest.toString(), is(equalTo(expected)));
 
         classToTest =
                 new MeilisearchApiException(
@@ -21,8 +23,8 @@ class MeilisearchApiExceptionTest {
                                 .setLink(
                                         "https://www.meilisearch.com/docs/reference/errors/error_codes#index_not_found")
                                 .setType("invalid_request"));
-        assertEquals(
-                "Meilisearch ApiException: {Error=APIError: {message='Index `movies` not found.', code='index_not_found', type='invalid_request', link='https://www.meilisearch.com/docs/reference/errors/error_codes#index_not_found'}}",
-                classToTest.toString());
+        expected =
+                "Meilisearch ApiException: {Error=APIError: {message='Index `movies` not found.', code='index_not_found', type='invalid_request', link='https://www.meilisearch.com/docs/reference/errors/error_codes#index_not_found'}}";
+        assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchCommunicationExceptionTest.java
+++ b/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchCommunicationExceptionTest.java
@@ -1,6 +1,8 @@
 package com.meilisearch.sdk.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,8 +12,8 @@ class MeilisearchCommunicationExceptionTest {
     void testToString() {
         MeilisearchCommunicationException classToTest =
                 new MeilisearchCommunicationException("This is a Test");
-        assertEquals(
-                "Meilisearch CommunicationException: {Error=This is a Test}",
-                classToTest.toString());
+        assertThat(
+                classToTest.toString(),
+                is(equalTo("Meilisearch CommunicationException: {Error=This is a Test}")));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchExceptionTest.java
+++ b/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchExceptionTest.java
@@ -1,6 +1,8 @@
 package com.meilisearch.sdk.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.net.MalformedURLException;
 import org.junit.jupiter.api.Test;
@@ -10,13 +12,13 @@ class MeilisearchExceptionTest {
     @Test
     void testToString() {
         MeilisearchException classToTest = new MeilisearchException("This is a Test");
-        assertEquals(
-                "Meilisearch Exception: {com.meilisearch.sdk.exceptions.MeilisearchException. Error=This is a Test}",
-                classToTest.toString());
+        String expected =
+                "Meilisearch Exception: {com.meilisearch.sdk.exceptions.MeilisearchException. Error=This is a Test}";
+        assertThat(classToTest.toString(), is(equalTo(expected)));
 
         classToTest = new MeilisearchException(new MalformedURLException());
-        assertEquals(
-                "Meilisearch Exception: {java.net.MalformedURLException. Error=java.net.MalformedURLException}",
-                classToTest.toString());
+        expected =
+                "Meilisearch Exception: {java.net.MalformedURLException. Error=java.net.MalformedURLException}";
+        assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchTimeoutExceptionTest.java
+++ b/src/test/java/com/meilisearch/sdk/exceptions/MeilisearchTimeoutExceptionTest.java
@@ -1,6 +1,8 @@
 package com.meilisearch.sdk.exceptions;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +11,8 @@ class MeilisearchTimeoutExceptionTest {
     @Test
     void testToString() {
         MeilisearchTimeoutException classToTest = new MeilisearchTimeoutException("This is a Test");
-        assertEquals(
-                "Meilisearch TimeoutException: {Error=This is a Test}", classToTest.toString());
+        assertThat(
+                classToTest.toString(),
+                is(equalTo("Meilisearch TimeoutException: {Error=This is a Test}")));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/http/BasicRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/BasicRequestTest.java
@@ -1,8 +1,8 @@
 package com.meilisearch.sdk.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import com.meilisearch.sdk.http.request.BasicRequest;
 import com.meilisearch.sdk.http.request.HttpMethod;
@@ -20,9 +20,9 @@ class BasicRequestTest {
     void basicUseCase() {
         HttpRequest httpRequest = request.create(HttpMethod.GET, "/", Collections.emptyMap(), null);
 
-        assertFalse(httpRequest.hasContent());
-        assertEquals(httpRequest.getPath(), "/");
-        assertEquals(httpRequest.getMethod(), HttpMethod.GET);
+        assertThat(httpRequest.hasContent(), is(equalTo(false)));
+        assertThat(httpRequest.getPath(), is(equalTo("/")));
+        assertThat(httpRequest.getMethod(), is(equalTo(HttpMethod.GET)));
     }
 
     @Test
@@ -30,10 +30,10 @@ class BasicRequestTest {
         HttpRequest httpRequest =
                 request.create(HttpMethod.GET, "/", Collections.emptyMap(), "thisisatest");
 
-        assertTrue(httpRequest.hasContent());
-        assertEquals(httpRequest.getContent(), "thisisatest");
-        assertEquals(httpRequest.getPath(), "/");
-        assertEquals(httpRequest.getMethod(), HttpMethod.GET);
+        assertThat(httpRequest.hasContent(), is(equalTo(true)));
+        assertThat(httpRequest.getContent(), is(equalTo("thisisatest")));
+        assertThat(httpRequest.getPath(), is(equalTo("/")));
+        assertThat(httpRequest.getMethod(), is(equalTo(HttpMethod.GET)));
     }
 
     @Test
@@ -45,10 +45,11 @@ class BasicRequestTest {
                         Collections.emptyMap(),
                         new Movie("thisisanid", "thisisatitle"));
 
-        assertTrue(httpRequest.hasContent());
-        assertEquals(
-                httpRequest.getContent(), "{\"id\":\"thisisanid\",\"title\":\"thisisatitle\"}");
-        assertEquals(httpRequest.getPath(), "/");
-        assertEquals(httpRequest.getMethod(), HttpMethod.GET);
+        assertThat(httpRequest.hasContent(), is(equalTo(true)));
+        assertThat(
+                httpRequest.getContent(),
+                is(equalTo("{\"id\":\"thisisanid\",\"title\":\"thisisatitle\"}")));
+        assertThat(httpRequest.getPath(), is(equalTo("/")));
+        assertThat(httpRequest.getMethod(), is(equalTo(HttpMethod.GET)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/http/BasicResponseTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/BasicResponseTest.java
@@ -1,8 +1,10 @@
 package com.meilisearch.sdk.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.meilisearch.sdk.http.response.BasicResponse;
 import com.meilisearch.sdk.http.response.HttpResponse;
@@ -18,13 +20,13 @@ public class BasicResponseTest {
 
     @Test
     void basicUseCase() {
-        HttpResponse<String> response = new HttpResponse<String>(null, 0, "");
+        HttpResponse<String> response = new HttpResponse<>(null, 0, "");
         HttpResponse<String> httpResponse = basicResponse.create(response, String.class);
 
-        assertTrue(httpResponse.hasContent());
-        assertEquals(httpResponse.getContent(), "");
-        assertNull(httpResponse.getHeaders());
-        assertEquals(httpResponse.getStatusCode(), 0);
+        assertThat(httpResponse.hasContent(), is(equalTo(true)));
+        assertThat(httpResponse.getContent(), is(emptyString()));
+        assertThat(httpResponse.getHeaders(), is(nullValue()));
+        assertThat(httpResponse.getStatusCode(), is(equalTo(0)));
     }
 
     @Test
@@ -35,56 +37,60 @@ public class BasicResponseTest {
                         put("thisisaheader", "header");
                     }
                 };
-        HttpResponse<String> response = new HttpResponse<String>(header, 0, "");
+        HttpResponse<String> response = new HttpResponse<>(header, 0, "");
         HttpResponse<String> httpResponse = basicResponse.create(response, String.class);
 
-        assertTrue(httpResponse.hasContent());
-        assertEquals(httpResponse.getHeaders(), header);
-        assertEquals(httpResponse.getStatusCode(), 0);
+        assertThat(httpResponse.hasContent(), is(equalTo(true)));
+        assertThat(httpResponse.getHeaders(), is(equalTo(header)));
+        assertThat(httpResponse.getStatusCode(), is(equalTo(0)));
     }
 
     @Test
     void statusCodeNotZero() {
-        HttpResponse<String> response = new HttpResponse<String>(null, 200, "");
+        HttpResponse<String> response = new HttpResponse<>(null, 200, "");
         HttpResponse<String> httpResponse = basicResponse.create(response, String.class);
 
-        assertTrue(httpResponse.hasContent());
-        assertEquals(httpResponse.getContent(), "");
-        assertNull(httpResponse.getHeaders());
-        assertEquals(httpResponse.getStatusCode(), 200);
+        assertThat(httpResponse.hasContent(), is(equalTo(true)));
+        assertThat(httpResponse.getContent(), is(emptyString()));
+        assertThat(httpResponse.getHeaders(), is(nullValue()));
+        assertThat(httpResponse.getStatusCode(), is(equalTo(200)));
     }
 
     @Test
     void contentString() {
-        HttpResponse<String> response = new HttpResponse<String>(null, 0, "thisisatest");
+        HttpResponse<String> response = new HttpResponse<>(null, 0, "thisisatest");
         HttpResponse<String> httpResponse = basicResponse.create(response, String.class);
 
-        assertNull(httpResponse.getHeaders());
-        assertEquals(httpResponse.getStatusCode(), 0);
-        assertTrue(httpResponse.hasContent());
-        assertEquals(httpResponse.getContent(), "thisisatest");
+        assertThat(httpResponse.getHeaders(), is(nullValue()));
+        assertThat(httpResponse.getStatusCode(), is(equalTo(0)));
+        assertThat(httpResponse.hasContent(), is(equalTo(true)));
+        assertThat(httpResponse.getContent(), is(equalTo("thisisatest")));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void contentClass() {
         String content =
                 "{ \"uid\": 0, \"indexUid\": \"\", \"status\": \"\", \"type\": null, \"details\": null, \"duration\": \"\", \"enqueuedAt\": null, \"startedAt\": null, \"finishedAt\": null}";
         HttpResponse response = new HttpResponse(null, 0, content);
         HttpResponse<Task> httpResponse = basicResponse.create(response, Task.class);
 
-        assertNull(httpResponse.getHeaders());
-        assertEquals(httpResponse.getStatusCode(), 0);
-        assertTrue(httpResponse.hasContent());
-        assertEquals(httpResponse.getContent().getStatus(), new Task().getStatus());
-        assertEquals(httpResponse.getContent().getUid(), new Task().getUid());
-        assertEquals(httpResponse.getContent().getIndexUid(), new Task().getIndexUid());
-        assertEquals(httpResponse.getContent().getType(), new Task().getType());
-        assertEquals(httpResponse.getContent().getDuration(), new Task().getDuration());
-        assertEquals(httpResponse.getContent().getEnqueuedAt(), new Task().getEnqueuedAt());
-        assertEquals(httpResponse.getContent().getStartedAt(), new Task().getStartedAt());
-        assertEquals(httpResponse.getContent().getFinishedAt(), new Task().getFinishedAt());
-        assertEquals(httpResponse.getContent().getError(), new Task().getError());
-        assertEquals(httpResponse.getContent().getDetails(), new Task().getDetails());
-        assertEquals(httpResponse.getContent().getClass(), Task.class);
+        assertThat(httpResponse.getHeaders(), is(nullValue()));
+        assertThat(httpResponse.getStatusCode(), is(equalTo(0)));
+        assertThat(httpResponse.hasContent(), is(equalTo(true)));
+        assertThat(httpResponse.getContent().getStatus(), is(equalTo(new Task().getStatus())));
+        assertThat(httpResponse.getContent().getUid(), is(equalTo(new Task().getUid())));
+        assertThat(httpResponse.getContent().getIndexUid(), is(equalTo(new Task().getIndexUid())));
+        assertThat(httpResponse.getContent().getType(), is(equalTo(new Task().getType())));
+        assertThat(httpResponse.getContent().getDuration(), is(equalTo(new Task().getDuration())));
+        assertThat(
+                httpResponse.getContent().getEnqueuedAt(), is(equalTo(new Task().getEnqueuedAt())));
+        assertThat(
+                httpResponse.getContent().getStartedAt(), is(equalTo(new Task().getStartedAt())));
+        assertThat(
+                httpResponse.getContent().getFinishedAt(), is(equalTo(new Task().getFinishedAt())));
+        assertThat(httpResponse.getContent().getError(), is(equalTo(new Task().getError())));
+        assertThat(httpResponse.getContent().getDetails(), is(equalTo(new Task().getDetails())));
+        assertThat(httpResponse.getContent().getClass(), is(equalTo(Task.class)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -1,5 +1,8 @@
 package com.meilisearch.sdk.http;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.text.SimpleDateFormat;
@@ -15,7 +18,7 @@ public class URLBuilderTest {
     void addSubroute() {
         classToTest.addSubroute("route");
 
-        assertEquals("/route", classToTest.getRoutes().toString());
+        assertThat(classToTest.getRoutes().toString(), is(equalTo("/route")));
     }
 
     @Test
@@ -26,59 +29,65 @@ public class URLBuilderTest {
                 .addSubroute("route3")
                 .addSubroute("route4");
 
-        assertEquals("/route1/route2/route3/route4", classToTest.getRoutes().toString());
+        assertThat(classToTest.getRoutes().toString(), is(equalTo("/route1/route2/route3/route4")));
     }
 
     @Test
     void addParameterStringInt() {
         classToTest.addParameter("parameter1", 1);
-        assertEquals("?parameter1=1", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1")));
 
         classToTest.addParameter("parameter2", 2);
-        assertEquals("?parameter1=1&parameter2=2", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1&parameter2=2")));
 
         classToTest.addParameter("parameter3", 3);
-        assertEquals("?parameter1=1&parameter2=2&parameter3=3", classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(),
+                is(equalTo("?parameter1=1&parameter2=2&parameter3=3")));
     }
 
     @Test
     void addParameterStringString() {
         classToTest.addParameter("parameter1", "1");
-        assertEquals("?parameter1=1", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1")));
 
         classToTest.addParameter("parameter2", "2");
-        assertEquals("?parameter1=1&parameter2=2", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1&parameter2=2")));
 
         classToTest.addParameter("parameter3", "3");
-        assertEquals("?parameter1=1&parameter2=2&parameter3=3", classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(),
+                is(equalTo("?parameter1=1&parameter2=2&parameter3=3")));
     }
 
     @Test
     void addParameterStringStringArray() {
         classToTest.addParameter("parameter1", new String[] {"1", "a"});
-        assertEquals("?parameter1=1,a", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1,a")));
 
         classToTest.addParameter("parameter2", new String[] {"2", "b"});
-        assertEquals("?parameter1=1,a&parameter2=2,b", classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(), is(equalTo("?parameter1=1,a&parameter2=2,b")));
 
         classToTest.addParameter("parameter3", new String[] {"3", "c"});
-        assertEquals(
-                "?parameter1=1,a&parameter2=2,b&parameter3=3,c",
-                classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(),
+                is(equalTo("?parameter1=1,a&parameter2=2,b&parameter3=3,c")));
     }
 
     @Test
     void addParameterStringIntArray() {
         classToTest.addParameter("parameter1", new int[] {1, 2});
-        assertEquals("?parameter1=1,2", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=1,2")));
 
         classToTest.addParameter("parameter2", new int[] {3, 4});
-        assertEquals("?parameter1=1,2&parameter2=3,4", classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(), is(equalTo("?parameter1=1,2&parameter2=3,4")));
 
         classToTest.addParameter("parameter3", new int[] {5, 6});
-        assertEquals(
-                "?parameter1=1,2&parameter2=3,4&parameter3=5,6",
-                classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(),
+                is(equalTo("?parameter1=1,2&parameter2=3,4&parameter3=5,6")));
     }
 
     @Test
@@ -93,7 +102,7 @@ public class URLBuilderTest {
                         .toString()
                         .substring(12, classToTest.getParams().toString().length());
         assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate1));
-        assertEquals("?parameter1=2042-01-30", classToTest.getParams().toString());
+        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=2042-01-30")));
 
         classToTest.addParameter("parameter2", date);
         String parameterDate2 =
@@ -102,17 +111,18 @@ public class URLBuilderTest {
                         .toString()
                         .substring(34, classToTest.getParams().toString().length());
         assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate2));
-        assertEquals(
-                "?parameter1=2042-01-30&parameter2=2042-01-30", classToTest.getParams().toString());
+        assertThat(
+                classToTest.getParams().toString(),
+                is(equalTo("?parameter1=2042-01-30&parameter2=2042-01-30")));
     }
 
     @Test
     void getURL() {
-        assertEquals("", classToTest.getURL());
+        assertThat(classToTest.getURL(), is(equalTo("")));
 
         classToTest.addSubroute("routes");
         classToTest.addParameter("parameter", "value");
 
-        assertEquals("/routes?parameter=value", classToTest.getURL());
+        assertThat(classToTest.getURL(), is(equalTo("/routes?parameter=value")));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -2,8 +2,11 @@ package com.meilisearch.sdk.json;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -22,7 +25,7 @@ class GsonJsonHandlerTest {
 
     @Test
     void serialize() throws Exception {
-        assertEquals("test", classToTest.encode("test"));
+        assertThat(classToTest.encode("test"), is(equalTo("test")));
         when(mapper.toJson(any(Movie.class))).thenThrow(new RuntimeException("Oh boy!"));
         assertThrows(JsonEncodingException.class, () -> classToTest.encode(new Movie()));
     }
@@ -37,7 +40,7 @@ class GsonJsonHandlerTest {
     @Test
     void deserializeString() throws Exception {
         String content = "{}";
-        assertEquals(content, classToTest.decode(content, String.class));
+        assertThat(classToTest.decode(content, String.class), is(equalTo(content)));
     }
 
     @Test
@@ -48,8 +51,8 @@ class GsonJsonHandlerTest {
     @Test
     @SuppressWarnings({"RedundantArrayCreation", "ConfusingArgumentToVarargsMethod"})
     void deserializeWithParametersEmpty() throws Exception {
-        assertNotNull(classToTest.decode("{}", Movie.class, (Class<?>[]) null));
-        assertNotNull(classToTest.decode("{}", Movie.class, new Class[0]));
+        assertThat(classToTest.decode("{}", Movie.class, (Class<?>[]) null), is(notNullValue()));
+        assertThat(classToTest.decode("{}", Movie.class, new Class[0]), is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -2,8 +2,11 @@ package com.meilisearch.sdk.json;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -21,7 +24,7 @@ class JacksonJsonHandlerTest {
 
     @Test
     void serialize() throws Exception {
-        assertEquals("test", classToTest.encode("test"));
+        assertThat(classToTest.encode("test"), is(equalTo("test")));
         when(mapper.writeValueAsString(any(Movie.class)))
                 .thenThrow(new RuntimeException("Oh boy!"));
         assertThrows(RuntimeException.class, () -> classToTest.encode(new Movie()));
@@ -37,7 +40,7 @@ class JacksonJsonHandlerTest {
     @Test
     void deserializeString() throws Exception {
         String content = "{}";
-        assertEquals(content, classToTest.decode(content, String.class));
+        assertThat(classToTest.decode(content, String.class), is(equalTo(content)));
     }
 
     @Test
@@ -48,8 +51,8 @@ class JacksonJsonHandlerTest {
     @Test
     @SuppressWarnings({"RedundantArrayCreation", "ConfusingArgumentToVarargsMethod"})
     void deserializeWithParametersEmpty() throws Exception {
-        assertNotNull(classToTest.decode("{}", Movie.class, (Class<?>[]) null));
-        assertNotNull(classToTest.decode("{}", Movie.class, new Class[0]));
+        assertThat(classToTest.decode("{}", Movie.class, (Class<?>[]) null), is(notNullValue()));
+        assertThat(classToTest.decode("{}", Movie.class, new Class[0]), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

Apologies for the enormous PR!

## Related issue
Fixes #324

## What does this PR do?
- Converts existing tests to use Hamcrest matchers where possible (it still uses JUnit for `assertThrows` and `assertDoesNotThrow`)
- Removes some unnecessary casts and other small tweaks to the tests here and there

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
