### PR TITLE
Add `showPerformanceDetails` to supported endpoints

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -11,6 +11,7 @@ public class MultiSearchFederation {
     private Integer offset;
     private MergeFacets mergeFacets;
     private Map<String, String[]> facetsByIndex;
+    private Boolean showPerformanceDetails;
 
     public MultiSearchFederation setLimit(Integer limit) {
         this.limit = limit;
@@ -29,6 +30,11 @@ public class MultiSearchFederation {
 
     public MultiSearchFederation setFacetsByIndex(Map<String, String[]> facetsByIndex) {
         this.facetsByIndex = facetsByIndex;
+        return this;
+    }
+
+    public MultiSearchFederation setShowPerformanceDetails(Boolean showPerformanceDetails) {
+        this.showPerformanceDetails = showPerformanceDetails;
         return this;
     }
 

--- a/src/main/java/com/meilisearch/sdk/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SearchRequest.java
@@ -46,6 +46,7 @@ public class SearchRequest {
     protected Hybrid hybrid;
     protected Double[] vector;
     protected Boolean retrieveVectors;
+    protected Boolean showPerformanceDetails;
     /**
      * Constructor for SearchRequest for building search queries with the default values: offset: 0,
      * limit: 20, attributesToRetrieve: ["*"], attributesToCrop: null, cropLength: 200,
@@ -110,7 +111,8 @@ public class SearchRequest {
                         .putOpt("locales", this.locales)
                         .putOpt("distinct", this.distinct)
                         .putOpt("vector", this.vector)
-                        .putOpt("retrieveVectors", this.retrieveVectors);
+                        .putOpt("retrieveVectors", this.retrieveVectors)
+                        .putOpt("showPerformanceDetails", this.showPerformanceDetails);
 
         if (this.hybrid != null) {
             jsonObject.put("hybrid", this.hybrid.toJSONObject());

--- a/src/main/java/com/meilisearch/sdk/SimilarDocumentRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SimilarDocumentRequest.java
@@ -20,6 +20,7 @@ public class SimilarDocumentRequest {
     private Boolean showRankingScoreDetails;
     private Double rankingScoreThreshold;
     private Boolean retrieveVectors;
+    private Boolean showPerformanceDetails;
 
     /** Constructor for SimilarDocumentsRequest for building search request for similar documents */
     public SimilarDocumentRequest() {}
@@ -37,6 +38,7 @@ public class SimilarDocumentRequest {
         jsonObject.putOpt("showRankingScoreDetails", this.showRankingScoreDetails);
         jsonObject.putOpt("rankingScoreThreshold", this.rankingScoreThreshold);
         jsonObject.putOpt("retrieveVectors", this.retrieveVectors);
+        jsonObject.putOpt("showPerformanceDetails", this.showPerformanceDetails);
 
         return jsonObject.toString();
     }

--- a/src/main/java/com/meilisearch/sdk/model/MultiSearchResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/MultiSearchResult.java
@@ -23,6 +23,7 @@ public class MultiSearchResult implements Searchable {
     int limit;
     int estimatedTotalHits;
     HashMap<String, FacetsByIndexInfo> facetsByIndex;
+    HashMap<String, Object> performanceDetails;
 
     public MultiSearchResult() {}
 }

--- a/src/main/java/com/meilisearch/sdk/model/SearchResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/SearchResult.java
@@ -24,6 +24,7 @@ public class SearchResult implements Searchable {
     int limit;
     int estimatedTotalHits;
     HashMap<String, Object> _vectors;
+    HashMap<String, Object> performanceDetails;
 
     public SearchResult() {}
 }

--- a/src/main/java/com/meilisearch/sdk/model/SimilarDocumentsResults.java
+++ b/src/main/java/com/meilisearch/sdk/model/SimilarDocumentsResults.java
@@ -20,4 +20,5 @@ public class SimilarDocumentsResults {
     int offset;
     int limit;
     int estimatedTotalHits;
+    HashMap<String, Object> performanceDetails;
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #933 

## What does this PR do?
- Adds `showPerformanceDetails` to all related endpoints
- Update response class to match the updated response 
- Updated tests to check for the `performanceDetailsField` 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can opt to include performance details with search, multi-search/federation, and similar-document requests; responses will include performance metrics and execution details when enabled.

* **Tests**
  * Added integration tests that validate requesting performance details and confirm returned results include the new metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->