### PR TITLE
Add support for export API

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -844,5 +844,5 @@ update_localized_attribute_settings_1: |-
 reset_localized_attribute_settings_1: |-
   client.index("INDEX_NAME").resetLocalizedAttributesSettings();
 export_post_1: |-
-  ExportRequest request = ExportRequest.builder().setUrl("http://anothermeiliinstance:7070").build();
+  ExportRequest request = ExportRequest.builder().url("http://anothermeiliinstance:7070").build();
   client.export(request);

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -843,3 +843,6 @@ update_localized_attribute_settings_1: |-
   );
 reset_localized_attribute_settings_1: |-
   client.index("INDEX_NAME").resetLocalizedAttributesSettings();
+export_post_1: |-
+  ExportRequest request = ExportRequest.builder().setUrl("http://anothermeiliinstance:7070").build();
+  client.export(request);

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -844,5 +844,7 @@ update_localized_attribute_settings_1: |-
 reset_localized_attribute_settings_1: |-
   client.index("INDEX_NAME").resetLocalizedAttributesSettings();
 export_post_1: |-
-  ExportRequest request = ExportRequest.builder().url("http://anothermeiliinstance:7070").build();
+  Map<String, ExportIndexFilter> indexes = new HashMap<>();
+  indexes.put("*", ExportIndexFilter.builder().overrideSettings(true).build());
+  ExportRequest request = ExportRequest.builder().url("TARGET_INSTANCE_URL").indexes(indexes).build();
   client.export(request);

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -219,6 +219,18 @@ public class Client {
     }
 
     /**
+     * Triggers the export of documents between Meilisearch Instances.
+     *
+     * @param request Export request parameters
+     * @return Meilisearch API response as TaskInfo
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/export">API specification</a>
+     */
+    public TaskInfo export(ExportRequest request) throws MeilisearchException {
+        return config.httpClient.post("/export", request, TaskInfo.class);
+    }
+
+    /**
      * Gets the status and availability of a Meilisearch instance
      *
      * @return String containing the status of the Meilisearch instance from Meilisearch API

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -219,7 +219,7 @@ public class Client {
     }
 
     /**
-     * Triggers the export of documents between Meilisearch Instances.
+     * Triggers the export of documents between Meilisearch instances.
      *
      * @param request Export request parameters
      * @return Meilisearch API response as TaskInfo

--- a/src/main/java/com/meilisearch/sdk/ExportIndexFilter.java
+++ b/src/main/java/com/meilisearch/sdk/ExportIndexFilter.java
@@ -1,0 +1,28 @@
+package com.meilisearch.sdk;
+
+import lombok.*;
+import org.json.JSONObject;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@Setter
+public class ExportIndexFilter {
+    private String filter;
+    @Builder.Default private boolean overrideSettings = false;
+
+    /**
+     * Method that returns the JSON String of the ExportRequest
+     *
+     * @return JSON String of the ExportRequest query
+     */
+    @Override
+    public String toString() {
+        JSONObject jsonObject =
+                new JSONObject()
+                        .putOpt("filter", this.filter)
+                        .putOpt("overrideSettings", this.overrideSettings);
+        return jsonObject.toString();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/ExportIndexFilter.java
+++ b/src/main/java/com/meilisearch/sdk/ExportIndexFilter.java
@@ -13,16 +13,20 @@ public class ExportIndexFilter {
     @Builder.Default private boolean overrideSettings = false;
 
     /**
-     * Method that returns the JSON String of the ExportRequest
+     * Method that returns the JSON String of the ExportIndexFilter
      *
-     * @return JSON String of the ExportRequest query
+     * @return JSON String of the ExportIndexFilter query
      */
     @Override
     public String toString() {
-        JSONObject jsonObject =
-                new JSONObject()
-                        .putOpt("filter", this.filter)
-                        .putOpt("overrideSettings", this.overrideSettings);
+        JSONObject jsonObject = new JSONObject();
+        if (this.filter != null) {
+            jsonObject.put("filter", this.filter);
+        }
+        if (this.overrideSettings) {
+            jsonObject.put("overrideSettings", true);
+        }
+
         return jsonObject.toString();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/ExportRequest.java
+++ b/src/main/java/com/meilisearch/sdk/ExportRequest.java
@@ -1,0 +1,33 @@
+package com.meilisearch.sdk;
+
+import java.util.Map;
+import lombok.*;
+import org.json.JSONObject;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@Setter
+public class ExportRequest {
+    private String url;
+    private String apiKey;
+    private String payloadSize;
+    private Map<String, ExportIndexFilter> indexes;
+
+    /**
+     * Method that returns the JSON String of the ExportRequest
+     *
+     * @return JSON String of the ExportRequest query
+     */
+    @Override
+    public String toString() {
+        JSONObject jsonObject =
+                new JSONObject()
+                        .put("url", this.url)
+                        .putOpt("apiKey", this.apiKey)
+                        .putOpt("payloadSize", this.payloadSize)
+                        .putOpt("indexes", this.indexes);
+        return jsonObject.toString();
+    }
+}

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -7,12 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.gson.*;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
+import com.meilisearch.sdk.ExportIndexFilter;
+import com.meilisearch.sdk.ExportRequest;
 import com.meilisearch.sdk.Index;
 import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.*;
 import com.meilisearch.sdk.utils.Movie;
 import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.*;
 
 @Tag("integration")
@@ -306,6 +310,22 @@ public class ClientTest extends AbstractIT {
 
         assertThat(task.getStatus(), is(equalTo(TaskStatus.ENQUEUED)));
         assertThat(snapshot.getType(), is(equalTo("snapshotCreation")));
+    }
+
+    /** Test call to initiate export */
+    @Test
+    public void testExport() throws Exception {
+        Map<String, ExportIndexFilter> indexes = new HashMap<>();
+        indexes.put("*", ExportIndexFilter.builder().filter("genres = action").build());
+
+        ExportRequest payload =
+                ExportRequest.builder().url(getMeilisearchHost()).indexes(indexes).build();
+        TaskInfo task = client.export(payload);
+        client.waitForTask(task.getTaskUid());
+        Task snapshot = client.getTask(task.getTaskUid());
+
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.ENQUEUED)));
+        assertThat(snapshot.getType(), is(equalTo("export")));
     }
 
     /**

--- a/src/test/java/com/meilisearch/integration/ClientTest.java
+++ b/src/test/java/com/meilisearch/integration/ClientTest.java
@@ -322,10 +322,10 @@ public class ClientTest extends AbstractIT {
                 ExportRequest.builder().url(getMeilisearchHost()).indexes(indexes).build();
         TaskInfo task = client.export(payload);
         client.waitForTask(task.getTaskUid());
-        Task snapshot = client.getTask(task.getTaskUid());
+        Task exportTask = client.getTask(task.getTaskUid());
 
         assertThat(task.getStatus(), is(equalTo(TaskStatus.ENQUEUED)));
-        assertThat(snapshot.getType(), is(equalTo("export")));
+        assertThat(exportTask.getType(), is(equalTo("export")));
     }
 
     /**

--- a/src/test/java/com/meilisearch/sdk/ExportRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/ExportRequestTest.java
@@ -3,7 +3,6 @@ package com.meilisearch.sdk;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,26 +14,25 @@ public class ExportRequestTest {
     @Test
     void toStringSimpleExportIndexFilter() {
         ExportIndexFilter filter = ExportIndexFilter.builder().build();
-        String expected = "{\"overrideSettings\":false}";
-        assertThat(filter.toString(), is(equalTo(expected)));
-        assertThat(filter.getFilter(), is(nullValue()));
-        assertThat(filter.isOverrideSettings(), is(false));
+        JSONObject json = new JSONObject(filter.toString());
+        assertThat(json.has("overrideSettings"), is(false));
+        assertThat(json.has("filter"), is(false));
     }
 
     @Test
     void toStringExportIndexFilterWithOverride() {
         ExportIndexFilter filter = ExportIndexFilter.builder().overrideSettings(true).build();
-        String expected = "{\"overrideSettings\":true}";
-        assertThat(filter.toString(), is(equalTo(expected)));
-        assertThat(filter.isOverrideSettings(), is(true));
+        JSONObject json = new JSONObject(filter.toString());
+        assertThat(json.getBoolean("overrideSettings"), is(true));
+        assertThat(json.has("filter"), is(false));
     }
 
     @Test
     void toStringExportIndexFilterWithFilter() {
         ExportIndexFilter filter = ExportIndexFilter.builder().filter("status = 'active'").build();
-        String expected = "{\"filter\":\"status = 'active'\",\"overrideSettings\":false}";
-        assertThat(filter.toString(), is(equalTo(expected)));
-        assertThat(filter.getFilter(), is(equalTo("status = 'active'")));
+        JSONObject json = new JSONObject(filter.toString());
+        assertThat(json.getString("filter"), is(equalTo("status = 'active'")));
+        assertThat(json.has("overrideSettings"), is(false));
     }
 
     @Test
@@ -44,8 +42,8 @@ public class ExportRequestTest {
         JSONObject json = new JSONObject(request.toString());
         assertThat(json.getString("url"), is(equalTo("http://localhost:7711")));
         assertThat(json.getString("payloadSize"), is(equalTo("123 MiB")));
-        assertThat(json.isNull("apiKey"), is(true));
-        assertThat(json.isNull("indexes"), is(true));
+        assertThat(json.has("apiKey"), is(false));
+        assertThat(json.has("indexes"), is(false));
     }
 
     @Test
@@ -60,19 +58,14 @@ public class ExportRequestTest {
                         .indexes(indexes)
                         .build();
 
-        String expected =
-                "{\"url\":\"http://localhost:7711\",\"payloadSize\":\"123 MiB\",\"indexes\":{\"*\":{\"overrideSettings\":true}}}";
-        JSONObject expectedJson = new JSONObject(expected);
         JSONObject json = new JSONObject(request.toString());
-
-        assertThat(expectedJson.toString(), is(json.toString()));
 
         assertThat(json.getString("url"), is(equalTo("http://localhost:7711")));
         assertThat(json.getString("payloadSize"), is(equalTo("123 MiB")));
-        assertThat(json.isNull("apiKey"), is(true));
+        assertThat(json.has("apiKey"), is(false));
         JSONObject indexesJson = json.getJSONObject("indexes");
         JSONObject starIndex = indexesJson.getJSONObject("*");
-        assertThat(starIndex.isNull("filter"), is(true));
+        assertThat(starIndex.has("filter"), is(false));
         assertThat(starIndex.getBoolean("overrideSettings"), is(true));
     }
 

--- a/src/test/java/com/meilisearch/sdk/ExportRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/ExportRequestTest.java
@@ -1,0 +1,100 @@
+package com.meilisearch.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class ExportRequestTest {
+
+    @Test
+    void toStringSimpleExportIndexFilter() {
+        ExportIndexFilter filter = ExportIndexFilter.builder().build();
+        String expected = "{\"overrideSettings\":false}";
+        assertThat(filter.toString(), is(equalTo(expected)));
+        assertThat(filter.getFilter(), is(nullValue()));
+        assertThat(filter.isOverrideSettings(), is(false));
+    }
+
+    @Test
+    void toStringExportIndexFilterWithOverride() {
+        ExportIndexFilter filter = ExportIndexFilter.builder().overrideSettings(true).build();
+        String expected = "{\"overrideSettings\":true}";
+        assertThat(filter.toString(), is(equalTo(expected)));
+        assertThat(filter.isOverrideSettings(), is(true));
+    }
+
+    @Test
+    void toStringExportIndexFilterWithFilter() {
+        ExportIndexFilter filter = ExportIndexFilter.builder().filter("status = 'active'").build();
+        String expected = "{\"filter\":\"status = 'active'\",\"overrideSettings\":false}";
+        assertThat(filter.toString(), is(equalTo(expected)));
+        assertThat(filter.getFilter(), is(equalTo("status = 'active'")));
+    }
+
+    @Test
+    void toStringSimpleExportRequest() {
+        ExportRequest request =
+                ExportRequest.builder().url("http://localhost:7711").payloadSize("123 MiB").build();
+        JSONObject json = new JSONObject(request.toString());
+        assertThat(json.getString("url"), is(equalTo("http://localhost:7711")));
+        assertThat(json.getString("payloadSize"), is(equalTo("123 MiB")));
+        assertThat(json.isNull("apiKey"), is(true));
+        assertThat(json.isNull("indexes"), is(true));
+    }
+
+    @Test
+    void toStringExportRequestWithIndexes() {
+        Map<String, ExportIndexFilter> indexes = new HashMap<>();
+        indexes.put("*", ExportIndexFilter.builder().overrideSettings(true).build());
+
+        ExportRequest request =
+                ExportRequest.builder()
+                        .url("http://localhost:7711")
+                        .payloadSize("123 MiB")
+                        .indexes(indexes)
+                        .build();
+
+        String expected =
+                "{\"url\":\"http://localhost:7711\",\"payloadSize\":\"123 MiB\",\"indexes\":{\"*\":{\"overrideSettings\":true}}}";
+        JSONObject expectedJson = new JSONObject(expected);
+        JSONObject json = new JSONObject(request.toString());
+
+        assertThat(expectedJson.toString(), is(json.toString()));
+
+        assertThat(json.getString("url"), is(equalTo("http://localhost:7711")));
+        assertThat(json.getString("payloadSize"), is(equalTo("123 MiB")));
+        assertThat(json.isNull("apiKey"), is(true));
+        JSONObject indexesJson = json.getJSONObject("indexes");
+        JSONObject starIndex = indexesJson.getJSONObject("*");
+        assertThat(starIndex.isNull("filter"), is(true));
+        assertThat(starIndex.getBoolean("overrideSettings"), is(true));
+    }
+
+    @Test
+    void gettersExportRequest() {
+        Map<String, ExportIndexFilter> indexes = new HashMap<>();
+        indexes.put(
+                "myindex",
+                ExportIndexFilter.builder().filter("id > 10").overrideSettings(false).build());
+
+        ExportRequest request =
+                ExportRequest.builder()
+                        .url("http://localhost:7711")
+                        .apiKey("mykey")
+                        .payloadSize("50 MiB")
+                        .indexes(indexes)
+                        .build();
+
+        assertThat(request.getUrl(), is(equalTo("http://localhost:7711")));
+        assertThat(request.getApiKey(), is(equalTo("mykey")));
+        assertThat(request.getPayloadSize(), is(equalTo("50 MiB")));
+        assertThat(request.getIndexes().get("myindex").getFilter(), is(equalTo("id > 10")));
+        assertThat(request.getIndexes().get("myindex").isOverrideSettings(), is(false));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #877 

## What does this PR do?
- Implement [Export API](https://www.meilisearch.com/docs/reference/api/export)
- The implementation is based on some other APIS like [Dumps API](https://www.meilisearch.com/docs/reference/api/dump)
- Integration tests for new Client#export method
- Unit tests for newly created ExportRequest and ExportIndexFilter classes

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting documents between Meilisearch instances with configurable target, payload size, and per-index filters, plus option to override index settings.
* **Tests**
  * Added integration and unit tests to validate export initiation, task tracking, and request serialization/behavior across scenarios.
* **Documentation**
  * Added a new code sample demonstrating how to construct and execute an export request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->