### PR TITLE
Add support for custom metadata in document operations

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -161,12 +161,36 @@ class Documents {
      */
     TaskInfo addDocuments(String uid, String document, String primaryKey, String csvDelimiter)
             throws MeilisearchException {
+        return addDocuments(uid, document, primaryKey, csvDelimiter, null);
+    }
+
+    /**
+     * Adds/Replaces a document at the specified index uid
+     *
+     * @param uid Partial index identifier for the document
+     * @param document String containing the document to add
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter CSV delimiter of the document
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo addDocuments(
+            String uid,
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata)
+            throws MeilisearchException {
         URLBuilder urlb = documentPath(uid);
         if (primaryKey != null) {
             urlb.addParameter("primaryKey", primaryKey);
         }
         if (csvDelimiter != null) {
             urlb.addParameter("csvDelimiter", csvDelimiter);
+        }
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
         }
         return httpClient.post(urlb.getURL(), document, TaskInfo.class);
     }
@@ -182,12 +206,36 @@ class Documents {
      */
     TaskInfo updateDocuments(String uid, String document, String primaryKey, String csvDelimiter)
             throws MeilisearchException {
+        return updateDocuments(uid, document, primaryKey, csvDelimiter, null);
+    }
+
+    /**
+     * Replaces a document at the specified index uid
+     *
+     * @param uid Partial index identifier for the document
+     * @param document String containing the document to replace the existing document
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter CSV delimiter of the document
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo updateDocuments(
+            String uid,
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata)
+            throws MeilisearchException {
         URLBuilder urlb = documentPath(uid);
         if (primaryKey != null) {
             urlb.addParameter("primaryKey", primaryKey);
         }
         if (csvDelimiter != null) {
             urlb.addParameter("csvDelimiter", csvDelimiter);
+        }
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
         }
         return httpClient.put(urlb.getURL(), document, TaskInfo.class);
     }
@@ -201,7 +249,25 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocument(String uid, String identifier) throws MeilisearchException {
-        return httpClient.<TaskInfo>delete(documentPath(uid, identifier).getURL(), TaskInfo.class);
+        return deleteDocument(uid, identifier, null);
+    }
+
+    /**
+     * Deletes the document from the specified index uid with the specified identifier
+     *
+     * @param uid Partial index identifier for the requested document
+     * @param identifier ID of the document
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo deleteDocument(String uid, String identifier, String customMetadata)
+            throws MeilisearchException {
+        URLBuilder urlb = documentPath(uid, identifier);
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
+        }
+        return httpClient.<TaskInfo>delete(urlb.getURL(), TaskInfo.class);
     }
 
     /**
@@ -213,7 +279,24 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocuments(String uid, List<String> identifiers) throws MeilisearchException {
+        return deleteDocuments(uid, identifiers, null);
+    }
+
+    /**
+     * Deletes the documents at the specified index uid with the specified identifiers
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @param identifiers ID of documents to delete
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo deleteDocuments(String uid, List<String> identifiers, String customMetadata)
+            throws MeilisearchException {
         URLBuilder urlb = documentPath(uid).addSubroute("delete-batch");
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
+        }
         return httpClient.post(urlb.getURL(), identifiers, TaskInfo.class);
     }
 
@@ -226,6 +309,20 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteDocumentsByFilter(String uid, String filter) throws MeilisearchException {
+        return deleteDocumentsByFilter(uid, filter, null);
+    }
+
+    /**
+     * Deletes the documents matching the given filter
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @param filter filter to match the documents on
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo deleteDocumentsByFilter(String uid, String filter, String customMetadata)
+            throws MeilisearchException {
         if (filter == null || filter.isEmpty()) {
             throw new MeilisearchException(
                     "Null or blank filter not allowed while deleting documents");
@@ -233,6 +330,9 @@ class Documents {
         HashMap<String, String> filterMap = new HashMap<>();
         filterMap.put("filter", filter);
         URLBuilder urlb = documentPath(uid).addSubroute("delete");
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
+        }
         return httpClient.post(urlb.getURL(), filterMap, TaskInfo.class);
     }
 
@@ -244,7 +344,23 @@ class Documents {
      * @throws MeilisearchException if the client request causes an error
      */
     TaskInfo deleteAllDocuments(String uid) throws MeilisearchException {
-        return httpClient.<TaskInfo>delete(documentPath(uid).getURL(), TaskInfo.class);
+        return deleteAllDocuments(uid, null);
+    }
+
+    /**
+     * Deletes all documents at the specified index uid
+     *
+     * @param uid Partial index identifier for the requested documents
+     * @param customMetadata Custom metadata to attach to the task
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo deleteAllDocuments(String uid, String customMetadata) throws MeilisearchException {
+        URLBuilder urlb = documentPath(uid);
+        if (customMetadata != null) {
+            urlb.addParameter("customMetadata", customMetadata);
+        }
+        return httpClient.<TaskInfo>delete(urlb.getURL(), TaskInfo.class);
     }
 
     /** Creates an URLBuilder for the constant route documents. */

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -205,6 +205,26 @@ public class Index implements Serializable {
     }
 
     /**
+     * Adds/Replaces documents in the index
+     *
+     * @param document Document to add in JSON or CSV string format
+     * @param primaryKey PrimaryKey of the document to add
+     * @param csvDelimiter Custom delimiter to use for the document being added
+     * @param customMetadata Custom metadata to attach to the task
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     specification</a>
+     */
+    public TaskInfo addDocuments(
+            String document, String primaryKey, String csvDelimiter, String customMetadata)
+            throws MeilisearchException {
+        return this.documents.addDocuments(
+                this.uid, document, primaryKey, csvDelimiter, customMetadata);
+    }
+
+    /**
      * Adds/Replaces documents in the index in batches
      *
      * @param batchSize size of the batch of documents
@@ -299,6 +319,26 @@ public class Index implements Serializable {
     }
 
     /**
+     * Updates documents in the index
+     *
+     * @param document Document to update in JSON or CSV string format
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter Custom delimiter to use for the document being added
+     * @param customMetadata Custom metadata to attach to the task
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     specification</a>
+     */
+    public TaskInfo updateDocuments(
+            String document, String primaryKey, String csvDelimiter, String customMetadata)
+            throws MeilisearchException {
+        return this.documents.updateDocuments(
+                this.uid, document, primaryKey, csvDelimiter, customMetadata);
+    }
+
+    /**
      * Updates documents in index in batches
      *
      * @param document Document to add in JSON string format
@@ -360,6 +400,22 @@ public class Index implements Serializable {
     }
 
     /**
+     * Deletes a document from the index
+     *
+     * @param identifier Identifier of the document to delete
+     * @param customMetadata Custom metadata to attach to the task
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-one-document">API
+     *     specification</a>
+     */
+    public TaskInfo deleteDocument(String identifier, String customMetadata)
+            throws MeilisearchException {
+        return this.documents.deleteDocument(this.uid, identifier, customMetadata);
+    }
+
+    /**
      * Deletes list of documents from the index
      *
      * @param documentsIdentifiers list of identifiers of documents to delete
@@ -373,6 +429,24 @@ public class Index implements Serializable {
     @Deprecated
     public TaskInfo deleteDocuments(List<String> documentsIdentifiers) throws MeilisearchException {
         return this.documents.deleteDocuments(this.uid, documentsIdentifiers);
+    }
+
+    /**
+     * Deletes list of documents from the index
+     *
+     * @param documentsIdentifiers list of identifiers of documents to delete
+     * @param customMetadata Custom metadata to attach to the task
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-batch">API
+     *     specification</a>
+     * @see com.meilisearch.sdk.Index#deleteDocumentsByFilter(String) Delete documents using filter
+     */
+    @Deprecated
+    public TaskInfo deleteDocuments(List<String> documentsIdentifiers, String customMetadata)
+            throws MeilisearchException {
+        return this.documents.deleteDocuments(this.uid, documentsIdentifiers, customMetadata);
     }
 
     /**
@@ -391,6 +465,23 @@ public class Index implements Serializable {
     }
 
     /**
+     * Deletes list of documents from the index using the given filter
+     *
+     * @param filter filter to match the documents to delete
+     * @param customMetadata Custom metadata to attach to the task
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-filter">API
+     *     specification</a>
+     * @since 1.2
+     */
+    public TaskInfo deleteDocumentsByFilter(String filter, String customMetadata)
+            throws MeilisearchException {
+        return this.documents.deleteDocumentsByFilter(this.uid, filter, customMetadata);
+    }
+
+    /**
      * Deletes all documents in the index
      *
      * @return List of tasks Meilisearch API response
@@ -401,6 +492,20 @@ public class Index implements Serializable {
      */
     public TaskInfo deleteAllDocuments() throws MeilisearchException {
         return this.documents.deleteAllDocuments(this.uid);
+    }
+
+    /**
+     * Deletes all documents in the index
+     *
+     * @param customMetadata Custom metadata to attach to the task
+     * @return List of tasks Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-all-documents">API
+     *     specification</a>
+     */
+    public TaskInfo deleteAllDocuments(String customMetadata) throws MeilisearchException {
+        return this.documents.deleteAllDocuments(this.uid, customMetadata);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/model/Task.java
+++ b/src/main/java/com/meilisearch/sdk/model/Task.java
@@ -20,6 +20,7 @@ public class Task {
     protected Date finishedAt = null;
     protected TaskError error = null;
     protected TaskDetails details = null;
+    protected String customMetadata = null;
 
     public Task() {}
 }

--- a/src/test/java/com/meilisearch/integration/DocumentsTest.java
+++ b/src/test/java/com/meilisearch/integration/DocumentsTest.java
@@ -731,4 +731,138 @@ public class DocumentsTest extends AbstractIT {
         movies = index.getDocuments(Movie.class).getResults();
         assertThat(movies, is(arrayWithSize(0)));
     }
+
+    /** Test addDocuments with customMetadata */
+    @Test
+    public void testAddDocumentsWithCustomMetadata() throws Exception {
+        String indexUid = "AddDocumentsWithCustomMetadata";
+        Index index = client.index(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        String singleDocument = this.gson.toJson(testData.getData().get(0));
+        TaskInfo task =
+                index.addDocuments("[" + singleDocument + "]", null, null, "add-movies-metadata");
+
+        index.waitForTask(task.getTaskUid());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("add-movies-metadata")));
+    }
+
+    /** Test updateDocuments with customMetadata */
+    @Test
+    public void testUpdateDocumentsWithCustomMetadata() throws Exception {
+        String indexUid = "UpdateDocumentsWithCustomMetadata";
+        Index index = createEmptyIndex(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo addTask = index.addDocuments(testData.getRaw());
+        index.waitForTask(addTask.getTaskUid());
+
+        String updateDocument =
+                "[{\"id\":\"419704\",\"title\":\"Ad Astra Updated\",\"genre\":[\"Drama\"]}]";
+        TaskInfo task = index.updateDocuments(updateDocument, null, null, "update-movies-metadata");
+
+        index.waitForTask(task.getTaskUid());
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentAdditionOrUpdate")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("update-movies-metadata")));
+    }
+
+    /** Test deleteDocument with customMetadata */
+    @Test
+    public void testDeleteDocumentWithCustomMetadata() throws Exception {
+        String indexUid = "DeleteDocumentWithCustomMetadata";
+        Index index = createEmptyIndex(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo addTask = index.addDocuments(testData.getRaw());
+        index.waitForTask(addTask.getTaskUid());
+
+        TaskInfo task = index.deleteDocument("419704", "delete-single-movie-metadata");
+        index.waitForTask(task.getTaskUid());
+
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentDeletion")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("delete-single-movie-metadata")));
+    }
+
+    /** Test deleteDocuments (batch) with customMetadata */
+    @Test
+    public void testDeleteDocumentsBatchWithCustomMetadata() throws Exception {
+        String indexUid = "DeleteDocumentsBatchWithCustomMetadata";
+        Index index = createEmptyIndex(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo addTask = index.addDocuments(testData.getRaw());
+        index.waitForTask(addTask.getTaskUid());
+
+        List<String> identifiers = Arrays.asList("419704", "574982");
+        TaskInfo task = index.deleteDocuments(identifiers, "delete-batch-metadata");
+        index.waitForTask(task.getTaskUid());
+
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentDeletion")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("delete-batch-metadata")));
+    }
+
+    /** Test deleteDocumentsByFilter with customMetadata */
+    @Test
+    public void testDeleteDocumentsByFilterWithCustomMetadata() throws Exception {
+        String indexUid = "DeleteDocumentsByFilterWithCustomMetadata";
+        Index index = createEmptyIndex(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo addTask = index.addDocuments(testData.getRaw());
+        index.waitForTask(addTask.getTaskUid());
+
+        index.waitForTask(
+                index.updateFilterableAttributesSettings(new String[] {"id"}).getTaskUid());
+
+        TaskInfo task = index.deleteDocumentsByFilter("id = 419704", "delete-filter-metadata");
+        index.waitForTask(task.getTaskUid());
+
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentDeletion")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("delete-filter-metadata")));
+    }
+
+    /** Test deleteAllDocuments with customMetadata */
+    @Test
+    public void testDeleteAllDocumentsWithCustomMetadata() throws Exception {
+        String indexUid = "DeleteAllDocumentsWithCustomMetadata";
+        Index index = client.index(indexUid);
+
+        TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+        TaskInfo addTask = index.addDocuments(testData.getRaw());
+        index.waitForTask(addTask.getTaskUid());
+
+        TaskInfo task = index.deleteAllDocuments("delete-all-metadata");
+        index.waitForTask(task.getTaskUid());
+
+        assertThat(task, is(instanceOf(TaskInfo.class)));
+        assertThat(task.getType(), is(equalTo("documentDeletion")));
+
+        // Verify the task was created with custom metadata
+        com.meilisearch.sdk.model.Task taskDetails = index.getTask(task.getTaskUid());
+        assertThat(taskDetails.getCustomMetadata(), is(equalTo("delete-all-metadata")));
+
+        Results<Movie> result = index.getDocuments(Movie.class);
+        assertThat(result.getResults(), is(arrayWithSize(0)));
+    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #905

## What does this PR do?
This pull request adds support for passing custom metadata when performing document operations in the Meilisearch Java SDK. The main changes include updating the `Documents` and `Index` classes to accept an optional `customMetadata` parameter for add, update, and delete operations, storing this metadata in the `Task` model, and introducing comprehensive integration tests to validate the new functionality.

### Model changes

* Updated the `Task` model (`Task.java`) to include a `customMetadata` field, ensuring that metadata attached to tasks is stored and accessible.

### Test coverage

* Added multiple integration tests in `DocumentsTest.java` to verify that custom metadata is correctly attached and retrievable for all document operations (add, update, delete single, delete batch, delete by filter, delete all).


## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom metadata across all document operations including add, update, single/batch delete, filter-based delete, and delete-all operations. Custom metadata can now be attached to document operations and is included in task responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->