### PR TITLE
Add attributesToSearchOn to IndexSearchRequest

### DIFF
--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -34,6 +34,8 @@ public class IndexSearchRequest {
     protected Boolean showRankingScore;
     protected Boolean showRankingScoreDetails;
     protected Double rankingScoreThreshold;
+    private String[] attributesToSearchOn;
+
 
     /**
      * Constructor for MultiSearchRequest for building search queries with the default values:
@@ -93,7 +95,8 @@ public class IndexSearchRequest {
                         .putOpt("filter", this.filterArray)
                         .putOpt("showRankingScore", this.showRankingScore)
                         .putOpt("showRankingScoreDetails", this.showRankingScoreDetails)
-                        .putOpt("rankingScoreThreshold", this.rankingScoreThreshold);
+                        .putOpt("rankingScoreThreshold", this.rankingScoreThreshold)
+                        .putOpt("attributesToSearchOn", this.attributesToSearchOn);
 
         return jsonObject.toString();
     }


### PR DESCRIPTION
PARAMETER

# Pull Request

## Related issue
“Fixes #<issue_number>”

## What does this PR do?
- ...When I use Non-federated multi-search, I find that I can't add attributesToSearchOn, I'm sure there is no this parameter in IndexSearchRequest.I added one attributesToSearchOn.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
