### PR TITLE
add prefix search setting and facet search setting methods

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -751,3 +751,16 @@ update_webhook_1: |-
   Webhook updated_webhook = this.client.updateWebhook(webhook.getUuid(), webhookReq2);
 delete_webhook_1: |-
   this.client.deleteWebhook("WEBHOOK_UUID");
+get_facet_search_setting_1: |-
+  Boolean value = index.getFacetSearchSettings();
+update_facet_search_setting_1: |-
+  index.updateFacetSearchSettings(false);
+reset_facet_search_setting_1: |-
+  index.resetFacetSearchSettings();
+get_prefix_search_settings_1: |-
+  PrefixSearchSetting prefixSearchSettings = index.getPrefixSearchSettings();
+update_prefix_search_setting_1: |-
+  PrefixSearchSetting newSetting = PrefixSearchSetting.DISABLED;
+  index.updatePrefixSearchSettings(newSetting);
+reset_prefix_search_setting_1: |-
+  index.resetPrefixSearchSettings();

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk;
 
+import com.meilisearch.sdk.enums.PrefixSearchSetting;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.*;
@@ -1447,5 +1448,71 @@ public class Index implements Serializable {
                 new URLBuilder("/indexes").addSubroute(this.uid).addSubroute("/compact").getURL(),
                 null,
                 TaskInfo.class);
+    }
+
+    /**
+     * Returns the current value of the facetSearch setting for the index.
+     *
+     * @return Returns the current value of the facetSearch setting.
+     * @throws MeilisearchException If the Authorization header is missing or index not found
+     */
+    public Boolean getFacetSearchSettings() throws MeilisearchException {
+        return this.settingsHandler.getFacetSearch(this.uid);
+    }
+
+    /**
+     * Updates the facetSearch setting for the index. Send the new value in the request body; send
+     * null to reset to default.
+     *
+     * @param isEnabled New value for the setting
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    public TaskInfo updateFacetSearchSettings(Boolean isEnabled) throws MeilisearchException {
+        return this.settingsHandler.updateFacetSearch(this.uid, isEnabled);
+    }
+
+    /**
+     * Resets the facetSearch setting to its default value.
+     *
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    public TaskInfo resetFacetSearchSettings() throws MeilisearchException {
+        return this.settingsHandler.resetFacetSearch(this.uid);
+    }
+
+    /**
+     * Returns the current value of the prefixSearch setting for the index.
+     *
+     * @return The current value of the prefixSearch setting.
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    public PrefixSearchSetting getPrefixSearchSettings() throws MeilisearchException {
+        return this.settingsHandler.getPrefixSearch(this.uid);
+    }
+
+    /**
+     * Updates the prefixSearch setting for the index. Send the new value in the request body; send
+     * null to reset to default.
+     *
+     * @param updatedPrefixSetting The body is of type enum. Available options: indexingTime,
+     *     disabled
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    public TaskInfo updatePrefixSearchSettings(PrefixSearchSetting updatedPrefixSetting)
+            throws MeilisearchException {
+        return this.settingsHandler.updatePrefixSearch(this.uid, updatedPrefixSetting);
+    }
+
+    /**
+     * Resets the prefixSearch setting to its default value.
+     *
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    public TaskInfo resetPrefixSearchSettings() throws MeilisearchException {
+        return this.settingsHandler.resetPrefixSearch(this.uid);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk;
 
+import com.meilisearch.sdk.enums.PrefixSearchSetting;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.Embedder;
@@ -852,5 +853,77 @@ public class SettingsHandler {
     TaskInfo resetEmbedders(String uid) throws MeilisearchException {
         return httpClient.delete(
                 settingsPath(uid).addSubroute("embedders").getURL(), TaskInfo.class);
+    }
+
+    /**
+     * Returns the current value of the facetSearch setting for the index.
+     *
+     * @return Returns the current value of the facetSearch setting.
+     * @throws MeilisearchException If the Authorization header is missing or index not found
+     */
+    Boolean getFacetSearch(String uid) throws MeilisearchException {
+        return httpClient.get(
+                settingsPath(uid).addSubroute("facet-search").getURL(), Boolean.class);
+    }
+
+    /**
+     * Updates the facetSearch setting for the index. Send the new value in the request body; send
+     * null to reset to default.
+     *
+     * @param isEnabled New value for the setting
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    TaskInfo updateFacetSearch(String uid, Boolean isEnabled) throws MeilisearchException {
+        return httpClient.put(
+                settingsPath(uid).addSubroute("facet-search").getURL(), isEnabled, TaskInfo.class);
+    }
+
+    /**
+     * Resets the facetSearch setting to its default value.
+     *
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    TaskInfo resetFacetSearch(String uid) throws MeilisearchException {
+        return httpClient.delete(
+                settingsPath(uid).addSubroute("facet-search").getURL(), TaskInfo.class);
+    }
+
+    /**
+     * Returns the current value of the prefixSearch setting for the index.
+     *
+     * @return The current value of the prefixSearch setting.
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    PrefixSearchSetting getPrefixSearch(String uid) throws MeilisearchException {
+        return httpClient.get(
+                settingsPath(uid).addSubroute("prefix-search").getURL(), PrefixSearchSetting.class);
+    }
+
+    /**
+     * Updates the prefixSearch setting for the index. Send the new value in the request body; send
+     * null to reset to default.
+     *
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    TaskInfo updatePrefixSearch(String uid, PrefixSearchSetting prefixSearchSetting)
+            throws MeilisearchException {
+        return httpClient.put(
+                settingsPath(uid).addSubroute("prefix-search").getURL(),
+                prefixSearchSetting,
+                TaskInfo.class);
+    }
+
+    /**
+     * Resets the prefixSearch setting to its default value.
+     *
+     * @return A summarized view of a task, returned when a task is enqueued
+     * @throws MeilisearchException If the Authorization header is missing or index not found.
+     */
+    TaskInfo resetPrefixSearch(String uid) throws MeilisearchException {
+        return httpClient.delete(
+                settingsPath(uid).addSubroute("prefix-search").getURL(), TaskInfo.class);
     }
 }

