### PR TITLE
Add Reverse ordering support for Task API

### DIFF
--- a/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
@@ -67,12 +67,21 @@ public class URLBuilder {
 
     public URLBuilder addParameter(String parameter, Date value) {
         if (value != null) {
-            // Changed to utilise RFC 3339 format
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
             addSeparator();
             params.append(parameter);
             params.append("=");
             params.append(formatter.format(value));
+        }
+        return this;
+    }
+
+    public URLBuilder addParameter(String parameter, Boolean value) {
+        if (value != null) {
+            addSeparator();
+            params.append(parameter);
+            params.append("=");
+            params.append(value);
         }
         return this;
     }

--- a/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
@@ -67,7 +67,8 @@ public class URLBuilder {
 
     public URLBuilder addParameter(String parameter, Date value) {
         if (value != null) {
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            // Changed to utilise RFC 3339 format
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
             addSeparator();
             params.append(parameter);
             params.append("=");

--- a/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
@@ -77,6 +77,13 @@ public class URLBuilder {
         return this;
     }
 
+    /**
+     * To add a boolean parameter to url
+     *
+     * @param parameter - parameter name
+     * @param value - value of the parameter
+     * @return - updated url object
+     */
     public URLBuilder addParameter(String parameter, Boolean value) {
         if (value != null) {
             addSeparator();

--- a/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
@@ -23,7 +23,7 @@ public class TasksQuery {
     private String[] types;
     private String[] indexUids;
     private int[] canceledBy;
-    private boolean reverse;
+    private Boolean reverse;
     private Date beforeEnqueuedAt;
     private Date afterEnqueuedAt;
     private Date beforeStartedAt;
@@ -49,7 +49,7 @@ public class TasksQuery {
                         .addParameter("afterStartedAt", this.getAfterStartedAt())
                         .addParameter("beforeFinishedAt", this.getBeforeFinishedAt())
                         .addParameter("afterFinishedAt", this.getAfterFinishedAt())
-                        .addParameter("reverse", String.valueOf(this.isReverse()));
+                        .addParameter("reverse", this.getReverse());
         return urlb.getURL();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
@@ -23,6 +23,7 @@ public class TasksQuery {
     private String[] types;
     private String[] indexUids;
     private int[] canceledBy;
+    private boolean reverse;
     private Date beforeEnqueuedAt;
     private Date afterEnqueuedAt;
     private Date beforeStartedAt;
@@ -47,7 +48,8 @@ public class TasksQuery {
                         .addParameter("beforeStartedAt", this.getBeforeStartedAt())
                         .addParameter("afterStartedAt", this.getAfterStartedAt())
                         .addParameter("beforeFinishedAt", this.getBeforeFinishedAt())
-                        .addParameter("afterFinishedAt", this.getAfterFinishedAt());
+                        .addParameter("afterFinishedAt", this.getAfterFinishedAt())
+                        .addParameter("reverse", String.valueOf(this.isReverse()));
         return urlb.getURL();
     }
 }

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -9,8 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
@@ -229,7 +228,8 @@ public class TasksTest extends AbstractIT {
                 Arrays.stream(defaultTaskList).map(Task::getUid).collect(Collectors.toList());
         List<Integer> reversedTaskOrder =
                 Arrays.stream(reversedTaskList).map(Task::getUid).collect(Collectors.toList());
-
+        assertFalse(originalTaskOrder.isEmpty());
+        assertFalse(reversedTaskOrder.isEmpty());
         assertIterableEquals(
                 originalTaskOrder,
                 reversedTaskOrder.stream()

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -206,11 +206,11 @@ public class TasksTest extends AbstractIT {
         assertThat(result.getNext(), is(notNullValue()));
         assertThat(result.getResults().length, is(notNullValue()));
     }
-    /** Test Get Tasks in reverse order */
+    /** Test to check if task list is reversed when enabled */
     @Test
     public void testGetTasksInReverse() {
         String indexUid = "tasksOnReverseOrder";
-        Date date = Date.from(Instant.now());
+        Date currentTime = Date.from(Instant.now());
         TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
 
         TaskInfo taskA = client.index(indexUid).addDocuments(testData.getRaw());
@@ -220,9 +220,9 @@ public class TasksTest extends AbstractIT {
         client.waitForTask(taskB.getTaskUid());
 
         Task[] defaultTaskList =
-                client.getTasks(new TasksQuery().setAfterEnqueuedAt(date)).getResults();
+                client.getTasks(new TasksQuery().setAfterEnqueuedAt(currentTime)).getResults();
         Task[] reversedTaskList =
-                client.getTasks(new TasksQuery().setAfterEnqueuedAt(date).setReverse(true))
+                client.getTasks(new TasksQuery().setAfterEnqueuedAt(currentTime).setReverse(true))
                         .getResults();
 
         List<Integer> originalTaskOrder =

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -8,11 +8,18 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.TimeZone;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class URLBuilderTest {
 
     private final URLBuilder classToTest = new URLBuilder();
+
+    @BeforeEach
+    void beforeEach() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     @Test
     void addSubroute() {
@@ -92,8 +99,8 @@ public class URLBuilderTest {
 
     @Test
     void addParameterStringDate() throws Exception {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-        Date date = format.parse("2042-01-30");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        Date date = format.parse("2042-01-30T10:30:00-05:00");
 
         classToTest.addParameter("parameter1", date);
         String parameterDate1 =
@@ -101,8 +108,9 @@ public class URLBuilderTest {
                         .getParams()
                         .toString()
                         .substring(12, classToTest.getParams().toString().length());
-        assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate1));
-        assertThat(classToTest.getParams().toString(), is(equalTo("?parameter1=2042-01-30")));
+
+        assertDoesNotThrow(() -> format.parse(parameterDate1));
+        assertEquals(classToTest.getParams().toString(), "?parameter1=" + format.format(date));
 
         classToTest.addParameter("parameter2", date);
         String parameterDate2 =

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,25 +102,16 @@ public class URLBuilderTest {
         Date date = format.parse("2042-01-30T10:30:00-05:00");
 
         classToTest.addParameter("parameter1", date);
-        String parameterDate1 =
-                classToTest
-                        .getParams()
-                        .toString()
-                        .substring(12, classToTest.getParams().toString().length());
-
+        String parameterDate1 = classToTest.getParams().substring(12);
         assertDoesNotThrow(() -> format.parse(parameterDate1));
-        assertEquals(classToTest.getParams().toString(), "?parameter1=" + format.format(date));
+        assertEquals(classToTest.getParams().toString(), "?parameter1=2042-01-30T15:30:00Z");
 
         classToTest.addParameter("parameter2", date);
-        String parameterDate2 =
-                classToTest
-                        .getParams()
-                        .toString()
-                        .substring(34, classToTest.getParams().toString().length());
-        assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE.parse(parameterDate2));
-        assertThat(
+        String parameterDate2 = classToTest.getParams().substring(44);
+        assertDoesNotThrow(() -> format.parse(parameterDate2));
+        assertEquals(
                 classToTest.getParams().toString(),
-                is(equalTo("?parameter1=2042-01-30&parameter2=2042-01-30")));
+                "?parameter1=2042-01-30T15:30:00Z&parameter2=2042-01-30T15:30:00Z");
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #798 

## What does this PR do?
- Accepts 'reverse' field to provider ordering flexibility

## PR checklist
Please check if your PR fulfills the following requirements:
- [ Y ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ Y ] Have you read the contributing guidelines?
- [ Y ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
