### PR TITLE
Fix Update settings api failure throws ClassCastException

### DIFF
--- a/src/main/java/com/meilisearch/sdk/HttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/HttpClient.java
@@ -133,14 +133,14 @@ public class HttpClient {
      */
     <S, T> T patch(String api, S body, Class<T> targetClass) throws MeilisearchException {
         HttpRequest requestConfig = request.create(HttpMethod.PATCH, api, this.headers, body);
-        HttpResponse<T> httpRequest = this.client.patch(requestConfig);
-        HttpResponse<T> httpResponse = response.create(httpRequest, targetClass);
+        HttpResponse<T> httpResponse = this.client.patch(requestConfig);
 
         if (httpResponse.getStatusCode() >= 400) {
             throw new MeilisearchApiException(
                     jsonHandler.decode(httpResponse.getContent(), APIError.class));
         }
-        return httpResponse.getContent();
+
+        return response.create(httpResponse, targetClass).getContent();
     }
 
     /**


### PR DESCRIPTION

# Pull Request

## Related issue
Fixes #764

## What does this PR do?
- throw MeilisearchApiException on response codes >= 400 when using patch method in httpclient

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
