### PR TITLE
THIS COMMIT WILL INDEXSEARCHREQUEST ADD ATTRIBUTESTOSEARCHON

### DIFF
--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -34,6 +34,8 @@ public class IndexSearchRequest {
     protected Boolean showRankingScore;
     protected Boolean showRankingScoreDetails;
     protected Double rankingScoreThreshold;
+    private String[] attributesToSearchOn;
+
 
     /**
      * Constructor for MultiSearchRequest for building search queries with the default values:
@@ -93,7 +95,8 @@ public class IndexSearchRequest {
                         .putOpt("filter", this.filterArray)
                         .putOpt("showRankingScore", this.showRankingScore)
                         .putOpt("showRankingScoreDetails", this.showRankingScoreDetails)
-                        .putOpt("rankingScoreThreshold", this.rankingScoreThreshold);
+                        .putOpt("rankingScoreThreshold", this.rankingScoreThreshold)
+                        .putOpt("attributesToSearchOn", this.attributesToSearchOn);
 
         return jsonObject.toString();
     }


### PR DESCRIPTION
When I use Non-federated multi-search, I find that I can't add attributesToSearchOn, I'm sure there is no this parameter in IndexSearchRequest.