### PR TITLE
Add check for empty API key before adding Authorization header

### DIFF
--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -56,7 +56,7 @@ public class CustomOkHttpClient {
         Request.Builder builder = new Request.Builder();
         builder.url(url);
 
-        if (this.config.getApiKey() != null)
+        if (this.config.getApiKey() != null && !this.config.getApiKey().isEmpty())
             builder.addHeader("Authorization", this.config.getBearerApiKey());
 
         for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #834

## What does this PR do?
- It adds empty string check before adding the `Authorization` header, so to make it consistent with the default apiKey value set by the host-only Config constructor

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
