### PR TITLE
Add usedDatabaseSize to stats, document and embeddings database metrics to index stats

### DIFF
--- a/src/main/java/com/meilisearch/sdk/model/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStats.java
@@ -22,8 +22,13 @@ public class IndexStats {
     public IndexStats() {}
 
     public IndexStats(
-            long numberOfDocuments, boolean isIndexing, Map<String, Integer> fieldDistribution,
-            long rawDocumentDbSize, long avgDocumentSize, long numberOfEmbeddedDocuments, long numberOfEmbeddings) {
+            long numberOfDocuments,
+            boolean isIndexing,
+            Map<String, Integer> fieldDistribution,
+            long rawDocumentDbSize,
+            long avgDocumentSize,
+            long numberOfEmbeddedDocuments,
+            long numberOfEmbeddings) {
         this.numberOfDocuments = numberOfDocuments;
         this.isIndexing = isIndexing;
         this.fieldDistribution = fieldDistribution;

--- a/src/main/java/com/meilisearch/sdk/model/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStats.java
@@ -14,13 +14,22 @@ public class IndexStats {
     protected long numberOfDocuments;
     protected boolean isIndexing;
     protected Map<String, Integer> fieldDistribution;
+    protected long rawDocumentDbSize;
+    protected long avgDocumentSize;
+    protected long numberOfEmbeddedDocuments;
+    protected long numberOfEmbeddings;
 
     public IndexStats() {}
 
     public IndexStats(
-            long numberOfDocuments, boolean isIndexing, Map<String, Integer> fieldDistribution) {
+            long numberOfDocuments, boolean isIndexing, Map<String, Integer> fieldDistribution,
+            long rawDocumentDbSize, long avgDocumentSize, long numberOfEmbeddedDocuments, long numberOfEmbeddings) {
         this.numberOfDocuments = numberOfDocuments;
         this.isIndexing = isIndexing;
         this.fieldDistribution = fieldDistribution;
+        this.rawDocumentDbSize = rawDocumentDbSize;
+        this.avgDocumentSize = avgDocumentSize;
+        this.numberOfEmbeddedDocuments = numberOfEmbeddedDocuments;
+        this.numberOfEmbeddings = numberOfEmbeddings;
     }
 }

--- a/src/main/java/com/meilisearch/sdk/model/Stats.java
+++ b/src/main/java/com/meilisearch/sdk/model/Stats.java
@@ -16,7 +16,10 @@ public class Stats {
     protected Map<String, IndexStats> indexes;
     protected long usedDatabaseSize;
 
-    public Stats(long databaseSize, Date lastUpdate, Map<String, IndexStats> indexes,
+    public Stats(
+            long databaseSize,
+            Date lastUpdate,
+            Map<String, IndexStats> indexes,
             long usedDatabaseSize) {
         this.databaseSize = databaseSize;
         this.lastUpdate = lastUpdate;

--- a/src/main/java/com/meilisearch/sdk/model/Stats.java
+++ b/src/main/java/com/meilisearch/sdk/model/Stats.java
@@ -14,11 +14,14 @@ public class Stats {
     protected long databaseSize;
     protected Date lastUpdate;
     protected Map<String, IndexStats> indexes;
+    protected long usedDatabaseSize;
 
-    public Stats(long databaseSize, Date lastUpdate, Map<String, IndexStats> indexes) {
+    public Stats(long databaseSize, Date lastUpdate, Map<String, IndexStats> indexes,
+            long usedDatabaseSize) {
         this.databaseSize = databaseSize;
         this.lastUpdate = lastUpdate;
         this.indexes = indexes;
+        this.usedDatabaseSize = usedDatabaseSize;
     }
 
     public Stats() {}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #819 #820 #821 

## What does this PR do?
- Adds `usedDatabaseSize` to stats
- Adds documents database metrics to stats
- Adds embbedings database metrics to stats

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
