### PR TITLE
Add backwards-compatible serialization for filtration

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -227,7 +227,10 @@ get_filterable_attributes_1: |-
   client.index("movies").getFilterableAttributesSettings();
 update_filterable_attributes_1: |-
   Settings settings = new Settings();
-  settings.setFilterableAttributes(new String[] {"genres", "director"});
+  Map<String, Boolean> filtersTypes = new HashMap<>();
+  filtersTypes.put("comparison",true);
+  filtersTypes.put("equality",true);
+  settings.setFilterableAttributes(new FilterableAttributes[] {new FilterableAttributes("genres"), new FilterableAttributes(new String[]{"director"}, true, filters)});
   client.index("movies").updateSettings(settings);
 reset_filterable_attributes_1: |-
   client.index("movies").resetFilterableAttributesSettings();

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -2,12 +2,7 @@ package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.http.URLBuilder;
-import com.meilisearch.sdk.model.Faceting;
-import com.meilisearch.sdk.model.LocalizedAttribute;
-import com.meilisearch.sdk.model.Pagination;
-import com.meilisearch.sdk.model.Settings;
-import com.meilisearch.sdk.model.TaskInfo;
-import com.meilisearch.sdk.model.TypoTolerance;
+import com.meilisearch.sdk.model.*;
 import java.util.Map;
 
 /**
@@ -318,9 +313,10 @@ public class SettingsHandler {
      * @return an array of strings that contains the filterable attributes settings
      * @throws MeilisearchException if an error occurs
      */
