### PR TITLE
Fixing empty TaskError response

### DIFF
--- a/src/main/java/com/meilisearch/sdk/model/Task.java
+++ b/src/main/java/com/meilisearch/sdk/model/Task.java
@@ -1,6 +1,5 @@
 package com.meilisearch.sdk.model;
 
-import com.meilisearch.sdk.TaskError;
 import java.util.Date;
 import lombok.Getter;
 

--- a/src/main/java/com/meilisearch/sdk/model/TaskError.java
+++ b/src/main/java/com/meilisearch/sdk/model/TaskError.java
@@ -1,4 +1,4 @@
-package com.meilisearch.sdk;
+package com.meilisearch.sdk.model;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/meilisearch/sdk/model/TaskError.java
+++ b/src/main/java/com/meilisearch/sdk/model/TaskError.java
@@ -3,14 +3,15 @@ package com.meilisearch.sdk.model;
 import lombok.Getter;
 import lombok.Setter;
 
-/** The code, type and error of the task error */
+/** The code, type‚ error and message of the task error */
 @Getter
 @Setter
 public class TaskError {
 
     public TaskError() {}
 
-    protected String taskErrorCode = "";
-    protected String taskErrorType = "";
-    protected String taskErrorLink = "";
+    protected String code = "";
+    protected String type = "";
+    protected String link = "";
+    protected String message = "";
 }

--- a/src/test/java/com/meilisearch/integration/ExceptionsTest.java
+++ b/src/test/java/com/meilisearch/integration/ExceptionsTest.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
-import com.meilisearch.sdk.TaskError;
 import com.meilisearch.sdk.exceptions.APIError;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchCommunicationException;
+import com.meilisearch.sdk.model.TaskError;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -60,8 +60,8 @@ public class ExceptionsTest extends AbstractIT {
     @Test
     public void testTaskErrorGetters() {
         TaskError error = new TaskError();
-        error.setTaskErrorCode("wrong field");
-        assertThat(error.getTaskErrorCode(), is(equalTo("wrong field")));
+        error.setCode("wrong field");
+        assertThat(error.getCode(), is(equalTo("wrong field")));
     }
 
     /** Test MeilisearchApiException is thrown on Meilisearch bad request */

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -88,6 +88,48 @@ public class TasksTest extends AbstractIT {
         assertThat(result.getResults().length, is(notNullValue()));
     }
 
+    /** Test Get Task Error Values */
+    @Test
+    public void testClientGetTaskErrorValues() throws Exception {
+        String indexUid = "CheckTaskErrorValues";
+        Index index = client.index(indexUid);
+
+        // Deleting all documents from an index that does not exist results in a task error.
+        TaskInfo taskInfo = index.deleteAllDocuments();
+        index.waitForTask(taskInfo.getTaskUid());
+
+        Task task = client.getTask(taskInfo.getTaskUid());
+
+        assertThat(task.getError(), is(notNullValue()));
+        assertThat(task.getError().getCode(), is(notNullValue()));
+        assertThat(task.getError().getType(), is(notNullValue()));
+        assertThat(task.getError().getLink(), is(notNullValue()));
+        assertThat(task.getError().getMessage(), is(notNullValue()));
+    }
+
+    /** Test Get Task Error Values When Adding Documents */
+    @Test
+    public void testClientGetTaskErrorWhenAddingDocuments() throws Exception {
+        String indexUid = "CheckTaskErrorWhenAddingDocuments";
+        Index index = client.index(indexUid);
+
+        TaskInfo taskInfo = client.createIndex(indexUid);
+        client.waitForTask(taskInfo.getTaskUid());
+
+        String json = "{\"identifyer\": 1, \"name\": \"Donald Duck\"}";
+        // Adding a document with a wrong identifier results in a task error.
+        TaskInfo taskInfoAddDocuments = index.addDocuments(json, "identifier");
+        client.waitForTask(taskInfoAddDocuments.getTaskUid());
+
+        Task task = client.getTask(taskInfoAddDocuments.getTaskUid());
+
+        assertThat(task.getError(), is(notNullValue()));
+        assertThat(task.getError().getCode(), is(notNullValue()));
+        assertThat(task.getError().getType(), is(notNullValue()));
+        assertThat(task.getError().getLink(), is(notNullValue()));
+        assertThat(task.getError().getMessage(), is(notNullValue()));
+    }
+
     /** Test Get Tasks with limit and from */
     @Test
     public void testClientGetTasksLimitAndFrom() throws Exception {

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -1,10 +1,12 @@
 package com.meilisearch.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,10 +103,10 @@ public class TasksTest extends AbstractIT {
         Task task = client.getTask(taskInfo.getTaskUid());
 
         assertThat(task.getError(), is(notNullValue()));
-        assertThat(task.getError().getCode(), is(notNullValue()));
-        assertThat(task.getError().getType(), is(notNullValue()));
-        assertThat(task.getError().getLink(), is(notNullValue()));
-        assertThat(task.getError().getMessage(), is(notNullValue()));
+        assertThat(task.getError().getCode(), not(blankOrNullString()));
+        assertThat(task.getError().getType(), not(blankOrNullString()));
+        assertThat(task.getError().getLink(), not(blankOrNullString()));
+        assertThat(task.getError().getMessage(), not(blankOrNullString()));
     }
 
     /** Test Get Task Error Values When Adding Documents */
@@ -124,10 +126,10 @@ public class TasksTest extends AbstractIT {
         Task task = client.getTask(taskInfoAddDocuments.getTaskUid());
 
         assertThat(task.getError(), is(notNullValue()));
-        assertThat(task.getError().getCode(), is(notNullValue()));
-        assertThat(task.getError().getType(), is(notNullValue()));
-        assertThat(task.getError().getLink(), is(notNullValue()));
-        assertThat(task.getError().getMessage(), is(notNullValue()));
+        assertThat(task.getError().getCode(), not(blankOrNullString()));
+        assertThat(task.getError().getType(), not(blankOrNullString()));
+        assertThat(task.getError().getLink(), not(blankOrNullString()));
+        assertThat(task.getError().getMessage(), not(blankOrNullString()));
     }
 
     /** Test Get Tasks with limit and from */


### PR DESCRIPTION
# Pull Request

Seems like the `TaskError` object is only returning empty Strings when trying to get the error details of a task. Seems to be a missmatch between the field naming, and number of fields based on the API response. Therefor it dosent understand what to map, and only gives empty strings back.


## Related issue
None

## What does this PR do?
- It moves the `TaskError` class to the `model` package, closer to the usage in `Task` class.
  - Since its peers`TaskDetails`, and `TaskStatus` are already here.
- Updates the field in `TaskError` to match the API naming, and number of fields.
- Updates the Exception integration test to use the correct naming and import.
- Adds Integration tests to check that `TaskError` fields is not blank or null.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?
