### PR TITLE
Add support for sorting on the documents API

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -110,7 +110,7 @@ class Documents {
      */
     <T> Results<T> getDocuments(String uid, DocumentsQuery param, Class<T> targetClass)
             throws MeilisearchException {
-        if (param.getFilter() != null) {
+        if (param.getFilter() != null || param.getSort() != null) {
             return httpClient.post(
                     documentPathWithFetch(uid).getURL(),
                     param.toString(),
@@ -141,7 +141,7 @@ class Documents {
      * @throws MeilisearchException if an error occurs
      */
     String getRawDocuments(String uid, DocumentsQuery param) throws MeilisearchException {
-        if (param.getFilter() != null) {
+        if (param.getFilter() != null || param.getSort() != null) {
             return httpClient.post(
                     documentPathWithFetch(uid).getURL(), param.toString(), String.class);
         }

--- a/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
@@ -21,6 +21,7 @@ public class DocumentsQuery {
     private int limit = -1;
     private String[] fields;
     private String[] filter;
+    private String[] sort;
 
     public DocumentsQuery() {}
 
@@ -29,7 +30,8 @@ public class DocumentsQuery {
                 new URLBuilder()
                         .addParameter("limit", this.getLimit())
                         .addParameter("offset", this.getOffset())
-                        .addParameter("fields", this.getFields());
+                        .addParameter("fields", this.getFields())
+                        .addParameter("sort", this.getSort());
         return urlb.getURL();
     }
 
@@ -47,6 +49,9 @@ public class DocumentsQuery {
         }
         if (filter != null) {
             jsonObject.put("filter", filter);
+        }
+        if (sort != null) {
+            jsonObject.put("sort", sort);
         }
         return jsonObject.toString();
     }

--- a/src/test/java/com/meilisearch/integration/DocumentsTest.java
+++ b/src/test/java/com/meilisearch/integration/DocumentsTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -545,7 +546,8 @@ public class DocumentsTest extends AbstractIT {
             assertThat(movies[i].getTitle(), is(notNullValue()));
             assertThat(movies[i + 1].getTitle(), is(notNullValue()));
             assertThat(
-                    movies[i].getTitle().compareTo(movies[i + 1].getTitle()), is(not(equalTo(1))));
+                    movies[i].getTitle().compareTo(movies[i + 1].getTitle()),
+                    is(lessThanOrEqualTo(0)));
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #884.

## What does this PR do?
- Adds support for sorting on the documents API by introducing a `sort` parameter to `DocumentsQuery`
- Updates the `Documents` class to use POST `/fetch` endpoint when sort parameter is present
- Adds integration tests to verify sorting functionality for both `getDocuments()` and `getRawDocuments()` methods

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document sorting for both standard and raw retrieval—sort by attributes in ascending or descending order and respect result limits.
* **Tests**
  * Added integration tests validating sorting behavior, ordering, and result limits for document fetches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->