-    String[] getFilterableAttributesSettings(String uid) throws MeilisearchException {
+    FilterableAttribute[] getFilterableAttributesSettings(String uid) throws MeilisearchException {
         return httpClient.get(
-                settingsPath(uid).addSubroute("filterable-attributes").getURL(), String[].class);
+                settingsPath(uid).addSubroute("filterable-attributes").getURL(),
+                FilterableAttribute[].class);
     }
 
     /**
@@ -332,13 +328,11 @@ public class SettingsHandler {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      */
-    TaskInfo updateFilterableAttributesSettings(String uid, String[] filterableAttributes)
-            throws MeilisearchException {
+    TaskInfo updateFilterableAttributesSettings(
+            String uid, FilterableAttribute[] filterableAttributes) throws MeilisearchException {
         return httpClient.put(
                 settingsPath(uid).addSubroute("filterable-attributes").getURL(),
-                filterableAttributes == null
-                        ? httpClient.jsonHandler.encode(filterableAttributes)
-                        : filterableAttributes,
+                httpClient.jsonHandler.encode(filterableAttributes),
                 TaskInfo.class);
     }
 

--- a/src/main/java/com/meilisearch/sdk/json/GsonFilterableAttributeSerializer.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonFilterableAttributeSerializer.java
@@ -1,0 +1,168 @@
+package com.meilisearch.sdk.json;
+
+import com.google.gson.*;
+import com.meilisearch.sdk.model.FilterableAttribute;
+import java.lang.reflect.Type;
+import java.util.*;
+
+/** JSON serializer/deserializer for {@link FilterableAttribute} objects. */
+public class GsonFilterableAttributeSerializer
+        implements JsonSerializer<FilterableAttribute>, JsonDeserializer<FilterableAttribute> {
+
+    @Override
+    public JsonElement serialize(
+            FilterableAttribute attributes,
+            Type type,
+            JsonSerializationContext jsonSerializationContext) {
+        // when possible, limit size of data sent by using legacy string format
+        return (canBeString(attributes))
+                ? new JsonPrimitive(attributes.getPatterns()[0])
+                : serializeAttribute(attributes);
+    }
+
+    private boolean canBeString(FilterableAttribute attribute) {
+        if (attribute == null) return false;
+        Map<String, Boolean> filters = attribute.getFilter();
+        if (filters == null) filters = new HashMap<>();
+        return (attribute.getPatterns() != null
+                && attribute.getPatterns().length == 1
+                && (attribute.getFacetSearch() == null || !attribute.getFacetSearch())
+                && (filters.containsKey("equality") && filters.get("equality"))
+                && (!filters.containsKey("comparison") || !filters.get("comparison")));
+    }
+
+    private JsonElement serializeAttribute(FilterableAttribute attribute) {
+        if (attribute == null) return null;
+        List<Exception> exceptions = new ArrayList<>();
+        JsonArray patternArray = new JsonArray();
+        if (attribute.getPatterns() != null && attribute.getPatterns().length > 0)
+            try {
+                // Collect values from POJO
+                patternArray =
+                        Arrays.stream(attribute.getPatterns())
+                                .map(JsonPrimitive::new)
+                                .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        else exceptions.add(new JsonParseException("Patterns to filter for were not specified!"));
+
+        JsonObject filters = new JsonObject();
+        if (attribute.getFilter() != null) {
+            try {
+                filters =
+                        attribute.getFilter().entrySet().stream()
+                                .collect(
+                                        JsonObject::new,
+                                        (jsonObject, kv) ->
+                                                jsonObject.addProperty(kv.getKey(), kv.getValue()),
+                                        this::combineJsonObjects);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        } else {
+            filters.addProperty("comparison", false);
+            filters.addProperty("equality", true);
+        }
+
+        if (!exceptions.isEmpty()) {
+            throw new JsonParseException(String.join("\n", Arrays.toString(exceptions.toArray())));
+        }
+
+        // Create JSON object
+        JsonObject jsonObject = new JsonObject();
+        JsonObject features = new JsonObject();
+        if (attribute.getFacetSearch() != null)
+            features.addProperty("facetSearch", attribute.getFacetSearch());
+        else features.addProperty("facetSearch", false);
+        features.add("filter", filters);
+        jsonObject.add("attributePatterns", patternArray);
+        jsonObject.add("features", features);
+        return jsonObject;
+    }
+
+    private void combineJsonObjects(JsonObject a, JsonObject b) {
+        for (Map.Entry<String, JsonElement> kv : b.entrySet()) a.add(kv.getKey(), kv.getValue());
+    }
+
+    @Override
+    public FilterableAttribute deserialize(
+            JsonElement jsonElement,
+            Type type,
+            JsonDeserializationContext jsonDeserializationContext)
+            throws JsonParseException {
+        try {
+            // legacy check
+            if (jsonElement.isJsonPrimitive() && jsonElement.getAsJsonPrimitive().isString())
+                return new FilterableAttribute(jsonElement.getAsString());
+
+            JsonObject object = jsonElement.getAsJsonObject();
+            JsonObject features =
+                    object.has("features") ? object.getAsJsonObject("features") : null;
+            // default values for instance lacking `features`
+            boolean facetSearch = false;
+            Map<String, Boolean> filters = new HashMap<>();
+            filters.put("equality", true);
+            filters.put("comparison", false);
+
+            List<Exception> exceptions = new ArrayList<>();
+            // pull values from features.
+            if (features != null && features.has("facetSearch")) {
+                try {
+                    JsonPrimitive facetSearchPrimitive = features.getAsJsonPrimitive("facetSearch");
+                    facetSearch =
+                            facetSearchPrimitive != null && facetSearchPrimitive.getAsBoolean();
+                } catch (ClassCastException | IllegalStateException e) {
+                    exceptions.add(e);
+                }
+            }
+            if (features != null && features.has("filter"))
+                try {
+                    filters =
+                            features.getAsJsonObject("filter").entrySet().stream()
+                                    .collect(
+                                            HashMap::new,
+                                            (m, kv) ->
+                                                    m.put(
+                                                            kv.getKey(),
+                                                            kv.getValue().getAsBoolean()),
+                                            HashMap::putAll);
+                } catch (ClassCastException | IllegalStateException e) {
+                    exceptions.add(e);
+                }
+            String[] patterns = new String[0];
+            try {
+                patterns =
+                        object.has("attributePatterns")
+                                ? object.getAsJsonArray("attributePatterns").asList().stream()
+                                        .map(JsonElement::getAsString)
+                                        .toArray(String[]::new)
+                                : new String[0];
+            } catch (ClassCastException | IllegalStateException e) {
+                exceptions.add(e);
+            }
+
+            if (!exceptions.isEmpty())
+                throw new JsonParseException(
+                        String.join("\n", Arrays.toString(exceptions.toArray())));
+
+            if (filters.entrySet().stream().noneMatch(Map.Entry::getValue))
+                exceptions.add(
+                        new JsonParseException(
+                                "No filtration methods were allowed! Must have at least one type <comparison, equality> allowed.\n"
+                                        + Arrays.toString(filters.entrySet().toArray())));
+            if (patterns.length == 0)
+                exceptions.add(
+                        new JsonParseException(
+                                "Patterns to filter for were not specified! Invalid Attribute."));
+
+            if (!exceptions.isEmpty())
+                throw new JsonParseException(
+                        String.join("\n", Arrays.toString(exceptions.toArray())));
+
+            return new FilterableAttribute(patterns, facetSearch, filters);
+        } catch (Exception e) {
+            throw new JsonParseException("Failed to deserialize FilterableAttribute", e);
+        }
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
+++ b/src/main/java/com/meilisearch/sdk/json/GsonJsonHandler.java
@@ -7,6 +7,7 @@ import com.google.gson.reflect.TypeToken;
 import com.meilisearch.sdk.exceptions.JsonDecodingException;
 import com.meilisearch.sdk.exceptions.JsonEncodingException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.model.FilterableAttribute;
 import com.meilisearch.sdk.model.Key;
 
 public class GsonJsonHandler implements JsonHandler {
@@ -16,6 +17,8 @@ public class GsonJsonHandler implements JsonHandler {
     public GsonJsonHandler() {
         GsonBuilder builder = new GsonBuilder();
         builder.registerTypeAdapter(Key.class, new GsonKeyTypeAdapter());
+        builder.registerTypeAdapter(
+                FilterableAttribute.class, new GsonFilterableAttributeSerializer());
         this.gson = builder.create();
     }
 

--- a/src/main/java/com/meilisearch/sdk/model/FilterableAttribute.java
+++ b/src/main/java/com/meilisearch/sdk/model/FilterableAttribute.java
@@ -1,0 +1,72 @@
+package com.meilisearch.sdk.model;
+
+import java.util.*;
+import lombok.Getter;
+
+/**
+ * Flattened filtration attributes for the MeiliSearch API See @link <a
+ * href="https://meilisearch.notion.site/API-usage-Settings-to-opt-out-indexing-features-filterableAttributes-1764b06b651f80aba8bdf359b2df3ca8?pvs=74">
+ * API </a>
+ */
+@Getter
+public class FilterableAttribute {
+
+    String[] patterns;
+    Boolean facetSearch;
+    Map<String, Boolean> filter;
+
+    public static final String _GEO = "_geo";
+
+    public FilterableAttribute(String pattern) {
+        boolean patternIsGeo = _GEO.equals(pattern);
+        this.patterns = new String[] {pattern};
+        this.facetSearch = patternIsGeo;
+        this.filter = new HashMap<>();
+        this.filter.put("equality", true);
+        this.filter.put("comparison", patternIsGeo);
+    }
+
+    public FilterableAttribute(String[] patterns) {
+        // Special case of '_geo' pattern will apply special conditions to default attributes
+        boolean patternHasGeo = false;
+        for (String s : patterns)
+            if (_GEO.equals(s)) {
+                patternHasGeo = true;
+                break;
+            }
+        this.facetSearch = patternHasGeo;
+        this.filter = new HashMap<>();
+        this.filter.put("equality", true);
+        this.filter.put("comparison", patternHasGeo);
+        this.patterns = patterns;
+    }
+
+    public FilterableAttribute(
+            String[] patterns, boolean facetSearch, Map<String, Boolean> filters) {
+        if (patterns == null) throw new IllegalArgumentException("Patterns cannot be null");
+        boolean patternHasGeo = false;
+        for (String s : patterns)
+            if (_GEO.equals(s)) {
+                patternHasGeo = true;
+                break;
+            }
+        if (patternHasGeo) checkGeoValidation(facetSearch, filters);
+        this.patterns = patterns;
+        this.facetSearch = facetSearch;
+        this.filter = filters;
+    }
+
+    private static void checkGeoValidation(boolean facetSearch, Map<String, Boolean> filters) {
+        String[] errors = new String[3];
+        if (!filters.containsKey("comparison") || filters.get("comparison") == false)
+            errors[0] = "Comparison filter cannot be null for '_geo' pattern";
+        // rewrite the below lines to be JDK 8 compatible.
+        if (!filters.containsKey("equality") || filters.get("equality") == false)
+            errors[1] = "Equality filter cannot be null for '_geo' pattern";
+        if (!facetSearch) errors[2] = "Facet search cannot be null for '_geo' pattern";
+        for (String error : errors)
+            if (error != null)
+                throw new RuntimeException(
+                        "Invalid filter for geo pattern: " + Arrays.toString(errors));
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/model/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/model/Settings.java
@@ -14,11 +14,10 @@ import lombok.experimental.Accessors;
 @Setter
 @Accessors(chain = true)
 public class Settings {
-
     protected HashMap<String, String[]> synonyms;
     protected String[] stopWords;
     protected String[] rankingRules;
-    protected String[] filterableAttributes;
+    protected FilterableAttribute[] filterableAttributes;
     protected String distinctAttribute;
     protected String[] searchableAttributes;
     protected String[] displayedAttributes;
@@ -35,4 +34,11 @@ public class Settings {
     protected LocalizedAttribute[] localizedAttributes;
 
     public Settings() {}
+
+    public final void setFilterableAttributes(String[] settings) {
+        this.filterableAttributes = new FilterableAttribute[settings.length];
+        for (int i = 0; i < settings.length; i++) {
+            this.filterableAttributes[i] = new FilterableAttribute(settings[i]);
+        }
+    }
 }

--- a/src/test/java/com/meilisearch/integration/FilterableAttributeTest.java
+++ b/src/test/java/com/meilisearch/integration/FilterableAttributeTest.java
@@ -1,0 +1,97 @@
+package com.meilisearch.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.meilisearch.sdk.model.FilterableAttribute;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class FilterableAttributeTest {
+
+    @Test
+    public void testSinglePatternConstructor() {
+        FilterableAttribute attribute = new FilterableAttribute("attribute1");
+        assertArrayEquals(new String[] {"attribute1"}, attribute.getPatterns());
+        assertFalse(attribute.getFacetSearch());
+        assertTrue(attribute.getFilter().get("equality"));
+        assertFalse(attribute.getFilter().get("comparison"));
+    }
+
+    @Test
+    public void testSinglePatternConstructorWithGeo() {
+        FilterableAttribute attribute = new FilterableAttribute("_geo");
+        assertArrayEquals(new String[] {"_geo"}, attribute.getPatterns());
+        assertTrue(attribute.getFacetSearch());
+        assertTrue(attribute.getFilter().get("equality"));
+        assertTrue(attribute.getFilter().get("comparison"));
+    }
+
+    @Test
+    public void testArrayPatternConstructor() {
+        FilterableAttribute attribute =
+                new FilterableAttribute(new String[] {"attribute1", "attribute2"});
+        assertArrayEquals(new String[] {"attribute1", "attribute2"}, attribute.getPatterns());
+        assertFalse(attribute.getFacetSearch());
+        assertTrue(attribute.getFilter().get("equality"));
+        assertFalse(attribute.getFilter().get("comparison"));
+    }
+
+    @Test
+    public void testArrayPatternConstructorWithGeo() {
+        FilterableAttribute attribute =
+                new FilterableAttribute(new String[] {"attribute1", "_geo"});
+        assertArrayEquals(new String[] {"attribute1", "_geo"}, attribute.getPatterns());
+        assertTrue(attribute.getFacetSearch());
+        assertTrue(attribute.getFilter().get("equality"));
+        assertTrue(attribute.getFilter().get("comparison"));
+    }
+
+    @Test
+    public void testFullConstructorValidInput() {
+        Map<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", true);
+        filters.put("comparison", true);
+        FilterableAttribute attribute =
+                new FilterableAttribute(new String[] {"attribute1"}, true, filters);
+        assertArrayEquals(new String[] {"attribute1"}, attribute.getPatterns());
+        assertTrue(attribute.getFacetSearch());
+        assertEquals(filters, attribute.getFilter());
+    }
+
+    @Test
+    public void testFullConstructorWithGeoValidation() {
+        Map<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", true);
+        filters.put("comparison", true);
+        FilterableAttribute attribute =
+                new FilterableAttribute(new String[] {"_geo"}, true, filters);
+        assertArrayEquals(new String[] {"_geo"}, attribute.getPatterns());
+        assertTrue(attribute.getFacetSearch());
+        assertEquals(filters, attribute.getFilter());
+    }
+
+    @Test
+    public void testFullConstructorWithInvalidGeoValidation() {
+        Map<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", false);
+        filters.put("comparison", false);
+        Exception exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> new FilterableAttribute(new String[] {"_geo"}, false, filters));
+        assertTrue(exception.getMessage().contains("Invalid filter for geo pattern"));
+    }
+
+    @Test
+    public void testFullConstructorWithNullPatterns() {
+        Map<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", true);
+        filters.put("comparison", true);
+        Exception exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new FilterableAttribute(null, true, filters));
+        assertEquals("Patterns cannot be null", exception.getMessage());
+    }
+}

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -142,7 +142,9 @@ public class TasksTest extends AbstractIT {
         int from = 2;
         TasksQuery query = new TasksQuery().setLimit(limit).setFrom(from);
         TasksResults result = client.getTasks(query);
-
+        System.out.println("Expected from: " + from);
+        System.out.println("Actual from: " + result.getFrom());
+        System.out.println("Tasks returned: " + Arrays.toString(result.getResults()));
         assertThat(result.getLimit(), is(equalTo(limit)));
         assertThat(result.getFrom(), is(equalTo(from)));
         assertThat(result.getFrom(), is(notNullValue()));

--- a/src/test/java/com/meilisearch/sdk/json/GsonFilterableAttributeSerializerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonFilterableAttributeSerializerTest.java
@@ -1,0 +1,166 @@
+package com.meilisearch.sdk.json;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.JsonParseException;
+import com.meilisearch.sdk.model.FilterableAttribute;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GsonFilterableAttributeSerializerTest {
+
+    GsonFilterableAttributeSerializer serializer;
+    GsonJsonHandler handler;
+
+    @BeforeEach
+    public void preTestSetup() {
+        handler = new GsonJsonHandler();
+    }
+
+    @AfterEach
+    public void postTestCleanup() {
+        // Cleanup after each test, if needed
+    }
+
+    @Test
+    public void testLegacySerialization() {
+        String input = "attribute1";
+        String expectedOutput = "\"attribute1\"";
+        String result = handler.encode(new FilterableAttribute(input));
+        assertEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testLegacyDeserialization() {
+        String input = "\"attribute1\"";
+        FilterableAttribute expectedOutput = new FilterableAttribute("attribute1");
+        assertDeserializedOutputsEquals(
+                handler.decode(input, FilterableAttribute.class), expectedOutput);
+    }
+
+    @Test
+    public void testNewDeserializationOutputArray() {
+        String input = "{attributePatterns:[\"attribute1\"]}";
+        FilterableAttribute expectedOutput = new FilterableAttribute("attribute1");
+        assertDeserializedOutputsEquals(
+                handler.decode(input, FilterableAttribute.class), expectedOutput);
+    }
+
+    @Test
+    public void testNewSerializationOutputArray() {
+        FilterableAttribute input = new FilterableAttribute(new String[] {"attribute1"});
+        String expectedOutput = "\"attribute1\"";
+        assertEquals(expectedOutput, handler.encode(input));
+    }
+
+    @Test
+    public void testMixedDeserializationOutputWithNoFeatures() {
+        String input = "[{attributePatterns:[\"attribute1\", \"attribute2\"]},\"attribute3\"]";
+        FilterableAttribute expectedOutputOne =
+                new FilterableAttribute(new String[] {"attribute1", "attribute2"});
+        FilterableAttribute expectedOutputTwo = new FilterableAttribute("attribute3");
+        FilterableAttribute[] expectedOutput =
+                new FilterableAttribute[] {expectedOutputOne, expectedOutputTwo};
+        FilterableAttribute[] result = handler.decode(input, FilterableAttribute[].class);
+        assertEquals(expectedOutput.length, result.length);
+        for (int i = 0; i < expectedOutput.length; i++) {
+            assertDeserializedOutputsEquals(expectedOutput[i], result[i]);
+        }
+    }
+
+    @Test
+    public void testDeserializationWithFeatures() {
+        String input =
+                "{attributePatterns:[\"attribute1\", \"attribute2\"],features: {facetSearch:true, filter:{equality:true, comparison:true}}}";
+        Map<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", true);
+        filters.put("comparison", true);
+        FilterableAttribute expectedOutput =
+                new FilterableAttribute(new String[] {"attribute1", "attribute2"}, true, filters);
+        FilterableAttribute result = handler.decode(input, FilterableAttribute.class);
+        assertDeserializedOutputsEquals(expectedOutput, result);
+    }
+
+    @Test
+    public void testMixedSerializationWithFeatures() {
+        HashMap<String, Boolean> filters = new HashMap<>();
+        filters.put("equality", false);
+        filters.put("comparison", true);
+        FilterableAttribute input =
+                new FilterableAttribute(new String[] {"attribute1", "attribute2"}, true, filters);
+        FilterableAttribute input2 = new FilterableAttribute("attribute3");
+        String expectedOutput =
+                "[{\"attributePatterns\":[\"attribute1\",\"attribute2\"],\"features\":{\"facetSearch\":true,\"filter\":{\"comparison\":true,\"equality\":false}}},\"attribute3\"]";
+        String array = handler.encode(new FilterableAttribute[] {input, input2});
+        assertEquals(expectedOutput, handler.encode(array));
+    }
+
+    @Test
+    public void testDeserializationWithNullElement() {
+        assertNull(handler.decode("null", FilterableAttribute.class));
+    }
+
+    @Test
+    public void testDeserializationWithInvalidFilter() {
+        String input =
+                "{attributePatterns:[\"attribute1\"],features: {facetSearch:true, filter:{equality:false, comparison:false}}}";
+        Exception exception =
+                assertThrows(
+                        JsonParseException.class,
+                        () -> handler.decode(input, FilterableAttribute.class));
+        assertTrue(exception.getMessage().contains("Failed to deserialize"));
+        assertTrue(
+                exception.getCause().getMessage().contains("No filtration methods were allowed"));
+    }
+
+    @Test
+    public void testDeserializationWithMissingPatterns() {
+        String input = "{features: {facetSearch:true, filter:{equality:true, comparison:true}}}";
+        Exception exception =
+                assertThrows(
+                        JsonParseException.class,
+                        () -> handler.decode(input, FilterableAttribute.class));
+        assertTrue(exception.getMessage().contains("Failed to deserialize"));
+        assertTrue(
+                exception
+                        .getCause()
+                        .getMessage()
+                        .contains("Patterns to filter for were not specified"));
+    }
+
+    @Test
+    public void testSerializationWithNullAttribute() {
+        FilterableAttribute input = null;
+        String result = handler.encode(input);
+        assertEquals("null", result);
+    }
+
+    @Test
+    public void testSerializationWithEmptyPatterns() {
+        FilterableAttribute input = new FilterableAttribute(new String[0], false, new HashMap<>());
+        Exception exception = assertThrows(Exception.class, () -> handler.encode(input));
+        assertTrue(
+                exception
+                        .getCause()
+                        .getMessage()
+                        .contains("Patterns to filter for were not specified"));
+    }
+
+    private static void assertDeserializedOutputsEquals(
+            FilterableAttribute a, FilterableAttribute b) {
+        if (a == null) assertNull(b);
+        else {
+            assertEquals(a.getPatterns().length, b.getPatterns().length);
+            for (int i = 0; i < a.getPatterns().length; i++) {
+                assertEquals(a.getPatterns()[i], b.getPatterns()[i]);
+            }
+            assertEquals(a.getFacetSearch(), b.getFacetSearch());
+            for (String key : a.getFilter().keySet()) {
+                assertEquals(a.getFilter().get(key), b.getFilter().get(key));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### New Additions
* **`FilterableAttribute`** is a flattened POJO implementation of the new [granular filtration feature](https://github.com/meilisearch/meilisearch/issues/5163). It contains backwards compatibility with legacy data.
* **`GsonFilterableAttributeSerializer`** allows for the serialization/deserialization of these POJOs from legacy primitive string filter attributes, as well as the persistence of new single-string attributes with default settings in legacy format. ### Changes
* **`GsonJsonHandler`** registers our new serializer.
* **`Index`**: `getFilterableAttributesSettings` is updated to accommodate the new POJO. Backwards compatible `legacyGetFilterableAttributesSettings` which returns the traditional `String[]` attribute configuration has been added as well. `updateFilterableAttributes` has been updated to accept `Object[]`, as polymorphic backwards compatibility which can accept `null` values, requires no ambiguity; as we cannot do a polymorphic method, this seemed the best fit.
* **`Settings`**: `filterableAttributes` was updated to now be of type `FilterableAttribute[]`.
* **`SettingsHandler`**: `updateFilterableAttributesSettings` now accepts a `FilterableAttribute[]` object. `getFilterableAttributesSettings` now returns one likewise.

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
