### PR TITLE
Support customising OkHttpClient instance through config

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Config.java
+++ b/src/main/java/com/meilisearch/sdk/Config.java
@@ -42,7 +42,8 @@ public class Config {
     }
 
     /**
-     * Creates a configuration with an API key and a provided OkHttpClient, and no customized headers.
+     * Creates a configuration with an API key and a provided OkHttpClient, and no customized
+     * headers.
      *
      * @param hostUrl URL of the Meilisearch instance
      * @param apiKey API key to pass to the header of requests sent to Meilisearch
@@ -87,7 +88,8 @@ public class Config {
     }
 
     /**
-     * Creates a configuration with an API key, client agent header value, a JSON handler and an OkHttpClient
+     * Creates a configuration with an API key, client agent header value, a JSON handler and an
+     * OkHttpClient
      *
      * @param hostUrl URL of the Meilisearch instance
      * @param apiKey API key to pass to the header of requests sent to Meilisearch
@@ -95,7 +97,12 @@ public class Config {
      * @param okHttpClient The OkHttpClient instance to use for the SDK's HTTP requests
      * @param clientAgents List of customized agents to be passed to User-Agent header.
      */
-    public Config(String hostUrl, String apiKey, JsonHandler jsonHandler, OkHttpClient okHttpClient, String[] clientAgents) {
+    public Config(
+            String hostUrl,
+            String apiKey,
+            JsonHandler jsonHandler,
+            OkHttpClient okHttpClient,
+            String[] clientAgents) {
         this.hostUrl = hostUrl;
         this.apiKey = apiKey;
         this.headers = configHeaders(clientAgents);

--- a/src/main/java/com/meilisearch/sdk/Config.java
+++ b/src/main/java/com/meilisearch/sdk/Config.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
+import okhttp3.OkHttpClient;
 
 /** Meilisearch configuration */
 @Getter
@@ -19,6 +20,7 @@ public class Config {
     protected final HttpClient httpClient;
     protected final Map<String, String> headers;
     protected JsonHandler jsonHandler;
+    protected final OkHttpClient okHttpClient;
 
     /**
      * Creates a configuration without an API key
@@ -36,7 +38,18 @@ public class Config {
      * @param apiKey API key to pass to the header of requests sent to Meilisearch
      */
     public Config(String hostUrl, String apiKey) {
-        this(hostUrl, apiKey, new GsonJsonHandler(), new String[0]);
+        this(hostUrl, apiKey, defaultJsonHandler(), new String[0]);
+    }
+
+    /**
+     * Creates a configuration with an API key and a provided OkHttpClient, and no customized headers.
+     *
+     * @param hostUrl URL of the Meilisearch instance
+     * @param apiKey API key to pass to the header of requests sent to Meilisearch
+     * @param okHttpClient The OkHttpClient instance to used by the SDK for making requests
+     */
+    public Config(String hostUrl, String apiKey, OkHttpClient okHttpClient) {
+        this(hostUrl, apiKey, defaultJsonHandler(), okHttpClient, new String[0]);
     }
 
     /**
@@ -58,7 +71,7 @@ public class Config {
      * @param clientAgents List of customized agents to be passed to User-Agent header.
      */
     public Config(String hostUrl, String apiKey, String[] clientAgents) {
-        this(hostUrl, apiKey, new GsonJsonHandler(), clientAgents);
+        this(hostUrl, apiKey, defaultJsonHandler(), clientAgents);
     }
 
     /**
@@ -70,10 +83,24 @@ public class Config {
      * @param clientAgents List of customized agents to be passed to User-Agent header.
      */
     public Config(String hostUrl, String apiKey, JsonHandler jsonHandler, String[] clientAgents) {
+        this(hostUrl, apiKey, jsonHandler, defaultOkHttpClient(), clientAgents);
+    }
+
+    /**
+     * Creates a configuration with an API key, client agent header value, a JSON handler and an OkHttpClient
+     *
+     * @param hostUrl URL of the Meilisearch instance
+     * @param apiKey API key to pass to the header of requests sent to Meilisearch
+     * @param jsonHandler JsonHandler to parse or write JSON
+     * @param okHttpClient The OkHttpClient instance to use for the SDK's HTTP requests
+     * @param clientAgents List of customized agents to be passed to User-Agent header.
+     */
+    public Config(String hostUrl, String apiKey, JsonHandler jsonHandler, OkHttpClient okHttpClient, String[] clientAgents) {
         this.hostUrl = hostUrl;
         this.apiKey = apiKey;
         this.headers = configHeaders(clientAgents);
         this.jsonHandler = jsonHandler;
+        this.okHttpClient = okHttpClient;
         this.httpClient = new HttpClient(this);
     }
 
@@ -94,5 +121,13 @@ public class Config {
         data.put("User-Agent", String.join(";", list));
 
         return data;
+    }
+
+    private static OkHttpClient defaultOkHttpClient() {
+        return new OkHttpClient();
+    }
+
+    private static JsonHandler defaultJsonHandler() {
+        return new GsonJsonHandler();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
+++ b/src/main/java/com/meilisearch/sdk/http/CustomOkHttpClient.java
@@ -28,7 +28,7 @@ public class CustomOkHttpClient {
 
     public CustomOkHttpClient(Config config) {
         this.config = config;
-        this.client = new OkHttpClient();
+        this.client = config.getOkHttpClient();
     }
 
     public <T> HttpResponse<T> execute(HttpRequest request) throws MeilisearchException {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #903

## What does this PR do?
- Adds a couple of custom constructors to `Config` class to allow consumer of library to provide a custom OkHttpClient instance
- Updates the `CustomOkHttpClient` class to pull its `OkHttpClient` instance from the configuration rather than instantiating its own

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for supplying a custom HTTP client during SDK configuration for greater control over networking.
  * SDK now uses the configured HTTP client for internal requests by default.
  * Centralized defaults for HTTP client and JSON handling to simplify configuration and improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->