--- a/src/main/java/com/meilisearch/sdk/enums/PrefixSearchSetting.java
+++ b/src/main/java/com/meilisearch/sdk/enums/PrefixSearchSetting.java
@@ -1,0 +1,10 @@
+package com.meilisearch.sdk.enums;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum PrefixSearchSetting {
+    @SerializedName("indexingTime")
+    INDEXING_TIME,
+    @SerializedName("disabled")
+    DISABLED
+}

--- a/src/main/java/com/meilisearch/sdk/model/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/model/Settings.java
@@ -1,5 +1,6 @@
 package com.meilisearch.sdk.model;
 
+import com.meilisearch.sdk.enums.PrefixSearchSetting;
 import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -38,6 +39,8 @@ public class Settings {
     protected String[] nonSeparatorTokens;
     protected HashMap<String, Embedder> embedders;
     protected LocalizedAttribute[] localizedAttributes;
+    protected Boolean facetSearch;
+    protected PrefixSearchSetting prefixSearch;
 
     public Settings() {}
 

--- a/src/test/java/com/meilisearch/integration/SettingsTest.java
+++ b/src/test/java/com/meilisearch/integration/SettingsTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.enums.PrefixSearchSetting;
 import com.meilisearch.sdk.exceptions.GranularFilterableAttributesException;
 import com.meilisearch.sdk.model.Embedder;
 import com.meilisearch.sdk.model.EmbedderDistribution;
@@ -1638,5 +1639,88 @@ public class SettingsTest extends AbstractIT {
         index.waitForTask(resetTask.getTaskUid());
         Map<String, Embedder> resetEmbedders = index.getEmbeddersSettings();
         assertThat(resetEmbedders.size(), is(equalTo(0)));
+    }
+
+    @Test
+    @DisplayName("Test get prefix search settings")
+    public void testGetPrefixSearch() throws Exception {
+        Index index = createEmptyIndex("testGetPrefixSearchSettings");
+        Settings initialSettings = index.getSettings();
+
+        PrefixSearchSetting searchSetting = index.getPrefixSearchSettings();
+
+        assertThat(searchSetting, is(instanceOf(PrefixSearchSetting.class)));
+        assertThat(searchSetting, is(equalTo(initialSettings.getPrefixSearch())));
+    }
+
+    @Test
+    @DisplayName("Test update prefix search settings")
+    public void testUpdatePrefixSearch() throws Exception {
+        Index index = createEmptyIndex("testUpdatePrefixSearchSettings");
+
+        PrefixSearchSetting newSetting = PrefixSearchSetting.DISABLED;
+        var task = index.updatePrefixSearchSettings(newSetting);
+        index.waitForTask(task.getTaskUid());
+        Settings initialSettings = index.getSettings();
+
+        assertThat(newSetting, is(equalTo(initialSettings.getPrefixSearch())));
+
+        PrefixSearchSetting newSetting1 = PrefixSearchSetting.INDEXING_TIME;
+        var task1 = index.updatePrefixSearchSettings(newSetting1);
+        index.waitForTask(task1.getTaskUid());
+        Settings initialSettings1 = index.getSettings();
+
+        assertThat(newSetting1, is(equalTo(initialSettings1.getPrefixSearch())));
+    }
+
+    @Test
+    @DisplayName("Test delete prefix search settings")
+    public void testResetPrefixSearch() throws Exception {
+        Index index = createEmptyIndex("testDeletePrefixSearchSettings");
+        PrefixSearchSetting newSetting = PrefixSearchSetting.DISABLED;
+
+        TaskInfo task = index.updatePrefixSearchSettings(newSetting);
+        index.waitForTask(task.getTaskUid());
+
+        TaskInfo task1 = index.resetPrefixSearchSettings();
+        index.waitForTask(task1.getTaskUid());
+        Settings settings = index.getSettings();
+
+        assertThat(settings.getPrefixSearch(), is(equalTo(PrefixSearchSetting.INDEXING_TIME)));
+    }
+
+    @Test
+    @DisplayName("Test get facet search settings")
+    public void testGetFacetSearch() throws Exception {
+        Index index = createEmptyIndex("testGetFacetSearchSettings");
+        Settings initialSettings = index.getSettings();
+
+        Boolean facetSetting = index.getFacetSearchSettings();
+
+        assertThat(facetSetting, is(equalTo(initialSettings.getFacetSearch())));
+    }
+
+    @Test
+    @DisplayName("Test update facet search settings")
+    public void testUpdateFacetSearch() throws Exception {
+        Index index = createEmptyIndex("testUpdateFacetSearchSettings");
+
+        var task = index.updateFacetSearchSettings(false);
+        index.waitForTask(task.getTaskUid());
+        Settings newSetting = index.getSettings();
+
+        assertThat(false, is(equalTo(newSetting.getFacetSearch())));
+    }
+
+    @Test
+    @DisplayName("Test reset facet search settings")
+    public void testResetFacetSearch() throws Exception {
+        Index index = createEmptyIndex("testResetFacetSearchSettings");
+
+        TaskInfo task = index.resetFacetSearchSettings();
+        index.waitForTask(task.getTaskUid());
+        Settings settings = index.getSettings();
+
+        assertThat(true, is(equalTo(settings.getFacetSearch())));
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #797 

## What does this PR do?
- Add `facetSearch` and `prefixSearch` fields to the Settings class.
- Implement the dedicated sub-route methods in SettingsHandler and Index.
- Add the corresponding integration tests and update the code samples.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added facet search settings management: retrieve, update, and reset.
  * Added prefix search settings management with two modes (indexing time, disabled): retrieve, update, and reset.

* **Tests**
  * Added integration tests covering facet and prefix search settings.

* **Documentation**
  * Added code samples demonstrating facet and prefix search settings usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->