### PR TITLE
Add Federation Parameter to multisearch method

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -22,8 +22,8 @@ import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TasksQuery;
 import com.meilisearch.sdk.model.TasksResults;
 import java.util.Date;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -432,16 +432,17 @@ public class Client {
     /*
      * Method overloading the multi search method to add federation parameter
      */
-    public MultiSearchResult multiSearch(MultiSearchRequest search,
-     MultiSearchFederation federation) throws MeilisearchException {
+    public MultiSearchResult multiSearch(
+            MultiSearchRequest search, MultiSearchFederation federation)
+            throws MeilisearchException {
         Map<String, Object> payload = new HashMap<>();
         payload.put("queries", search.getQueries());
         payload.put("federation", federation);
-        return this.config.httpClient.post(
-                "/multi-search", payload, MultiSearchResult.class);
-     }
+        return this.config.httpClient.post("/multi-search", payload, MultiSearchResult.class);
+    }
 
-    public Results<MultiSearchResult> multiSearch(MultiSearchRequest search) throws MeilisearchException {
+    public Results<MultiSearchResult> multiSearch(MultiSearchRequest search)
+            throws MeilisearchException {
         return this.config.httpClient.post(
                 "/multi-search", search, Results.class, MultiSearchResult.class);
     }

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -23,6 +23,7 @@ import com.meilisearch.sdk.model.TasksQuery;
 import com.meilisearch.sdk.model.TasksResults;
 import java.util.Date;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -428,8 +429,19 @@ public class Client {
         this.keysHandler.deleteKey(key);
     }
 
-    public Results<MultiSearchResult> multiSearch(MultiSearchRequest search)
-            throws MeilisearchException {
+    /*
+     * Method overloading the multi search method to add federation parameter
+     */
+    public MultiSearchResult multiSearch(MultiSearchRequest search,
+     MultiSearchFederation federation) throws MeilisearchException {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("queries", search.getQueries());
+        payload.put("federation", federation);
+        return this.config.httpClient.post(
+                "/multi-search", payload, MultiSearchResult.class);
+     }
+
+    public Results<MultiSearchResult> multiSearch(MultiSearchRequest search) throws MeilisearchException {
         return this.config.httpClient.post(
                 "/multi-search", search, Results.class, MultiSearchResult.class);
     }

--- a/src/main/java/com/meilisearch/sdk/FederationOptions.java
+++ b/src/main/java/com/meilisearch/sdk/FederationOptions.java
@@ -3,7 +3,7 @@ package com.meilisearch.sdk;
 import org.json.JSONObject;
 
 public class FederationOptions {
-    
+
     private Double weight;
 
     public FederationOptions setWeight(Double weight) {
@@ -14,13 +14,11 @@ public class FederationOptions {
     /**
      * Method that returns the JSON String of the FederationOptions
      *
-     * @return JSON String of the FederationOptions 
+     * @return JSON String of the FederationOptions
      */
     @Override
-    public String toString(){
-        JSONObject jsonObject =
-                new JSONObject()
-                .put("weight", this.weight);
+    public String toString() {
+        JSONObject jsonObject = new JSONObject().put("weight", this.weight);
         return jsonObject.toString();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/FederationOptions.java
+++ b/src/main/java/com/meilisearch/sdk/FederationOptions.java
@@ -1,0 +1,26 @@
+package com.meilisearch.sdk;
+
+import org.json.JSONObject;
+
+public class FederationOptions {
+    
+    private Double weight;
+
+    public FederationOptions setWeight(Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    /**
+     * Method that returns the JSON String of the FederationOptions
+     *
+     * @return JSON String of the FederationOptions 
+     */
+    @Override
+    public String toString(){
+        JSONObject jsonObject =
+                new JSONObject()
+                .put("weight", this.weight);
+        return jsonObject.toString();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -88,9 +88,11 @@ public class IndexSearchRequest {
                         .put("sort", this.sort)
                         .put("page", this.page)
                         .put("hitsPerPage", this.hitsPerPage)
-                        .put("federationOptions", this.federationOptions != null
-                        ? this.federationOptions.toString()
-                        : null)
+                        .put(
+                                "federationOptions",
+                                this.federationOptions != null
+                                        ? this.federationOptions.toString()
+                                        : null)
                         .putOpt("attributesToCrop", this.attributesToCrop)
                         .putOpt("attributesToHighlight", this.attributesToHighlight)
                         .putOpt("filter", this.filter)

--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -34,6 +34,7 @@ public class IndexSearchRequest {
     protected Boolean showRankingScore;
     protected Boolean showRankingScoreDetails;
     protected Double rankingScoreThreshold;
+    private FederationOptions federationOptions;
 
     /**
      * Constructor for MultiSearchRequest for building search queries with the default values:
@@ -87,6 +88,9 @@ public class IndexSearchRequest {
                         .put("sort", this.sort)
                         .put("page", this.page)
                         .put("hitsPerPage", this.hitsPerPage)
+                        .put("federationOptions", this.federationOptions != null
+                        ? this.federationOptions.toString()
+                        : null)
                         .putOpt("attributesToCrop", this.attributesToCrop)
                         .putOpt("attributesToHighlight", this.attributesToHighlight)
                         .putOpt("filter", this.filter)

--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -1,0 +1,41 @@
+package com.meilisearch.sdk;
+
+import org.json.JSONObject;
+
+public class MultiSearchFederation {
+    
+    private Integer limit;
+    private Integer offset;
+
+    public MultiSearchFederation setLimit(Integer limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public MultiSearchFederation setOffset(Integer offset) {
+        this.offset = offset;
+        return this;
+    }
+    
+    public Integer getLimit(){
+        return this.limit;
+    }
+
+    public Integer getOffset(){
+        return this.offset;
+    }
+
+    /**
+     * Method that returns the JSON String of the MultiSearchFederation
+     *
+     * @return JSON String of the MultiSearchFederation 
+     */
+    @Override
+    public String toString(){
+        JSONObject jsonObject =
+                new JSONObject()
+                .put("limit", this.limit)
+                .put("offset", this.offset);
+        return jsonObject.toString();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -3,7 +3,7 @@ package com.meilisearch.sdk;
 import org.json.JSONObject;
 
 public class MultiSearchFederation {
-    
+
     private Integer limit;
     private Integer offset;
 
@@ -16,26 +16,24 @@ public class MultiSearchFederation {
         this.offset = offset;
         return this;
     }
-    
-    public Integer getLimit(){
+
+    public Integer getLimit() {
         return this.limit;
     }
 
-    public Integer getOffset(){
+    public Integer getOffset() {
         return this.offset;
     }
 
     /**
      * Method that returns the JSON String of the MultiSearchFederation
      *
-     * @return JSON String of the MultiSearchFederation 
+     * @return JSON String of the MultiSearchFederation
      */
     @Override
-    public String toString(){
+    public String toString() {
         JSONObject jsonObject =
-                new JSONObject()
-                .put("limit", this.limit)
-                .put("offset", this.offset);
+                new JSONObject().put("limit", this.limit).put("offset", this.offset);
         return jsonObject.toString();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/MultiSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchRequest.java
@@ -10,6 +10,13 @@ public class MultiSearchRequest {
         this.queries = new ArrayList();
     }
 
+    /*
+     * Method to get Queries as a list 
+     */
+    public ArrayList<IndexSearchRequest> getQueries(){
+        return this.queries;
+    }
+
     /**
      * Method to add new Query
      *

--- a/src/main/java/com/meilisearch/sdk/MultiSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchRequest.java
@@ -11,9 +11,9 @@ public class MultiSearchRequest {
     }
 
     /*
-     * Method to get Queries as a list 
+     * Method to get Queries as a list
      */
-    public ArrayList<IndexSearchRequest> getQueries(){
+    public ArrayList<IndexSearchRequest> getQueries() {
         return this.queries;
     }
 

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -813,9 +813,11 @@ public class SearchTest extends AbstractIT {
         }
         MultiSearchRequest search = new MultiSearchRequest();
         search.addQuery(new IndexSearchRequest("MultiSearch1").setQuery("batman"));
-        search.addQuery(new IndexSearchRequest("MultiSearch2").setQuery("batman")
-        .setFederationOptions(new FederationOptions().setWeight(0.9)));
-        
+        search.addQuery(
+                new IndexSearchRequest("MultiSearch2")
+                        .setQuery("batman")
+                        .setFederationOptions(new FederationOptions().setWeight(0.9)));
+
         MultiSearchFederation federation = new MultiSearchFederation();
         federation.setLimit(2);
         MultiSearchResult results = client.multiSearch(search, federation);
@@ -824,7 +826,7 @@ public class SearchTest extends AbstractIT {
         assertThat(results.getLimit(), is(2));
         ArrayList<HashMap<String, Object>> hits = results.getHits();
         assertThat(hits, hasSize(2));
-        for(HashMap<String, Object> record : hits){
+        for (HashMap<String, Object> record : hits) {
             assertThat(record.containsKey("_federation"), is(true));
         }
     }

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -795,6 +795,40 @@ public class SearchTest extends AbstractIT {
         }
     }
 
+    /*
+     * Test the federation parameter in multi search method
+     */
+    @Test
+    public void testFederation() throws Exception {
+        HashSet<String> indexUids = new HashSet();
+        indexUids.add("MultiSearch1");
+        indexUids.add("MultiSearch2");
+        for (String indexUid : indexUids) {
+            Index index = client.index(indexUid);
+
+            TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+            TaskInfo task = index.addDocuments(testData.getRaw());
+
+            index.waitForTask(task.getTaskUid());
+        }
+        MultiSearchRequest search = new MultiSearchRequest();
+        search.addQuery(new IndexSearchRequest("MultiSearch1").setQuery("batman"));
+        search.addQuery(new IndexSearchRequest("MultiSearch2").setQuery("batman")
+        .setFederationOptions(new FederationOptions().setWeight(0.9)));
+        
+        MultiSearchFederation federation = new MultiSearchFederation();
+        federation.setLimit(2);
+        MultiSearchResult results = client.multiSearch(search, federation);
+
+        assertThat(results.getEstimatedTotalHits(), is(2));
+        assertThat(results.getLimit(), is(2));
+        ArrayList<HashMap<String, Object>> hits = results.getHits();
+        assertThat(hits, hasSize(2));
+        for(HashMap<String, Object> record : hits){
+            assertThat(record.containsKey("_federation"), is(true));
+        }
+    }
+
     /** Test multisearch with ranking score threshold */
     @Test
     public void testMultiSearchWithRankingScoreThreshold() throws Exception {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #768

## What does this PR do?
- Adds a new parameter federation to the multiSearch method.
- Introduces a new search parameter federationOptions to the search query.
- Adds a getter method to the MultiSearchRequest class to retrieve the query list for creating the payload.
- Adds a test to validate the new functionality.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
