### PR TITLE
Fix publish workflow for Impossible to deploy on OSSRH issue

### DIFF
--- a/.github/workflows/ossrh-publish.yml
+++ b/.github/workflows/ossrh-publish.yml
@@ -34,7 +34,7 @@ jobs:
           echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
       - name: Publish, close and release Nexus Repository
-        run: ./gradlew publishToSonatype closeAndReleaseStagingRepository -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        run: ./gradlew publishToSonatype closeAndReleaseStagingRepositories -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
         env:
           OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
           OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #729 

## What does this PR do?
- The closeAndReleaseStagingRepository method was renamed to closeAndReleaseStagingRepositories in version 2.0.0 of the io.github.gradle-nexus.publish-plugin. The code has been updated to reflect this change.
- ref. https://github.com/gradle-nexus/publish-plugin/releases/tag/v2.0.0

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
