### PR TITLE
Allow skipCreation when adding/replacing documents

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -40,14 +40,22 @@ add_or_replace_documents_1: |-
     + "\"poster\": \"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg\","
     + "\"overview\": \"A boy is given the ability to become an adult superhero in times of need with a single magic word.\","
     + "\"release_date\": \"2019-03-23\""
-    + "}]"
+    + "}]",
+    null,
+    null,
+    null,
+    false
   );
 add_or_update_documents_1: |-
-  client.index("movies").updateDocuments("[{
+  client.index("movies").updateDocuments("[{"
     + "\"id\": 287947,"
     + "\"title\": \"Shazam ⚡️\","
     + "\"genres\": \"comedy\""
-    + "}]"
+    + "}]",
+    null,
+    null,
+    null,
+    false
   );
 delete_all_documents_1: |-
   client.index("movies").deleteAllDocuments();

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -161,7 +161,7 @@ class Documents {
      */
     TaskInfo addDocuments(String uid, String document, String primaryKey, String csvDelimiter)
             throws MeilisearchException {
-        return addDocuments(uid, document, primaryKey, csvDelimiter, null);
+        return addDocuments(uid, document, primaryKey, csvDelimiter, null, null);
     }
 
     /**
@@ -182,6 +182,29 @@ class Documents {
             String csvDelimiter,
             String customMetadata)
             throws MeilisearchException {
+        return addDocuments(uid, document, primaryKey, csvDelimiter, customMetadata, null);
+    }
+
+    /**
+     * Adds/Replaces a document at the specified index uid
+     *
+     * @param uid Partial index identifier for the document
+     * @param document String containing the document to add
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter CSV delimiter of the document
+     * @param customMetadata Custom metadata to attach to the task
+     * @param skipCreation If true, skips document creation and only updates existing documents
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo addDocuments(
+            String uid,
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata,
+            Boolean skipCreation)
+            throws MeilisearchException {
         URLBuilder urlb = documentPath(uid);
         if (primaryKey != null) {
             urlb.addParameter("primaryKey", primaryKey);
@@ -191,6 +214,9 @@ class Documents {
         }
         if (customMetadata != null) {
             urlb.addParameter("customMetadata", customMetadata);
+        }
+        if (skipCreation != null) {
+            urlb.addParameter("skipCreation", skipCreation.toString());
         }
         return httpClient.post(urlb.getURL(), document, TaskInfo.class);
     }
@@ -206,7 +232,7 @@ class Documents {
      */
     TaskInfo updateDocuments(String uid, String document, String primaryKey, String csvDelimiter)
             throws MeilisearchException {
-        return updateDocuments(uid, document, primaryKey, csvDelimiter, null);
+        return updateDocuments(uid, document, primaryKey, csvDelimiter, null, null);
     }
 
     /**
@@ -227,6 +253,29 @@ class Documents {
             String csvDelimiter,
             String customMetadata)
             throws MeilisearchException {
+        return updateDocuments(uid, document, primaryKey, csvDelimiter, customMetadata, null);
+    }
+
+    /**
+     * Replaces a document at the specified index uid
+     *
+     * @param uid Partial index identifier for the document
+     * @param document String containing the document to replace the existing document
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter CSV delimiter of the document
+     * @param customMetadata Custom metadata to attach to the task
+     * @param skipCreation If true, skips document creation and only updates existing documents
+     * @return Meilisearch's TaskInfo API response
+     * @throws MeilisearchException if the client request causes an error
+     */
+    TaskInfo updateDocuments(
+            String uid,
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata,
+            Boolean skipCreation)
+            throws MeilisearchException {
         URLBuilder urlb = documentPath(uid);
         if (primaryKey != null) {
             urlb.addParameter("primaryKey", primaryKey);
@@ -236,6 +285,9 @@ class Documents {
         }
         if (customMetadata != null) {
             urlb.addParameter("customMetadata", customMetadata);
+        }
+        if (skipCreation != null) {
+            urlb.addParameter("skipCreation", skipCreation.toString());
         }
         return httpClient.put(urlb.getURL(), document, TaskInfo.class);
     }

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -221,7 +221,32 @@ public class Index implements Serializable {
             String document, String primaryKey, String csvDelimiter, String customMetadata)
             throws MeilisearchException {
         return this.documents.addDocuments(
-                this.uid, document, primaryKey, csvDelimiter, customMetadata);
+                this.uid, document, primaryKey, csvDelimiter, customMetadata, null);
+    }
+
+    /**
+     * Adds/Replaces documents in the index
+     *
+     * @param document Document to add in JSON or CSV string format
+     * @param primaryKey PrimaryKey of the document to add
+     * @param csvDelimiter Custom delimiter to use for the document being added
+     * @param customMetadata Custom metadata to attach to the task
+     * @param skipCreation If true, skips document creation and only updates existing documents
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     specification</a>
+     */
+    public TaskInfo addDocuments(
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata,
+            Boolean skipCreation)
+            throws MeilisearchException {
+        return this.documents.addDocuments(
+                this.uid, document, primaryKey, csvDelimiter, customMetadata, skipCreation);
     }
 
     /**
@@ -335,7 +360,32 @@ public class Index implements Serializable {
             String document, String primaryKey, String csvDelimiter, String customMetadata)
             throws MeilisearchException {
         return this.documents.updateDocuments(
-                this.uid, document, primaryKey, csvDelimiter, customMetadata);
+                this.uid, document, primaryKey, csvDelimiter, customMetadata, null);
+    }
+
+    /**
+     * Updates documents in the index
+     *
+     * @param document Document to update in JSON or CSV string format
+     * @param primaryKey PrimaryKey of the document
+     * @param csvDelimiter Custom delimiter to use for the document being added
+     * @param customMetadata Custom metadata to attach to the task
+     * @param skipCreation If true, skips document creation and only updates existing documents
+     * @return TaskInfo Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     specification</a>
+     */
+    public TaskInfo updateDocuments(
+            String document,
+            String primaryKey,
+            String csvDelimiter,
+            String customMetadata,
+            Boolean skipCreation)
+            throws MeilisearchException {
+        return this.documents.updateDocuments(
+                this.uid, document, primaryKey, csvDelimiter, customMetadata, skipCreation);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #919.

## What does this PR do?
- Adds support for the `skipCreation` parameter introduced in Meilisearch v1.31.0
- Allows users to skip document creation when using `addDocuments` and `updateDocuments` methods, while still allowing updates to existing documents
- Updates code examples to demonstrate the new parameter usage

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skipCreation parameter option to control whether document operations create new documents or only update existing ones.

* **Tests**
  * Added integration tests for skipCreation behavior across add and update operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->