### PR TITLE
docs: update README with SDK changes and add pagination examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ index.search(
 #### Custom Search With Pagination <!-- omit in toc -->
 
 ```java
-import com.meilisearch.sdk.Searchable;
+import com.meilisearch.sdk.SearchResultPaginated;
 
 // ...
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ import com.meilisearch.sdk.SearchRequest;
 
 // ...
 
-SearchResult results = (SearchResult) orderIndex.search(
+SearchResult results = (SearchResult) index.search(
     new SearchRequest("of")
         .setShowMatchesPosition(true)
         .setAttributesToHighlight(new String[]{"title"})

--- a/README.md
+++ b/README.md
@@ -217,6 +217,34 @@ index.search(
   "query": "wonder"
 }
 ```
+#### Custom Search With Pagination <!-- omit in toc -->
+
+```java
+index.search(
+    new SearchRequest("wonder")
+        .setPage(1)
+        .setHitsPerPage(20)
+);
+```
+
+```json
+{
+    "hits": [
+        {
+            "id": 2,
+            "title": "Wonder Woman",
+            "genres": ["Action","Adventure"]
+        }
+    ], 
+    "query": "wonder",
+    "processingTimeMs": 0,
+    "hitsPerPage": 20,
+    "page": 1,
+    "totalPages": 1,
+    "totalHits": 1
+}
+```
+
 ## 🛠 Customization
 
 ### JSON <!-- omit in toc -->

--- a/README.md
+++ b/README.md
@@ -144,13 +144,14 @@ All the supported options are described in the [search parameters](https://www.m
 
 ```java
 import com.meilisearch.sdk.SearchRequest;
+import com.meilisearch.sdk.Searchable;
 
 // ...
 
-SearchResult results = index.search(
-  new SearchRequest("of")
-  .setShowMatchesPosition(true)
-  .setAttributesToHighlight(new String[]{"title"})
+Searchable results = (SearchResult) orderIndex.search(
+    new SearchRequest("of")
+        .setShowMatchesPosition(true)
+        .setAttributesToHighlight(new String[]{"title"})
 );
 System.out.println(results.getHits());
 ```

--- a/README.md
+++ b/README.md
@@ -144,11 +144,10 @@ All the supported options are described in the [search parameters](https://www.m
 
 ```java
 import com.meilisearch.sdk.SearchRequest;
-import com.meilisearch.sdk.Searchable;
 
 // ...
 
-Searchable results = (SearchResult) orderIndex.search(
+SearchResult results = (SearchResult) orderIndex.search(
     new SearchRequest("of")
         .setShowMatchesPosition(true)
         .setAttributesToHighlight(new String[]{"title"})
@@ -220,7 +219,11 @@ index.search(
 #### Custom Search With Pagination <!-- omit in toc -->
 
 ```java
-index.search(
+import com.meilisearch.sdk.Searchable;
+
+// ...
+
+SearchResultPaginated results = (SearchResultPaginated) index.search(
     new SearchRequest("wonder")
         .setPage(1)
         .setHitsPerPage(20)


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Updates the README example code to show the necessity to cast the returned value (new `Searchable` interface) to `SearchResult`
- Adds a new comprehensive example demonstrating custom search with pagination
- Shows practical usage of pagination parameters like `setPage()` and `setHitsPerPage()`
- Includes example JSON response showing pagination metadata (totalPages, hitsPerPage, etc.)

## PR checklist
- [x] Changes are clearly described in the PR description above
- [ ] Contributing guidelines have been reviewed (needs confirmer)
- [x] PR title accurately describes changes: "fix(docs): update README example to reflect latest sdk changes"