### PR TITLE
Add all-args-constructor for easy initial config Pagination

### DIFF
--- a/src/main/java/com/meilisearch/sdk/model/Pagination.java
+++ b/src/main/java/com/meilisearch/sdk/model/Pagination.java
@@ -9,4 +9,8 @@ public class Pagination {
     protected int maxTotalHits;
 
     public Pagination() {}
+
+    public Pagination(int maxTotalHits) {
+        this.maxTotalHits = maxTotalHits;
+    }
 }

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -989,6 +989,38 @@ public class SettingsTest extends AbstractIT {
     }
 
     @Test
+    @DisplayName("Test initial pagination settings with param")
+    public void testInitialPaginationSettingsWithParam() throws Exception {
+        Index index = createIndex("testInitialPaginationSettingsWithParam");
+
+        int MaxTotalHitsTypos = 100;
+        Pagination newPagination = new Pagination(MaxTotalHitsTypos);
+        index.waitForTask(index.updatePaginationSettings(newPagination).getTaskUid());
+        Pagination updatedPagination = index.getPaginationSettings();
+
+        assertThat(updatedPagination.getMaxTotalHits(), is(equalTo(100)));
+    }
+
+    @Test
+    @DisplayName("Test reset pagination settings when constructor with param")
+    public void testResetPaginationSettingsWhenConstructorWithParam() throws Exception {
+        Index index = createIndex("testResetPaginationSettingsWhenConstructorWithParam");
+
+        Pagination initialPagination = index.getPaginationSettings();
+        int MaxTotalHitsTypos = 100;
+        Pagination newPagination = new Pagination(MaxTotalHitsTypos);
+        index.waitForTask(index.updatePaginationSettings(newPagination).getTaskUid());
+        Pagination updatedPagination = index.getPaginationSettings();
+
+        index.waitForTask(index.resetPaginationSettings().getTaskUid());
+        Pagination paginationAfterReset = index.getPaginationSettings();
+
+        assertThat(initialPagination.getMaxTotalHits(), is(equalTo(1000)));
+        assertThat(updatedPagination.getMaxTotalHits(), is(equalTo(100)));
+        assertThat(paginationAfterReset.getMaxTotalHits(), is(equalTo(1000)));
+    }
+
+    @Test
     @DisplayName("Test reset pagination settings")
     public void testResetPaginationSettings() throws Exception {
         Index index = createIndex("testResetPaginationSettings");


### PR DESCRIPTION
# Pull Request for Enhancement

## What does this PR do?
This is a tiny PR to make the Pagination initial more easier.
The current implementation make extra lines to config Pagination. Here is an example:

**Before**
```Kotlin
val index = meilisearchClient.index(it.getIndex())
val defaultPagination = Pagination()
defaultPagination.maxTotalHits = 5000
index.updatePaginationSettings(defaultPagination)
```
**After**
```Kotlin
val index = meilisearchClient.index(it.getIndex())
index.updatePaginationSettings(Pagination(5000))
```