### PR TITLE
Adjust the targetClass parameter variable of the decode method in JsonHandler from class<?> to class<T>

### DIFF
--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -34,7 +34,7 @@ public class GsonJsonHandler implements JsonHandler {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T decode(Object o, Class<?> targetClass, Class<?>... parameters)
+    public <T> T decode(Object o, Class<T> targetClass, Class<?>... parameters)
             throws MeilisearchException {
         if (o == null) {
             throw new JsonDecodingException("Response to deserialize is null");
@@ -44,10 +44,10 @@ public class GsonJsonHandler implements JsonHandler {
         }
         try {
             if (parameters == null || parameters.length == 0) {
-                return gson.<T>fromJson((String) o, targetClass);
+                return gson.fromJson((String) o, targetClass);
             } else {
                 TypeToken<?> parameterized = TypeToken.getParameterized(targetClass, parameters);
-                return gson.<T>fromJson((String) o, parameterized.getType());
+                return gson.fromJson((String) o, parameterized.getType());
             }
         } catch (JsonSyntaxException e) {
             throw new JsonDecodingException(e);

--- a/src/main/java/com/meilisearch/sdk/json/JacksonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/JacksonJsonHandler.java
@@ -48,7 +48,7 @@ public class JacksonJsonHandler implements JsonHandler {
     /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T decode(Object o, Class<?> targetClass, Class<?>... parameters)
+    public <T> T decode(Object o, Class<T> targetClass, Class<?>... parameters)
             throws MeilisearchException {
         if (o == null) {
             throw new JsonDecodingException("Response to deserialize is null");
@@ -58,7 +58,7 @@ public class JacksonJsonHandler implements JsonHandler {
         }
         try {
             if (parameters == null || parameters.length == 0) {
-                return (T) mapper.readValue((String) o, targetClass);
+                return mapper.readValue((String) o, targetClass);
             } else {
                 return mapper.readValue(
                         (String) o,

--- a/src/main/java/com/meilisearch/sdk/json/JsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/JsonHandler.java
@@ -19,6 +19,6 @@ public interface JsonHandler {
      * @return the deserialized object
      * @throws MeilisearchException wrapped exceptions of the used json library
      */
-    <T> T decode(Object o, Class<?> targetClass, Class<?>... parameters)
+    <T> T decode(Object o, Class<T> targetClass, Class<?>... parameters)
             throws MeilisearchException;
 }


### PR DESCRIPTION
## Related issue
Refactor #737

## What does this PR do?
The targetClass parameter should be of type Class<T>, not Class<?>. This provides stronger type safety because you can check the type of T at compile time rather than at run time
