### PR TITLE
Improve GSON JSON handler, moving Key specific logic

### DIFF
--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -35,7 +35,7 @@ public class GsonJsonHandler implements JsonHandler {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T decode(Object o, Class<?> targetClass, Class<?>... parameters)
-        throws MeilisearchException {
+            throws MeilisearchException {
         if (o == null) {
             throw new JsonDecodingException("Response to deserialize is null");
         }

--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -2,9 +2,6 @@ package com.meilisearch.sdk.json;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.meilisearch.sdk.exceptions.JsonDecodingException;

--- a/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
@@ -1,0 +1,154 @@
+package com.meilisearch.sdk.json;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.meilisearch.sdk.model.Key;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
+
+    private static final DateFormat DATE_FORMAT =
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    @Override
+    public void write(JsonWriter writer, Key key) throws IOException {
+        boolean serializeNulls = writer.getSerializeNulls();
+
+        writer.beginObject();
+        writer.setSerializeNulls(true);
+        writeOptionalString(writer, "name", key.getName());
+        writeOptionalString(writer, "description", key.getDescription());
+        writeOptionalString(writer, "uid", key.getUid());
+        writeOptionalString(writer, "key", key.getKey());
+        writeStringArray(writer, "actions", key.getActions());
+        writeStringArray(writer, "indexes", key.getIndexes());
+        if (key.getExpiresAt() == null) {
+            writeNull(writer, "expiresAt");
+        } else {
+            writeDate(writer, "expiresAt", key.getExpiresAt());
+        }
+        writeDate(writer, "createdAt", key.getCreatedAt());
+        writeDate(writer, "updatedAt", key.getUpdatedAt());
+        writer.endObject();
+
+        writer.setSerializeNulls(serializeNulls);
+    }
+
+    @Override
+    public Key read(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+            return null;
+        }
+
+        Key key = new Key();
+        reader.beginObject();
+        while (reader.peek() != JsonToken.END_OBJECT) {
+            String name = reader.nextName();
+            switch (name) {
+                case "name":
+                    key.setName(readString(reader));
+                    break;
+                case "description":
+                    key.setDescription(readString(reader));
+                    break;
+                case "uid":
+                    key.setUid(readString(reader));
+                    break;
+                case "key":
+                    key.setKey(readString(reader));
+                    break;
+                case "actions":
+                    key.setActions(readStringArray(reader));
+                    break;
+                case "indexes":
+                    key.setIndexes(readStringArray(reader));
+                    break;
+                case "expiresAt":
+                    key.setExpiresAt(readDate(reader));
+                    break;
+                case "createdAt":
+                    key.setCreatedAt(readDate(reader));
+                    break;
+                case "updatedAt":
+                    key.setUpdatedAt(readDate(reader));
+                    break;
+                default:
+                    discardNext(reader);
+                    break;
+            }
+        }
+
+        reader.endObject();
+        return key;
+    }
+
+    private String readString(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+            reader.nextNull();
+            return null;
+        }
+        return reader.nextString();
+    }
+
+    private String[] readStringArray(JsonReader reader) throws IOException {
+        List<String> values = new ArrayList<>();
+        reader.beginArray();
+        while (reader.peek() != JsonToken.END_ARRAY) {
+            values.add(reader.nextString());
+        }
+        reader.endArray();
+        return values.toArray(new String[0]);
+    }
+
+    private Date readDate(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+            reader.nextNull();
+            return null;
+        }
+        String value = reader.nextString();
+        return Date.from(Instant.parse(value));
+    }
+
+    private JsonWriter writeNull(JsonWriter writer, String key) throws IOException {
+        return writer.name(key).nullValue();
+    }
+
+    private JsonWriter writeOptionalString(JsonWriter writer, String key, String value) throws IOException {
+        if (value == null) {
+            return writer;
+        }
+        return writer.name(key).value(value);
+    }
+
+    private JsonWriter writeStringArray(JsonWriter writer, String key, String[] value) throws IOException {
+        if (value == null) {
+            return writer;
+        }
+
+        writer.name(key).beginArray();
+        for (String item : value) {
+            writer.value(item);
+        }
+        return writer.endArray();
+    }
+
+    private JsonWriter writeDate(JsonWriter writer, String key, Date value) throws IOException {
+        if (value == null) {
+            return writer;
+        }
+        return writer.name(key).value(DATE_FORMAT.format(value));
+    }
+
+    private JsonReader discardNext(JsonReader reader) throws IOException {
+        reader.skipValue();
+        return reader;
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
@@ -55,48 +55,46 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
 
     @Override
     public Key read(JsonReader reader) throws IOException {
-        if (reader.peek() == JsonToken.NULL) {
-            return null;
-        }
-
-        Key key = new Key();
-        readStartObject(reader);
-        while (reader.peek() != JsonToken.END_OBJECT) {
-            switch (reader.nextName()) {
-                case KEY_NAME:
-                    key.setName(readString(reader));
-                    break;
-                case KEY_DESCRIPTION:
-                    key.setDescription(readString(reader));
-                    break;
-                case KEY_UID:
-                    key.setUid(readString(reader));
-                    break;
-                case KEY_KEY:
-                    key.setKey(readString(reader));
-                    break;
-                case KEY_ACTIONS:
-                    key.setActions(readStringArray(reader));
-                    break;
-                case KEY_INDEXES:
-                    key.setIndexes(readStringArray(reader));
-                    break;
-                case KEY_EXPIRES_AT:
-                    key.setExpiresAt(readDate(reader));
-                    break;
-                case KEY_CREATED_AT:
-                    key.setCreatedAt(readDate(reader));
-                    break;
-                case KEY_UPDATED_AT:
-                    key.setUpdatedAt(readDate(reader));
-                    break;
-                default:
-                    readAndDiscard(reader);
-                    break;
+        return nullOrElse(reader, r -> {
+            Key key = new Key();
+            readStartObject(r);
+            while (r.peek() != JsonToken.END_OBJECT) {
+                switch (r.nextName()) {
+                    case KEY_NAME:
+                        key.setName(readString(r));
+                        break;
+                    case KEY_DESCRIPTION:
+                        key.setDescription(readString(r));
+                        break;
+                    case KEY_UID:
+                        key.setUid(readString(r));
+                        break;
+                    case KEY_KEY:
+                        key.setKey(readString(r));
+                        break;
+                    case KEY_ACTIONS:
+                        key.setActions(readStringArray(r));
+                        break;
+                    case KEY_INDEXES:
+                        key.setIndexes(readStringArray(r));
+                        break;
+                    case KEY_EXPIRES_AT:
+                        key.setExpiresAt(readDate(r));
+                        break;
+                    case KEY_CREATED_AT:
+                        key.setCreatedAt(readDate(r));
+                        break;
+                    case KEY_UPDATED_AT:
+                        key.setUpdatedAt(readDate(r));
+                        break;
+                    default:
+                        readAndDiscard(r);
+                        break;
+                }
             }
-        }
-        readEndObject(reader);
-        return key;
+            readEndObject(r);
+            return key;
+        });
     }
 
     private void writeStartObject(JsonWriter writer) throws IOException {
@@ -169,7 +167,11 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
         reader.skipValue();
     }
 
-    private <T> T nullOrElse(JsonReader reader, ReaderFn<T> fn) throws IOException {
+    private Date parseDate(String value) {
+        return Date.from(Instant.parse(value));
+    }
+
+    private <T> T nullOrElse(JsonReader reader, ReadValueFunction<T> fn) throws IOException {
         if (reader.peek() == JsonToken.NULL) {
             reader.nextNull();
             return null;
@@ -178,11 +180,8 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
         return fn.apply(reader);
     }
 
-    private Date parseDate(String value) {
-        return Date.from(Instant.parse(value));
-    }
+    private interface ReadValueFunction<T> {
 
-    private interface ReaderFn<T> {
         T apply(JsonReader reader) throws IOException;
     }
 }

--- a/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonKeyTypeAdapter.java
@@ -24,8 +24,7 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
     private static final String KEY_EXPIRES_AT = "expiresAt";
     private static final String KEY_CREATED_AT = "createdAt";
     private static final String KEY_UPDATED_AT = "updatedAt";
-    private static final DateFormat DATE_FORMAT =
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     @Override
     public void write(JsonWriter writer, Key key) throws IOException {
@@ -55,46 +54,48 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
 
     @Override
     public Key read(JsonReader reader) throws IOException {
-        return nullOrElse(reader, r -> {
-            Key key = new Key();
-            readStartObject(r);
-            while (r.peek() != JsonToken.END_OBJECT) {
-                switch (r.nextName()) {
-                    case KEY_NAME:
-                        key.setName(readString(r));
-                        break;
-                    case KEY_DESCRIPTION:
-                        key.setDescription(readString(r));
-                        break;
-                    case KEY_UID:
-                        key.setUid(readString(r));
-                        break;
-                    case KEY_KEY:
-                        key.setKey(readString(r));
-                        break;
-                    case KEY_ACTIONS:
-                        key.setActions(readStringArray(r));
-                        break;
-                    case KEY_INDEXES:
-                        key.setIndexes(readStringArray(r));
-                        break;
-                    case KEY_EXPIRES_AT:
-                        key.setExpiresAt(readDate(r));
-                        break;
-                    case KEY_CREATED_AT:
-                        key.setCreatedAt(readDate(r));
-                        break;
-                    case KEY_UPDATED_AT:
-                        key.setUpdatedAt(readDate(r));
-                        break;
-                    default:
-                        readAndDiscard(r);
-                        break;
-                }
-            }
-            readEndObject(r);
-            return key;
-        });
+        return nullOrElse(
+                reader,
+                r -> {
+                    Key key = new Key();
+                    readStartObject(r);
+                    while (r.peek() != JsonToken.END_OBJECT) {
+                        switch (r.nextName()) {
+                            case KEY_NAME:
+                                key.setName(readString(r));
+                                break;
+                            case KEY_DESCRIPTION:
+                                key.setDescription(readString(r));
+                                break;
+                            case KEY_UID:
+                                key.setUid(readString(r));
+                                break;
+                            case KEY_KEY:
+                                key.setKey(readString(r));
+                                break;
+                            case KEY_ACTIONS:
+                                key.setActions(readStringArray(r));
+                                break;
+                            case KEY_INDEXES:
+                                key.setIndexes(readStringArray(r));
+                                break;
+                            case KEY_EXPIRES_AT:
+                                key.setExpiresAt(readDate(r));
+                                break;
+                            case KEY_CREATED_AT:
+                                key.setCreatedAt(readDate(r));
+                                break;
+                            case KEY_UPDATED_AT:
+                                key.setUpdatedAt(readDate(r));
+                                break;
+                            default:
+                                readAndDiscard(r);
+                                break;
+                        }
+                    }
+                    readEndObject(r);
+                    return key;
+                });
     }
 
     private void writeStartObject(JsonWriter writer) throws IOException {
@@ -116,7 +117,8 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
         writer.name(key).value(value);
     }
 
-    private void writeStringArray(JsonWriter writer, String key, String[] value) throws IOException {
+    private void writeStringArray(JsonWriter writer, String key, String[] value)
+            throws IOException {
         if (value == null) {
             return;
         }
@@ -148,15 +150,17 @@ public class GsonKeyTypeAdapter extends TypeAdapter<Key> {
     }
 
     private String[] readStringArray(JsonReader reader) throws IOException {
-        return nullOrElse(reader, r -> {
-            List<String> values = new ArrayList<>();
-            r.beginArray();
-            while (r.peek() != JsonToken.END_ARRAY) {
-                values.add(r.nextString());
-            }
-            r.endArray();
-            return values.toArray(new String[0]);
-        });
+        return nullOrElse(
+                reader,
+                r -> {
+                    List<String> values = new ArrayList<>();
+                    r.beginArray();
+                    while (r.peek() != JsonToken.END_ARRAY) {
+                        values.add(r.nextString());
+                    }
+                    r.endArray();
+                    return values.toArray(new String[0]);
+                });
     }
 
     private Date readDate(JsonReader reader) throws IOException {

--- a/src/main/java/com/meilisearch/sdk/model/Key.java
+++ b/src/main/java/com/meilisearch/sdk/model/Key.java
@@ -13,13 +13,12 @@ import lombok.experimental.Accessors;
  * @see <a href="https://www.meilisearch.com/docs/reference/api/keys">API specification</a>
  */
 @Getter
+@Setter
 @JsonInclude(Include.NON_NULL)
 public class Key {
-    @Setter
     @Accessors(chain = true)
     protected String name = null;
 
-    @Setter
     @Accessors(chain = true)
     protected String description = null;
 
@@ -27,15 +26,12 @@ public class Key {
 
     protected String key = null;
 
-    @Setter
     @Accessors(chain = true)
     protected String[] actions = null;
 
-    @Setter
     @Accessors(chain = true)
     protected String[] indexes = null;
 
-    @Setter
     @Accessors(chain = true)
     @JsonInclude(Include.ALWAYS)
     protected Date expiresAt = null;

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Getter;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 class GsonJsonHandlerTest {
@@ -206,6 +208,23 @@ class GsonJsonHandlerTest {
     }
 
     @Test
+    void decodeKeyWithNullIndexes() {
+        Key key = classToTest.decode("{\"indexes\":null}", Key.class);
+
+        assertThat(key, is(notNullValue()));
+        assertThat(key.getIndexes(), is(nullValue()));
+    }
+
+    @Test
+    void decodeKeyWithEmptyArrayActions() {
+        Key key = classToTest.decode("{\"actions\":[]}", Key.class);
+
+        assertThat(key, is(notNullValue()));
+        assertThat(key.getActions(), is(notNullValue()));
+        assertThat(key.getActions(), is(arrayWithSize(0)));
+    }
+
+    @Test
     void decodeKeyWithAllFieldsSet() {
         String timestamp = "2023-11-23T21:29:16.123Z";
         String input = "{\"key\":\"foo\",\"uid\":\"foo123\",\"name\":\"Foo\",\"description\":\"Foo bar\","
@@ -226,6 +245,26 @@ class GsonJsonHandlerTest {
         assertThat(key.getExpiresAt(), is(nullValue()));
         assertThat(key.getCreatedAt(), is(equalTo(Date.from(Instant.parse(timestamp)))));
         assertThat(key.getKey(), is(equalTo("foo")));
+    }
 
+    @Test
+    void decodeNullAsKey() {
+        Key result = classToTest.decode("null", Key.class);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void decodeNestedKeyWhereValueIsNull() {
+        Container result = classToTest.decode("{\"key\":null,\"enabled\":true}", Container.class);
+
+        assertThat(result.getKey(), is(nullValue()));
+        assertThat(result.getEnabled(), is(equalTo(true)));
+    }
+
+    @Getter
+    private static class Container {
+        private Key key;
+        private Boolean enabled;
     }
 }

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -48,8 +48,7 @@ class GsonJsonHandlerTest {
 
         assertThat(content, matchesPattern("\\{[^}]*}"));
 
-        Map<String, String> values = Arrays.stream(content.substring(1, content.length() - 1).split(","))
-            .map(String::trim)
+        Map<String, String> values = Arrays.stream(content.substring(1, content.length() - 1).split(",")).map(String::trim)
             .map(s -> Stream.of(s.split(":")).map(String::trim).map(i -> i.substring(1, i.length() - 1)).collect(Collectors.toList()))
             .collect(Collectors.toMap(i -> i.get(0), i -> i.get(1)));
 
@@ -121,8 +120,6 @@ class GsonJsonHandlerTest {
         assertThat(result, containsString("\"expiresAt\":null"));
     }
 
-    // TODO - multiple keys?
-
     @Test
     void deserialize() {
         assertDoesNotThrow(() -> classToTest.decode("{}", Movie.class));
@@ -150,10 +147,8 @@ class GsonJsonHandlerTest {
 
     @Test
     void deserializeMap() throws Exception {
-        String mapString =
-            "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
-        HashMap<String, String> decode =
-            classToTest.decode(mapString, HashMap.class, String.class, String.class);
+        String mapString = "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
+        HashMap<String, String> decode = classToTest.decode(mapString, HashMap.class, String.class, String.class);
 
         assertThat(decode, notNullValue());
         assertThat(decode, aMapWithSize(3));
@@ -213,18 +208,9 @@ class GsonJsonHandlerTest {
     @Test
     void decodeKeyWithAllFieldsSet() {
         String timestamp = "2023-11-23T21:29:16.123Z";
-        String input =
-            "{\n"
-                + "  \"key\":\"foo\",\n"
-                + "  \"uid\":\"foo123\",\n"
-                + "  \"name\":\"Foo\",\n"
-                + "  \"description\":\"Foo bar\",\n"
-                + "  \"actions\":[\"*\"],\n"
-                + "  \"indexes\":[\"*\"],\n"
-                + "  \"expiresAt\":null,\n"
-                + "  \"createdAt\":\"" + timestamp + "\",\n"
-                + "  \"updatedAt\":\"" + timestamp + "\"\n"
-                + "}\n";
+        String input = "{\"key\":\"foo\",\"uid\":\"foo123\",\"name\":\"Foo\",\"description\":\"Foo bar\","
+            + "\"actions\":[\"*\"],\"indexes\":[\"*\"],\"expiresAt\":null,\"createdAt\":\"" + timestamp + "\","
+            + "\"updatedAt\":\"" + timestamp + "\"}";
 
         Key key = classToTest.decode(input, Key.class);
 

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 class GsonJsonHandlerTest {
@@ -50,9 +49,16 @@ class GsonJsonHandlerTest {
 
         assertThat(content, matchesPattern("\\{[^}]*}"));
 
-        Map<String, String> values = Arrays.stream(content.substring(1, content.length() - 1).split(",")).map(String::trim)
-            .map(s -> Stream.of(s.split(":")).map(String::trim).map(i -> i.substring(1, i.length() - 1)).collect(Collectors.toList()))
-            .collect(Collectors.toMap(i -> i.get(0), i -> i.get(1)));
+        Map<String, String> values =
+                Arrays.stream(content.substring(1, content.length() - 1).split(","))
+                        .map(String::trim)
+                        .map(
+                                s ->
+                                        Stream.of(s.split(":"))
+                                                .map(String::trim)
+                                                .map(i -> i.substring(1, i.length() - 1))
+                                                .collect(Collectors.toList()))
+                        .collect(Collectors.toMap(i -> i.get(0), i -> i.get(1)));
 
         assertThat(values, is(aMapWithSize(3)));
         assertThat(values.get("id"), is(equalTo("foo")));
@@ -62,12 +68,16 @@ class GsonJsonHandlerTest {
 
     @Test
     void encodeThrowsJsonEncodingExceptionWhenGsonThrowsException() {
-        assertThrows(JsonEncodingException.class, () -> classToTest.encode(new JsonElement() {
-            @Override
-            public JsonElement deepCopy() {
-                return null;
-            }
-        }));
+        assertThrows(
+                JsonEncodingException.class,
+                () ->
+                        classToTest.encode(
+                                new JsonElement() {
+                                    @Override
+                                    public JsonElement deepCopy() {
+                                        return null;
+                                    }
+                                }));
     }
 
     @Test
@@ -108,8 +118,8 @@ class GsonJsonHandlerTest {
         key.setUid("foo123");
         key.setName("Foo");
         key.setDescription("Foo bar");
-        key.setActions(new String[]{"*"});
-        key.setIndexes(new String[]{"*"});
+        key.setActions(new String[] {"*"});
+        key.setIndexes(new String[] {"*"});
 
         String result = classToTest.encode(key);
 
@@ -149,8 +159,10 @@ class GsonJsonHandlerTest {
 
     @Test
     void deserializeMap() throws Exception {
-        String mapString = "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
-        HashMap<String, String> decode = classToTest.decode(mapString, HashMap.class, String.class, String.class);
+        String mapString =
+                "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
+        HashMap<String, String> decode =
+                classToTest.decode(mapString, HashMap.class, String.class, String.class);
 
         assertThat(decode, notNullValue());
         assertThat(decode, aMapWithSize(3));
@@ -227,9 +239,14 @@ class GsonJsonHandlerTest {
     @Test
     void decodeKeyWithAllFieldsSet() {
         String timestamp = "2023-11-23T21:29:16.123Z";
-        String input = "{\"key\":\"foo\",\"uid\":\"foo123\",\"name\":\"Foo\",\"description\":\"Foo bar\","
-            + "\"actions\":[\"*\"],\"indexes\":[\"*\"],\"expiresAt\":null,\"createdAt\":\"" + timestamp + "\","
-            + "\"updatedAt\":\"" + timestamp + "\"}";
+        String input =
+                "{\"key\":\"foo\",\"uid\":\"foo123\",\"name\":\"Foo\",\"description\":\"Foo bar\","
+                        + "\"actions\":[\"*\"],\"indexes\":[\"*\"],\"expiresAt\":null,\"createdAt\":\""
+                        + timestamp
+                        + "\","
+                        + "\"updatedAt\":\""
+                        + timestamp
+                        + "\"}";
 
         Key key = classToTest.decode(input, Key.class);
 

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -2,33 +2,126 @@ package com.meilisearch.sdk.json;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
-import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.meilisearch.sdk.exceptions.JsonEncodingException;
+import com.meilisearch.sdk.model.Key;
 import com.meilisearch.sdk.utils.Movie;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 class GsonJsonHandlerTest {
 
-    private final Gson mapper = spy(new Gson());
-    private final GsonJsonHandler classToTest = new GsonJsonHandler(mapper);
+    private final GsonJsonHandler classToTest = new GsonJsonHandler();
 
     @Test
-    void serialize() throws Exception {
+    void encodeBasicString() {
         assertThat(classToTest.encode("test"), is(equalTo("test")));
-        when(mapper.toJson(any(Movie.class))).thenThrow(new RuntimeException("Oh boy!"));
-        assertThrows(JsonEncodingException.class, () -> classToTest.encode(new Movie()));
     }
+
+    @Test
+    void encodeAnObject() {
+        Movie movie = new Movie();
+        movie.setId("foo");
+        movie.setTitle("Foo");
+        movie.setLanguage("English");
+
+        String content = classToTest.encode(movie);
+
+        assertThat(content, matchesPattern("\\{[^}]*}"));
+
+        Map<String, String> values = Arrays.stream(content.substring(1, content.length() - 1).split(","))
+            .map(String::trim)
+            .map(s -> Stream.of(s.split(":")).map(String::trim).map(i -> i.substring(1, i.length() - 1)).collect(Collectors.toList()))
+            .collect(Collectors.toMap(i -> i.get(0), i -> i.get(1)));
+
+        assertThat(values, is(aMapWithSize(3)));
+        assertThat(values.get("id"), is(equalTo("foo")));
+        assertThat(values.get("title"), is(equalTo("Foo")));
+        assertThat(values.get("language"), is(equalTo("English")));
+    }
+
+    @Test
+    void encodeThrowsJsonEncodingExceptionWhenGsonThrowsException() {
+        assertThrows(JsonEncodingException.class, () -> classToTest.encode(new JsonElement() {
+            @Override
+            public JsonElement deepCopy() {
+                return null;
+            }
+        }));
+    }
+
+    @Test
+    void encodeEmptyKeyWritesExpiresAtNull() {
+        Key key = new Key();
+
+        String result = classToTest.encode(key);
+
+        assertThat(result, is(equalTo("{\"expiresAt\":null}")));
+    }
+
+    @Test
+    void encodeKeyWithNonNullValueWritesValueAndExpiresAt() {
+        Key key = new Key();
+        key.setKey("foo");
+
+        String result = classToTest.encode(key);
+
+        assertThat(result, containsString("\"key\":\"foo\""));
+        assertThat(result, containsString("\"expiresAt\":null"));
+    }
+
+    @Test
+    void encodeKeyWithExpiresAtSetWritesExpiresAtValue() {
+        Date expiresAt = Date.from(Instant.parse("2023-11-23T18:18:45.345Z"));
+        Key key = new Key();
+        key.setExpiresAt(expiresAt);
+
+        String result = classToTest.encode(key);
+
+        assertThat(result, containsString("\"expiresAt\":\"2023-11-23T18:18:45Z\""));
+    }
+
+    @Test
+    void encodeWithMultipleValuesSetWritesAllValuesIncludingExpiresAt() {
+        Key key = new Key();
+        key.setKey("foo");
+        key.setUid("foo123");
+        key.setName("Foo");
+        key.setDescription("Foo bar");
+        key.setActions(new String[]{"*"});
+        key.setIndexes(new String[]{"*"});
+
+        String result = classToTest.encode(key);
+
+        assertThat(result, containsString("\"key\":\"foo\""));
+        assertThat(result, containsString("\"uid\":\"foo123\""));
+        assertThat(result, containsString("\"name\":\"Foo\""));
+        assertThat(result, containsString("\"description\":\"Foo bar\""));
+        assertThat(result, containsString("\"actions\":[\"*\"]"));
+        assertThat(result, containsString("\"indexes\":[\"*\"]"));
+        assertThat(result, containsString("\"expiresAt\":null"));
+    }
+
+    // TODO - multiple keys?
 
     @Test
     void deserialize() {
@@ -58,11 +151,95 @@ class GsonJsonHandlerTest {
     @Test
     void deserializeMap() throws Exception {
         String mapString =
-                "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
+            "{\"commitSha\":\"b46889b5f0f2f8b91438a08a358ba8f05fc09fc1\",\"commitDate\":\"2019-11-15T09:51:54.278247+00:00\",\"pkgVersion\":\"0.1.1\"}";
         HashMap<String, String> decode =
-                classToTest.decode(mapString, HashMap.class, String.class, String.class);
+            classToTest.decode(mapString, HashMap.class, String.class, String.class);
 
         assertThat(decode, notNullValue());
         assertThat(decode, aMapWithSize(3));
+    }
+
+    @Test
+    void decodeEmptyKey() {
+        Key key = classToTest.decode("{}", Key.class);
+
+        assertThat(key, is(notNullValue()));
+        assertThat(key.getKey(), is(nullValue()));
+        assertThat(key.getName(), is(nullValue()));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getUid(), is(nullValue()));
+        assertThat(key.getIndexes(), is(nullValue()));
+        assertThat(key.getActions(), is(nullValue()));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(nullValue()));
+        assertThat(key.getUpdatedAt(), is(nullValue()));
+    }
+
+    @Test
+    void decodeKeyWithASingleValue() {
+        Key key = classToTest.decode("{\"key\":\"foo\"}", Key.class);
+
+        assertThat(key, is(notNullValue()));
+        assertThat(key.getKey(), is(equalTo("foo")));
+        assertThat(key.getName(), is(nullValue()));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getUid(), is(nullValue()));
+        assertThat(key.getIndexes(), is(nullValue()));
+        assertThat(key.getActions(), is(nullValue()));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(nullValue()));
+        assertThat(key.getUpdatedAt(), is(nullValue()));
+    }
+
+    @Test
+    void decodeKeyWithOnlyExpiresAtSet() {
+        String timestamp = "2021-08-11T10:00:00Z";
+        Date expected = Date.from(Instant.parse(timestamp));
+
+        Key key = classToTest.decode("{\"expiresAt\":\"" + timestamp + "\"}", Key.class);
+
+        assertThat(key, is(notNullValue()));
+        assertThat(key.getExpiresAt(), is(equalTo(expected)));
+        assertThat(key.getKey(), is(nullValue()));
+        assertThat(key.getName(), is(nullValue()));
+        assertThat(key.getDescription(), is(nullValue()));
+        assertThat(key.getUid(), is(nullValue()));
+        assertThat(key.getIndexes(), is(nullValue()));
+        assertThat(key.getActions(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(nullValue()));
+        assertThat(key.getUpdatedAt(), is(nullValue()));
+    }
+
+    @Test
+    void decodeKeyWithAllFieldsSet() {
+        String timestamp = "2023-11-23T21:29:16.123Z";
+        String input =
+            "{\n"
+                + "  \"key\":\"foo\",\n"
+                + "  \"uid\":\"foo123\",\n"
+                + "  \"name\":\"Foo\",\n"
+                + "  \"description\":\"Foo bar\",\n"
+                + "  \"actions\":[\"*\"],\n"
+                + "  \"indexes\":[\"*\"],\n"
+                + "  \"expiresAt\":null,\n"
+                + "  \"createdAt\":\"" + timestamp + "\",\n"
+                + "  \"updatedAt\":\"" + timestamp + "\"\n"
+                + "}\n";
+
+        Key key = classToTest.decode(input, Key.class);
+
+        assertThat(key, is(instanceOf(Key.class)));
+        assertThat(key.getKey(), is(equalTo("foo")));
+        assertThat(key.getUid(), is(equalTo("foo123")));
+        assertThat(key.getName(), is(equalTo("Foo")));
+        assertThat(key.getDescription(), is(equalTo("Foo bar")));
+        assertThat(key.getActions(), is(arrayWithSize(1)));
+        assertThat(key.getActions(), is(arrayContaining("*")));
+        assertThat(key.getIndexes(), is(arrayWithSize(1)));
+        assertThat(key.getIndexes(), is(arrayContaining("*")));
+        assertThat(key.getExpiresAt(), is(nullValue()));
+        assertThat(key.getCreatedAt(), is(equalTo(Date.from(Instant.parse(timestamp)))));
+        assertThat(key.getKey(), is(equalTo("foo")));
+
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #487

## What does this PR do?
- Removes Key specific logic from `GsonJsonHandler` in favour of creating a type adapter for serializing and deserializing `Key`
- Removes a constructor in `GsonJsonHandler` which seemingly is only used for testing (a _spy_ was created in one of the unit tests, recording actions taken - this unit test has been updated). This specific constructor allowed a `Gson` instance to be passed in, which would allow bypassing the addition of the type adapter, which would break the `Key` specific functionality just added.
  Depending on how you view this, it could be seen as a breaking change, if you consider the `GsonJsonHandler` to be part of the public API. However, I would argue that it should not be and I don't see another way (though I may well be wrong) to feasibly move the `Key` logic out of this class.
- Moved the `@Setter` annotation on `Key` to class level, which results in a setter being generated for every field. Previously, setters were only generated for some fields. If this is a problem, then I think the way to get around this is to use reflection to set fields in the type adapter. This is less ideal but it's possible to do. I believe the Gson library itself (Jackson too) uses reflection to set fields anyway. I am happy to make this change and roll back the changes made to `Key` if this is preferable.
- Added many more unit tests to `GsonJsonHandlerTest` related to encoding/decoding `Key`, and updates some earlier tests. These tests were added to compare the existing functionality (before my changes - with the `Key` specific logic still in place) with the changes that I have made, to ensure that they are compatible and that there are no differences/breakages. These tests could theoretically be committed first and they should pass against the `GsonJsonHandler` as it is now (before this PR).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
