### PR TITLE
Fix `OKHTTP` dependency inconsistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,17 +39,6 @@ jacocoTestCoverageVerification {
 		}
 	}
 }
-configurations.all {
-    resolutionStrategy {
-        componentSelection {
-            all { ComponentSelection selection ->
-                if (selection.candidate.version =~ /(?i).*[.-](alpha|beta|rc|m)[.\d-]*/) {
-                    selection.reject("Pre-release versions are not allowed")
-                }
-            }
-        }
-    }
-}
 
 repositories {
 	mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.12.1'
 	implementation 'org.json:json:20250107'
 	// https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5
-	api 'com.squareup.okhttp3:okhttp:[4.10.0,5.0.0)'
+	api 'com.squareup.okhttp3:okhttp:4.12.0'
 
 	// Use JUnit test framework
 	testImplementation(platform('org.junit:junit-bom:5.11.4'))


### PR DESCRIPTION
# Pull Request

Following up on PR https://github.com/meilisearch/meilisearch-java/pull/856, that tried to fix the issue with dependency resolving to alpha version of the OKHTTP dependency.

Example repo that showcases that `meilisearch-java:0.14.6` still resolves to OKHTTP `5.0.0-alpha.16`.
https://github.com/larskristianhaga/Meilisearch-OKHTTP-dependency-crash-demo

## What does this PR do?
- Pinning OKHTTP version to `4.12.0`, which is the same used as test scope. 
- Removed dependency selection rejection that did not work.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the okhttp dependency to a fixed version (4.12.0).
  - Removed restrictions that previously blocked pre-release dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->