### PR TITLE
Fix possible unintended definition of BasicResponse.create

### DIFF
--- a/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
+++ b/src/main/java/com/meilisearch/sdk/http/response/BasicResponse.java
@@ -9,12 +9,12 @@ public class BasicResponse {
         this.jsonHandler = jsonHandler;
     }
 
-    public <T> HttpResponse<T> create(
-            HttpResponse<T> httpResponse, Class<T> targetClass, Class<?>... parameters) {
+    public <T, R> HttpResponse<R> create(
+            HttpResponse<T> httpResponse, Class<R> targetClass, Class<?>... parameters) {
         try {
-            T content = this.jsonHandler.decode(httpResponse.getContent(), targetClass, parameters);
+            R content = this.jsonHandler.decode(httpResponse.getContent(), targetClass, parameters);
 
-            return new HttpResponse<T>(
+            return new HttpResponse<>(
                     httpResponse.getHeaders(),
                     httpResponse.getStatusCode(),
                     httpResponse.getContent() == null ? null : content);

--- a/src/test/java/com/meilisearch/sdk/http/BasicResponseTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/BasicResponseTest.java
@@ -68,11 +68,10 @@ public class BasicResponseTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void contentClass() {
         String content =
                 "{ \"uid\": 0, \"indexUid\": \"\", \"status\": \"\", \"type\": null, \"details\": null, \"duration\": \"\", \"enqueuedAt\": null, \"startedAt\": null, \"finishedAt\": null}";
-        HttpResponse response = new HttpResponse(null, 0, content);
+        HttpResponse<String> response = new HttpResponse<>(null, 0, content);
         HttpResponse<Task> httpResponse = basicResponse.create(response, Task.class);
 
         assertThat(httpResponse.getHeaders(), is(nullValue()));


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #642 

## What does this PR do?
- Fixes a minor issue with `BasicResponse.create`, allowing the second argument to declare the type parameter of the returned `HttpResponse`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
