### PR TITLE
Mark internal fields as transient

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -19,12 +19,12 @@ public class Index implements Serializable {
     @Getter protected Pagination pagination;
     @Getter protected Faceting faceting;
     @Getter @ToString.Exclude protected String updatedAt;
-    @Getter @ToString.Exclude protected Config config;
-    @ToString.Exclude protected Documents documents;
-    @ToString.Exclude protected TasksHandler tasksHandler;
-    @ToString.Exclude protected Search search;
-    @ToString.Exclude protected SettingsHandler settingsHandler;
-    @ToString.Exclude protected InstanceHandler instanceHandler;
+     @Getter @ToString.Exclude protected transient Config config;
+    @ToString.Exclude protected transient Documents documents;
+    @ToString.Exclude protected transient TasksHandler tasksHandler;
+    @ToString.Exclude protected transient Search search;
+    @ToString.Exclude protected transient SettingsHandler settingsHandler;
+    @ToString.Exclude protected transient InstanceHandler instanceHandler;
 
     /**
      * Sets the Meilisearch configuration for the index

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -19,7 +19,7 @@ public class Index implements Serializable {
     @Getter protected Pagination pagination;
     @Getter protected Faceting faceting;
     @Getter @ToString.Exclude protected String updatedAt;
-     @Getter @ToString.Exclude protected transient Config config;
+    @Getter @ToString.Exclude protected transient Config config;
     @ToString.Exclude protected transient Documents documents;
     @ToString.Exclude protected transient TasksHandler tasksHandler;
     @ToString.Exclude protected transient Search search;

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -1,14 +1,5 @@
 package com.meilisearch.integration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.google.gson.*;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -20,6 +11,10 @@ import com.meilisearch.sdk.utils.Movie;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Modifier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("integration")
 public class ClientTest extends AbstractIT {
@@ -312,13 +307,11 @@ public class ClientTest extends AbstractIT {
     public void testTransientFieldExclusion() throws MeilisearchException {
         Index test = client.index("Transient");
 
-        Gson gsonWithTransient = new GsonBuilder()
-            .excludeFieldsWithModifiers(Modifier.STATIC)
-            .create();
+        Gson gsonWithTransient =
+                new GsonBuilder().excludeFieldsWithModifiers(Modifier.STATIC).create();
 
         // TODO: Throws StackOverflowError on JDK 1.8, but InaccessibleObjectException on JDK9+
         Assertions.assertThrows(StackOverflowError.class, () -> gsonWithTransient.toJson(test));
         Assertions.assertDoesNotThrow(() -> gson.toJson(test));
     }
-
 }

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -1,5 +1,9 @@
 package com.meilisearch.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.google.gson.*;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -8,13 +12,8 @@ import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.*;
 import com.meilisearch.sdk.utils.Movie;
-import org.junit.jupiter.api.*;
-
 import java.lang.reflect.Modifier;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.*;
 
 @Tag("integration")
 public class ClientTest extends AbstractIT {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #655

## What does this PR do?
Gson has issues working with the class `com.meilisearch.sdk.Index` in Java 9 and higher. Specifically all the fields which hold a `com.meilisearch.sdk.HttpClient`. Marking those fields as `transient` excludes them from serialization and thus preventing the reflective access on JDK-internal types.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
