### PR TITLE
Add disableOnNumbers setting in TypoTolerance

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -452,6 +452,10 @@ typo_tolerance_guide_4: |-
           };
   typoTolerance.setMinWordSizeForTypos(minWordSizeTypos);
   client.index("movies").updateTypoToleranceSettings(typoTolerance);
+typo_tolerance_guide_5: |-
+  TypoTolerance typoTolerance = new TypoTolerance();
+  typoTolerance.setDisableOnNumbers(true);
+  client.index("1917").updateTypoToleranceSettings(typoTolerance);
 getting_started_add_documents: |-
   // For Maven:
   // Add the following code to the `<dependencies>` section of your project:

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -455,7 +455,7 @@ typo_tolerance_guide_4: |-
 typo_tolerance_guide_5: |-
   TypoTolerance typoTolerance = new TypoTolerance();
   typoTolerance.setDisableOnNumbers(true);
-  client.index("1917").updateTypoToleranceSettings(typoTolerance);
+  client.index("movies").updateTypoToleranceSettings(typoTolerance);
 getting_started_add_documents: |-
   // For Maven:
   // Add the following code to the `<dependencies>` section of your project:

--- a/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
+++ b/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
@@ -19,7 +19,7 @@ public class TypoTolerance {
     protected HashMap<String, Integer> minWordSizeForTypos;
     protected String[] disableOnWords;
     protected String[] disableOnAttributes;
-    protected boolean disableOnNumbers;
+    protected Boolean disableOnNumbers;
 
     public TypoTolerance() {}
 }

--- a/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
+++ b/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
@@ -19,6 +19,7 @@ public class TypoTolerance {
     protected HashMap<String, Integer> minWordSizeForTypos;
     protected String[] disableOnWords;
     protected String[] disableOnAttributes;
+    protected boolean disableOnNumbers;
 
     public TypoTolerance() {}
 }

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -904,18 +904,16 @@ public class SettingsTest extends AbstractIT {
     @DisplayName("Test update disableOnNumbers tolerance settings")
     public void testUpdateDisableOnNumbersTolerance() throws Exception {
         Index index = createIndex("testUpdateDisableOnNumbers");
-
-        TypoTolerance newTypoTolerance = new TypoTolerance();
-        index.waitForTask(index.updateTypoToleranceSettings(newTypoTolerance).getTaskUid());
-        TypoTolerance updatedTypoToleranceDefault = index.getTypoToleranceSettings();
+        TypoTolerance defaultTypoTolerance = index.getTypoToleranceSettings();
 
         TypoTolerance newTypoToleranceDisableOnNumbers = new TypoTolerance();
         newTypoToleranceDisableOnNumbers.setDisableOnNumbers(true);
-        index.waitForTask(index.updateTypoToleranceSettings(newTypoToleranceDisableOnNumbers).getTaskUid());
-        TypoTolerance updatedTypoToleranceDisableOnNumbers = index.getTypoToleranceSettings();
+        index.waitForTask(
+                index.updateTypoToleranceSettings(newTypoToleranceDisableOnNumbers).getTaskUid());
+        TypoTolerance updatedTypoTolerance = index.getTypoToleranceSettings();
 
-        assertThat(updatedTypoToleranceDefault.isDisableOnNumbers(), is(equalTo(false)));
-        assertThat(updatedTypoToleranceDisableOnNumbers.isDisableOnNumbers(), is(equalTo(true)));
+        assertThat(defaultTypoTolerance.getDisableOnNumbers(), is(equalTo(false)));
+        assertThat(updatedTypoTolerance.getDisableOnNumbers(), is(equalTo(true)));
     }
 
     /** Tests of all the specifics setting methods when null is passed */

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -900,6 +900,24 @@ public class SettingsTest extends AbstractIT {
                 is(notNullValue()));
     }
 
+    @Test
+    @DisplayName("Test update disableOnNumbers tolerance settings")
+    public void testUpdateDisableOnNumbersTolerance() throws Exception {
+        Index index = createIndex("testUpdateDisableOnNumbers");
+
+        TypoTolerance newTypoTolerance = new TypoTolerance();
+        index.waitForTask(index.updateTypoToleranceSettings(newTypoTolerance).getTaskUid());
+        TypoTolerance updatedTypoToleranceDefault = index.getTypoToleranceSettings();
+
+        TypoTolerance newTypoToleranceDisableOnNumbers = new TypoTolerance();
+        newTypoToleranceDisableOnNumbers.setDisableOnNumbers(true);
+        index.waitForTask(index.updateTypoToleranceSettings(newTypoToleranceDisableOnNumbers).getTaskUid());
+        TypoTolerance updatedTypoToleranceDisableOnNumbers = index.getTypoToleranceSettings();
+
+        assertThat(updatedTypoToleranceDefault.isDisableOnNumbers(), is(equalTo(false)));
+        assertThat(updatedTypoToleranceDisableOnNumbers.isDisableOnNumbers(), is(equalTo(true)));
+    }
+
     /** Tests of all the specifics setting methods when null is passed */
     @Test
     @DisplayName("Test update synonyms settings when null is passed")


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #871

## What does this PR do?
- Adds a unit test to verify storing and retrieving the disableOnNumbers setting in TypoTolerance
- Adds typo_tolerance_guide_5 code sample in .code-samples.meilisearch.yaml demonstrating how to enable disableOnNumbers


## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to disable typo tolerance on numeric content, providing finer control over search behavior with numbers.

- **Documentation**
  - Added a code sample demonstrating how to enable the "disable on numbers" typo-tolerance option.

- **Tests**
  - Added integration tests verifying the option is false by default and true when enabled (note: duplicated test case included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->