### PR TITLE
Enforce only v4.x versions are allowed for OkHTTP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.12.1'
 	implementation 'org.json:json:20250107'
 	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-	api 'com.squareup.okhttp3:okhttp:4.+'
+	api 'com.squareup.okhttp3:okhttp:[4.10.0,5.0.0)'
 
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.11.4'))


### PR DESCRIPTION
# Pull Request

## Related issue

A user reported that their build was broken after a clean maven install due to the poor resource version constraints defined in the okhttp definition.

## What does this PR do?
- Ensure no other version than a stable one could be used.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the OkHttp library dependency to allow for automatic use of the latest version within major version 4.
	- Improved dependency management by excluding pre-release versions to ensure stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->