### PR TITLE
Ignore tests when running gradle build on releasing

### DIFF
--- a/.github/workflows/ossrh-publish.yml
+++ b/.github/workflows/ossrh-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x test
       - name: Archive test report
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-java/issues/704

## What does this PR do?
- Remove the test task from the build task since we already ran the tests. On the main, there is no need to test execution further.
- For some reason there is a test now that requires meilisearch to run (which was not the case before)
