### PR TITLE
Support "Hybrid" parameter in `IndexSearchRequest` to enable multi search with hybrid search

### DIFF
--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -111,11 +111,7 @@ public class IndexSearchRequest {
                         .putOpt("locales", this.locales)
                         .putOpt("distinct", this.distinct)
                         .putOpt("retrieveVectors", this.retrieveVectors)
-                        .putOpt(
-                                "hybrid",
-                                this.hybrid != null
-                                    ? this.hybrid.toJSONObject() :
-                                    null);
+                        .putOpt("hybrid", this.hybrid != null ? this.hybrid.toJSONObject() : null);
 
         return jsonObject.toString();
     }

--- a/src/test/java/com/meilisearch/sdk/IndexSearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/IndexSearchRequestTest.java
@@ -1,23 +1,23 @@
 package com.meilisearch.sdk;
 
-import com.meilisearch.sdk.model.Hybrid;
-import org.junit.jupiter.api.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+
+import com.meilisearch.sdk.model.Hybrid;
+import org.junit.jupiter.api.Test;
 
 class IndexSearchRequestTest {
     @Test
     void toStringWithHybridUsingBuilder() {
         IndexSearchRequest classToTest =
-            IndexSearchRequest.builder()
-                .q("This is a Test")
-                .hybrid(Hybrid.builder().semanticRatio(0.5).embedder("default").build())
-                .build();
+                IndexSearchRequest.builder()
+                        .q("This is a Test")
+                        .hybrid(Hybrid.builder().semanticRatio(0.5).embedder("default").build())
+                        .build();
 
         String expected =
-            "{\"q\":\"This is a Test\",\"hybrid\":{\"semanticRatio\":0.5,\"embedder\":\"default\"}}";
+                "{\"q\":\"This is a Test\",\"hybrid\":{\"semanticRatio\":0.5,\"embedder\":\"default\"}}";
         assertThat(classToTest.toString(), is(equalTo(expected)));
 
         // Verify getters
@@ -28,28 +28,28 @@ class IndexSearchRequestTest {
     @Test
     void toStringWithHybridAndOtherParameters() {
         IndexSearchRequest classToTest =
-            IndexSearchRequest.builder()
-                .q("This is a Test")
-                .offset(200)
-                .limit(900)
-                .hybrid(
-                    Hybrid.builder()
-                        .semanticRatio(0.7)
-                        .embedder("custom-embedder")
-                        .build())
-                .build();
+                IndexSearchRequest.builder()
+                        .q("This is a Test")
+                        .offset(200)
+                        .limit(900)
+                        .hybrid(
+                                Hybrid.builder()
+                                        .semanticRatio(0.7)
+                                        .embedder("custom-embedder")
+                                        .build())
+                        .build();
 
         String expected =
-            "{\"q\":\"This is a Test\",\"hybrid\":{\"semanticRatio\":0.7,\"embedder\":\"custom-embedder\"},\"offset\":200,\"limit\":900}";
+                "{\"q\":\"This is a Test\",\"hybrid\":{\"semanticRatio\":0.7,\"embedder\":\"custom-embedder\"},\"offset\":200,\"limit\":900}";
         assertThat(classToTest.toString(), is(equalTo(expected)));
     }
 
     @Test
     void toStringWithHybridOnlyEmbedder() {
         IndexSearchRequest classToTest =
-            new IndexSearchRequest("someIndexUuid")
-                .setQuery("This is a Test")
-                .setHybrid(Hybrid.builder().embedder("default").build());
+                new IndexSearchRequest("someIndexUuid")
+                        .setQuery("This is a Test")
+                        .setHybrid(Hybrid.builder().embedder("default").build());
 
         String expected = "{\"q\":\"This is a Test\",\"hybrid\":{\"embedder\":\"default\"}}";
         assertThat(classToTest.toString(), is(equalTo(expected)));


### PR DESCRIPTION
# Pull Request

## Related issue
- 

## What does this PR do?
- Adds the Hybrid search option to IndexSearchRequest which is used in multi [search queries](https://www.meilisearch.com/docs/reference/api/multi_search) 
- This is basically a clone of the hybrid implementation in the SearchRequest class

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hybrid search configuration to requests, allowing users to provide semantic ratio and embedder settings for combined keyword + semantic search; hybrid settings are included in request serialization.

* **Tests**
  * Added tests verifying hybrid configuration is correctly represented in serialized request output and stringified form across multiple parameter combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->