### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -634,7 +634,7 @@ webhooks_get_single_1: |-
   client.getWebhook();
 webhooks_post_1: |-
   HashMap<String, Object> headers = new HashMap<>();
-  headers.put("authorization", "MASTER_KEY");
+  headers.put("authorization", "MEILISEARCH_KEY");
   headers.put("referer", "http://example.com");
   CreateUpdateWebhookRequest webhookReq1 = new CreateUpdateWebhookRequest("http://webiste.com", headers);
 

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -449,7 +449,7 @@ add_movies_json_1: |-
 
   Path fileName = Path.of("movies.json");
   String moviesJson = Files.readString(fileName);
-  Client client = new Client(new Config("MEILISEARCH_URL", "masterKey"));
+  Client client = new Client(new Config("MEILISEARCH_URL", "MEILISEARCH_KEY"));
   Index index = client.index("movies");
   index.addDocuments(moviesJson);
 post_dump_1: |-
@@ -537,7 +537,7 @@ primary_field_guide_add_document_primary_key: |-
     + "}]"
   , "reference_number");
 authorization_header_1: |-
-  Client client = new Client(new Config("MEILISEARCH_URL", "masterKey"));
+  Client client = new Client(new Config("MEILISEARCH_URL", "MEILISEARCH_KEY"));
   client.getKeys();
 tenant_token_guide_generate_sdk_1: |-
   Map<String, Object> filters = new HashMap<String, Object>();

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -116,7 +116,7 @@ class TestMeilisearch {
 }
 ```
 
-With the `taskUid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task endpoint](https://www.meilisearch.com/docs/reference/api/tasks).
+With the `taskUid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task endpoint](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks).
 
 #### Basic Search <!-- omit in toc -->
 
@@ -139,7 +139,7 @@ SearchResult(hits=[{id=1.0, title=Carol, genres:[Romance, Drama]}], offset=0, li
 #### Custom Search <!-- omit in toc -->
 
 If you want a custom search, the easiest way is to create a `SearchRequest` object, and set the parameters that you need.<br>
-All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) section of the documentation.
+All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters) section of the documentation.
 
 ```java
 import com.meilisearch.sdk.SearchRequest;
@@ -188,7 +188,7 @@ index.updateFilterableAttributesSettings(new String[]
 
 You only need to perform this operation once.
 
-Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [task status](https://www.meilisearch.com/docs/reference/api/tasks).
+Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [task status](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks).
 
 Then, you can perform the search:
 
@@ -300,10 +300,10 @@ This SDK is compatible with the following JDK versions:
 
 The following sections in our main documentation website may interest you:
 
-- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents) or read more about [documents](https://www.meilisearch.com/docs/learn/core_concepts/documents).
-- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters).
-- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/core_concepts/indexes).
-- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/reference/api/settings#settings_parameters).
+- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get) or read more about [documents](https://www.meilisearch.com/docs/learn/getting_started/documents).
+- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search/search-with-post) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters).
+- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/getting_started/indexes).
+- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#settings_parameters).
 
 ## ⚙️ Contributing
 

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -43,7 +43,7 @@ public class Client {
      * @param uid Unique identifier for the index to create
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#create-an-index">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#create-an-index">API
      *     specification</a>
      */
     public TaskInfo createIndex(String uid) throws MeilisearchException {
@@ -57,7 +57,7 @@ public class Client {
      * @param primaryKey The primary key of the documents in that index
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#create-an-index">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#create-an-index">API
      *     specification</a>
      */
     public TaskInfo createIndex(String uid, String primaryKey) throws MeilisearchException {
@@ -69,7 +69,7 @@ public class Client {
      *
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#list-all-indexes">API
      *     specification</a>
      */
     public Results<Index> getIndexes() throws MeilisearchException {
@@ -86,7 +86,7 @@ public class Client {
      * @param params query parameters accepted by the get indexes route
      * @return Results containing a list of indexes from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#list-all-indexes">API
      *     specification</a>
      */
     public Results<Index> getIndexes(IndexesQuery params) throws MeilisearchException {
@@ -102,7 +102,7 @@ public class Client {
      *
      * @return List of indexes from the Meilisearch API as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#list-all-indexes">API
      *     specification</a>
      */
     public String getRawIndexes() throws MeilisearchException {
@@ -115,7 +115,7 @@ public class Client {
      * @param params query parameters accepted by the get indexes route
      * @return List of indexes from the Meilisearch API as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#list-all-indexes">API
      *     specification</a>
      */
     public String getRawIndexes(IndexesQuery params) throws MeilisearchException {
@@ -144,7 +144,7 @@ public class Client {
      * @param uid Unique identifier of the index to get
      * @return Meilisearch API response as Index instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#get-one-index">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#get-one-index">API
      *     specification</a>
      */
     public Index getIndex(String uid) throws MeilisearchException {
@@ -160,7 +160,7 @@ public class Client {
      * @param primaryKey Primary key of the documents in the index
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#update-an-index">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#update-an-index">API
      *     specification</a>
      */
     public TaskInfo updateIndex(String uid, String primaryKey) throws MeilisearchException {
@@ -182,7 +182,7 @@ public class Client {
      * @param uid Unique identifier of the index to delete
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#delete-one-index">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#delete-one-index">API
      *     specification</a>
      */
     public TaskInfo deleteIndex(String uid) throws MeilisearchException {
@@ -195,7 +195,7 @@ public class Client {
      * @param param accepted by the swap-indexes route
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#swap-indexes">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#swap-indexes">API
      *     specification</a>
      */
     public TaskInfo swapIndexes(SwapIndexesParams[] param) throws MeilisearchException {
@@ -207,7 +207,7 @@ public class Client {
      *
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/dump#create-a-dump">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/backups/create-dump#create-a-dump">API
      *     specification</a>
      */
     public TaskInfo createDump() throws MeilisearchException {
@@ -219,7 +219,7 @@ public class Client {
      *
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/snapshots">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/backups/create-snapshot">API specification</a>
      */
     public TaskInfo createSnapshot() throws MeilisearchException {
         return config.httpClient.post("/snapshots", "", TaskInfo.class);
@@ -231,7 +231,7 @@ public class Client {
      * @param request Export request parameters
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/export">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/export/export-to-a-remote-meilisearch">API specification</a>
      */
     public TaskInfo export(ExportRequest request) throws MeilisearchException {
         return config.httpClient.post("/export", request, TaskInfo.class);
@@ -243,7 +243,7 @@ public class Client {
      * @return String containing the status of the Meilisearch instance from Meilisearch API
      *     response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/health#health">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/health/get-health#health">API
      *     specification</a>
      */
     public String health() throws MeilisearchException {
@@ -255,7 +255,7 @@ public class Client {
      *
      * @return True if the Meilisearch instance is available or false if it is not
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/health#health">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/health/get-health#health">API
      *     specification</a>
      */
     public Boolean isHealthy() throws MeilisearchException {
@@ -267,7 +267,7 @@ public class Client {
      *
      * @return Stats instance from Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats#stats-object">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes#stats-object">API
      *     specification</a>
      */
     public Stats getStats() throws MeilisearchException {
@@ -279,7 +279,7 @@ public class Client {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/version#version">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/version/get-version#version">API
      *     specification</a>
      */
     public String getVersion() throws MeilisearchException {
@@ -292,7 +292,7 @@ public class Client {
      * @param uid Identifier of the requested Task
      * @return Meilisearch API response as Task Instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-one-task">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-one-task">API
      *     specification</a>
      */
     public Task getTask(int uid) throws MeilisearchException {
@@ -304,7 +304,7 @@ public class Client {
      *
      * @return TasksResults containing a list of tasks from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks">API
      *     specification</a>
      */
     public TasksResults getTasks() throws MeilisearchException {
@@ -317,7 +317,7 @@ public class Client {
      * @param param accept by the tasks route
      * @return TasksResults containing a list of tasks from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks">API
      *     specification</a>
      */
     public TasksResults getTasks(TasksQuery param) throws MeilisearchException {
@@ -330,7 +330,7 @@ public class Client {
      * @param param accept by the tasks route
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#cancel-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#cancel-tasks">API
      *     specification</a>
      */
     public TaskInfo cancelTasks(CancelTasksQuery param) throws MeilisearchException {
@@ -343,7 +343,7 @@ public class Client {
      * @param param accept by the tasks route
      * @return Meilisearch API response as TaskInfo
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#delete-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#delete-tasks">API
      *     specification</a>
      */
     public TaskInfo deleteTasks(DeleteTasksQuery param) throws MeilisearchException {
@@ -389,7 +389,7 @@ public class Client {
      * @param uid Identifier of the requested Key
      * @return Meilisearch API response as Key Instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#get-one-key">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-one-key">API
      *     specification</a>
      */
     public Key getKey(String uid) throws MeilisearchException {
@@ -401,7 +401,7 @@ public class Client {
      *
      * @return Results containing a list of Key from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#get-all-keys">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-all-keys">API
      *     specification</a>
      */
     public Results<Key> getKeys() throws MeilisearchException {
@@ -414,7 +414,7 @@ public class Client {
      * @param params query parameters accepted by the get keys route
      * @return Results containing a list of Key from the Meilisearch API
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#get-all-keys">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-all-keys">API
      *     specification</a>
      */
     public Results<Key> getKeys(KeysQuery params) throws MeilisearchException {
@@ -427,7 +427,7 @@ public class Client {
      * @param options Key containing the options of the key
      * @return Meilisearch API response as Key Instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#create-a-key">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#create-a-key">API
      *     specification</a>
      */
     public Key createKey(Key options) throws MeilisearchException {
@@ -441,7 +441,7 @@ public class Client {
      * @param options String containing the options to update
      * @return Meilisearch API response as Key Instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#update-a-key">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#update-a-key">API
      *     specification</a>
      */
     public Key updateKey(String key, KeyUpdate options) throws MeilisearchException {
@@ -453,7 +453,7 @@ public class Client {
      *
      * @param key String containing the key
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#delete-a-key">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#delete-a-key">API
      *     specification</a>
      */
     public void deleteKey(String key) throws MeilisearchException {
@@ -500,7 +500,7 @@ public class Client {
      * @return String containing the tenant token
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/learn/security/tenant_tokens#multitenancy-and-tenant-tokens">Meilisearch
+     *     href="https://www.meilisearch.com/docs/learn/security/generate_tenant_token_sdk#multitenancy-and-tenant-tokens">Meilisearch
      *     Tenant Tokens</a>
      */
     public String generateTenantToken(

--- a/src/main/java/com/meilisearch/sdk/Documents.java
+++ b/src/main/java/com/meilisearch/sdk/Documents.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Class covering the Meilisearch Document API
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/documents">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get">API specification</a>
  */
 class Documents {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/FacetSearch.java
+++ b/src/main/java/com/meilisearch/sdk/FacetSearch.java
@@ -7,7 +7,7 @@ import com.meilisearch.sdk.model.FacetSearchable;
 /**
  * Class used for performing facet searching on Meilisearch indexes
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/facet_search">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets">API specification</a>
  */
 public class FacetSearch {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -51,7 +51,7 @@ public class Index implements Serializable {
      * @param targetClass Class of the document returned
      * @return Object containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-one-document">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-one-document">API
      *     specification</a>
      */
     public <T> T getDocument(String identifier, Class<T> targetClass) throws MeilisearchException {
@@ -67,7 +67,7 @@ public class Index implements Serializable {
      * @param targetClass Class of documents returned
      * @return Object containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-one-document">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-one-document">API
      *     specification</a>
      */
     public <T> T getDocument(String identifier, DocumentQuery param, Class<T> targetClass)
@@ -81,7 +81,7 @@ public class Index implements Serializable {
      * @param identifier Identifier of the document to get
      * @return String containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-one-document">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-one-document">API
      *     specification</a>
      */
     public String getRawDocument(String identifier) throws MeilisearchException {
@@ -95,7 +95,7 @@ public class Index implements Serializable {
      * @param param accept by the documents route
      * @return String containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-one-document">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-one-document">API
      *     specification</a>
      */
     public String getRawDocument(String identifier, DocumentQuery param)
@@ -110,7 +110,7 @@ public class Index implements Serializable {
      * @param targetClass Class of documents returned
      * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-documents">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-documents">API
      *     specification</a>
      */
     public <T> Results<T> getDocuments(Class<T> targetClass) throws MeilisearchException {
@@ -125,7 +125,7 @@ public class Index implements Serializable {
      * @param targetClass Class of documents returned
      * @return Results containing a list of Object containing the requested document
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-documents">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-documents">API
      *     specification</a>
      */
     public <T> Results<T> getDocuments(DocumentsQuery param, Class<T> targetClass)
@@ -138,7 +138,7 @@ public class Index implements Serializable {
      *
      * @return String containing a list of documents
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-documents">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-documents">API
      *     specification</a>
      */
     public String getRawDocuments() throws MeilisearchException {
@@ -151,7 +151,7 @@ public class Index implements Serializable {
      * @param param accept by the documents route
      * @return String containing a list of documents
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#get-documents">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#get-documents">API
      *     specification</a>
      */
     public String getRawDocuments(DocumentsQuery param) throws MeilisearchException {
@@ -165,7 +165,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo addDocuments(String document) throws MeilisearchException {
@@ -180,7 +180,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo addDocuments(String document, String primaryKey) throws MeilisearchException {
@@ -196,7 +196,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo addDocuments(String document, String primaryKey, String csvDelimiter)
@@ -214,7 +214,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo addDocuments(
@@ -233,7 +233,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo[] addDocumentsInBatches(String document, Integer batchSize, String primaryKey)
@@ -264,7 +264,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo[] addDocumentsInBatches(String document) throws MeilisearchException {
@@ -278,7 +278,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo updateDocuments(String document) throws MeilisearchException {
@@ -293,7 +293,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo updateDocuments(String document, String primaryKey)
@@ -310,7 +310,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo updateDocuments(String document, String primaryKey, String csvDelimiter)
@@ -328,7 +328,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo updateDocuments(
@@ -347,7 +347,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo[] updateDocumentsInBatches(
@@ -378,7 +378,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#add-or-replace-documents">API
      *     specification</a>
      */
     public TaskInfo[] updateDocumentsInBatches(String document) throws MeilisearchException {
@@ -392,7 +392,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-one-document">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-one-document">API
      *     specification</a>
      */
     public TaskInfo deleteDocument(String identifier) throws MeilisearchException {
@@ -407,7 +407,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-one-document">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-one-document">API
      *     specification</a>
      */
     public TaskInfo deleteDocument(String identifier, String customMetadata)
@@ -422,7 +422,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-batch">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-documents-by-batch">API
      *     specification</a>
      * @see com.meilisearch.sdk.Index#deleteDocumentsByFilter(String) Delete documents using filter
      */
@@ -439,7 +439,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-batch">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-documents-by-batch">API
      *     specification</a>
      * @see com.meilisearch.sdk.Index#deleteDocumentsByFilter(String) Delete documents using filter
      */
@@ -456,7 +456,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-filter">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-documents-by-filter">API
      *     specification</a>
      * @since 1.2
      */
@@ -472,7 +472,7 @@ public class Index implements Serializable {
      * @return TaskInfo Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-documents-by-filter">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-documents-by-filter">API
      *     specification</a>
      * @since 1.2
      */
@@ -487,7 +487,7 @@ public class Index implements Serializable {
      * @return List of tasks Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-all-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-all-documents">API
      *     specification</a>
      */
     public TaskInfo deleteAllDocuments() throws MeilisearchException {
@@ -501,7 +501,7 @@ public class Index implements Serializable {
      * @return List of tasks Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/documents#delete-all-documents">API
+     *     href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#delete-all-documents">API
      *     specification</a>
      */
     public TaskInfo deleteAllDocuments(String customMetadata) throws MeilisearchException {
@@ -515,7 +515,7 @@ public class Index implements Serializable {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-post">API
+     *     href="https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-in-an-index-with-post">API
      *     specification</a>
      */
     public SearchResult search(String q) throws MeilisearchException {
@@ -529,7 +529,7 @@ public class Index implements Serializable {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/search#search-in-an-index-with-post">API
+     *     href="https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-in-an-index-with-post">API
      *     specification</a>
      */
     public Searchable search(SearchRequest searchRequest) throws MeilisearchException {
@@ -546,7 +546,7 @@ public class Index implements Serializable {
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/facet_search#perform-a-facet-search">API
+     *     href="https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets#perform-a-facet-search">API
      *     specification</a>
      * @see Index#getFilterableAttributesSettings() getFilterableAttributesSettings
      * @see Index#updateGranularFilterableAttributesSettings(FilterableAttributesConfig[])
@@ -576,7 +576,7 @@ public class Index implements Serializable {
      *
      * @return settings of a given uid as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-settings">API
      *     specification</a>
      */
     public Settings getSettings() throws MeilisearchException {
@@ -589,7 +589,7 @@ public class Index implements Serializable {
      * @param settings the object that contains the data with the new settings
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-settings">API
      *     specification</a>
      */
     public TaskInfo updateSettings(Settings settings) throws MeilisearchException {
@@ -601,7 +601,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-settings">API
      *     specification</a>
      */
     public TaskInfo resetSettings() throws MeilisearchException {
@@ -613,7 +613,7 @@ public class Index implements Serializable {
      *
      * @return ranking rules of a given uid as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-settings">API
      *     specification</a>
      */
     public String[] getRankingRulesSettings() throws MeilisearchException {
@@ -626,7 +626,7 @@ public class Index implements Serializable {
      * @param rankingRules array that contain the data with the new ranking rules
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-settings">API
      *     specification</a>
      */
     public TaskInfo updateRankingRulesSettings(String[] rankingRules) throws MeilisearchException {
@@ -638,7 +638,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-settings">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-settings">API
      *     specification</a>
      */
     public TaskInfo resetRankingRulesSettings() throws MeilisearchException {
@@ -650,7 +650,7 @@ public class Index implements Serializable {
      *
      * @return synonyms of a given uid as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-synonyms">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-synonyms">API
      *     specification</a>
      */
     public Map<String, String[]> getSynonymsSettings() throws MeilisearchException {
@@ -663,7 +663,7 @@ public class Index implements Serializable {
      * @param synonyms key (String) value (array) pair of synonyms
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-synonyms">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-synonyms">API
      *     specification</a>
      */
     public TaskInfo updateSynonymsSettings(Map<String, String[]> synonyms)
@@ -676,7 +676,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-synonyms">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-synonyms">API
      *     specification</a>
      */
     public TaskInfo resetSynonymsSettings() throws MeilisearchException {
@@ -688,7 +688,7 @@ public class Index implements Serializable {
      *
      * @return stop-words of a given uid as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-stop-words">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-stop-words">API
      *     specification</a>
      */
     public String[] getStopWordsSettings() throws MeilisearchException {
@@ -701,7 +701,7 @@ public class Index implements Serializable {
      * @param stopWords An array of strings that contains the stop-words.
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-stop-words">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-stop-words">API
      *     specification</a>
      */
     public TaskInfo updateStopWordsSettings(String[] stopWords) throws MeilisearchException {
@@ -713,7 +713,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-stop-words">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-stop-words">API
      *     specification</a>
      */
     public TaskInfo resetStopWordsSettings() throws MeilisearchException {
@@ -726,7 +726,7 @@ public class Index implements Serializable {
      * @return searchable attributes of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-searchable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-searchable-attributes">API
      *     specification</a>
      */
     public String[] getSearchableAttributesSettings() throws MeilisearchException {
@@ -740,7 +740,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-searchable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-searchable-attributes">API
      *     specification</a>
      */
     public TaskInfo updateSearchableAttributesSettings(String[] searchableAttributes)
@@ -755,7 +755,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-searchable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-searchable-attributes">API
      *     specification</a>
      */
     public TaskInfo resetSearchableAttributesSettings() throws MeilisearchException {
@@ -768,7 +768,7 @@ public class Index implements Serializable {
      * @return display attributes of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-displayed-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-displayed-attributes">API
      *     specification</a>
      */
     public String[] getDisplayedAttributesSettings() throws MeilisearchException {
@@ -782,7 +782,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-displayed-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-displayed-attributes">API
      *     specification</a>
      */
     public TaskInfo updateDisplayedAttributesSettings(String[] displayAttributes)
@@ -796,7 +796,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-displayed-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-displayed-attributes">API
      *     specification</a>
      */
     public TaskInfo resetDisplayedAttributesSettings() throws MeilisearchException {
@@ -809,7 +809,7 @@ public class Index implements Serializable {
      * @return localized attributes of a given uid as LocalizedAttribute
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-localized-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-localized-attributes">API
      *     specification</a>
      */
     public LocalizedAttribute[] getLocalizedAttributesSettings() throws MeilisearchException {
@@ -824,7 +824,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-localized-attribute-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-localized-attribute-settings">API
      *     specification</a>
      */
     public TaskInfo updateLocalizedAttributesSettings(LocalizedAttribute[] localizedAttributes)
@@ -849,7 +849,7 @@ public class Index implements Serializable {
      * @return filterable attributes of a given uid as String
      * @throws MeilisearchException if an error occurs or granular configs cannot be reduced
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-filterable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-filterable-attributes">API
      *     specification</a>
      */
     public String[] getFilterableAttributesSettings() throws MeilisearchException {
@@ -865,7 +865,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-filterable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-filterable-attributes">API
      *     specification</a>
      */
     public TaskInfo updateFilterableAttributesSettings(String[] filterableAttributes)
@@ -880,7 +880,7 @@ public class Index implements Serializable {
      * @return filterable attributes of a given uid as FilterableAttributesConfig[]
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-filterable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-filterable-attributes">API
      *     specification</a>
      */
     public FilterableAttributesConfig[] getGranularFilterableAttributesSettings()
@@ -897,7 +897,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-filterable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-filterable-attributes">API
      *     specification</a>
      */
     public TaskInfo updateGranularFilterableAttributesSettings(
@@ -912,7 +912,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-filterable-attributes">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-filterable-attributes">API
      *     specification</a>
      */
     public TaskInfo resetFilterableAttributesSettings() throws MeilisearchException {
@@ -938,7 +938,7 @@ public class Index implements Serializable {
      * @return distinct attribute field of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-distinct-attribute">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-distinct-attribute">API
      *     specification</a>
      */
     public String getDistinctAttributeSettings() throws MeilisearchException {
@@ -952,7 +952,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-distinct-attribute">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-distinct-attribute">API
      *     specification</a>
      */
     public TaskInfo updateDistinctAttributeSettings(String distinctAttribute)
@@ -966,7 +966,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-distinct-attribute">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-distinct-attribute">API
      *     specification</a>
      */
     public TaskInfo resetDistinctAttributeSettings() throws MeilisearchException {
@@ -978,7 +978,7 @@ public class Index implements Serializable {
      *
      * @return TypoTolerance instance from Index
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-typo-tolerance">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-typo-tolerance">API
      *     specification</a>
      */
     public TypoTolerance getTypoToleranceSettings() throws MeilisearchException {
@@ -992,7 +992,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-typo-tolerance">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-typo-tolerance">API
      *     specification</a>
      */
     public TaskInfo updateTypoToleranceSettings(TypoTolerance typoTolerance)
@@ -1006,7 +1006,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-typo-tolerance">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-typo-tolerance">API
      *     specification</a>
      */
     public TaskInfo resetTypoToleranceSettings() throws MeilisearchException {
@@ -1019,7 +1019,7 @@ public class Index implements Serializable {
      * @return Pagination instance from Index
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-pagination-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-pagination-settings">API
      *     specification</a>
      */
     public Pagination getPaginationSettings() throws MeilisearchException {
@@ -1033,7 +1033,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-pagination-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-pagination-settings">API
      *     specification</a>
      */
     public TaskInfo updatePaginationSettings(Pagination pagination) throws MeilisearchException {
@@ -1046,7 +1046,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-pagination-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-pagination-settings">API
      *     specification</a>
      */
     public TaskInfo resetPaginationSettings() throws MeilisearchException {
@@ -1059,7 +1059,7 @@ public class Index implements Serializable {
      * @return Faceting instance from Index
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-faceting-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-faceting-settings">API
      *     specification</a>
      */
     public Faceting getFacetingSettings() throws MeilisearchException {
@@ -1073,7 +1073,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/en/reference/api/settings#update-faceting-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-faceting-settings">API
      *     specification</a>
      */
     public TaskInfo updateFacetingSettings(Faceting faceting) throws MeilisearchException {
@@ -1086,7 +1086,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-faceting-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-faceting-settings">API
      *     specification</a>
      */
     public TaskInfo resetFacetingSettings() throws MeilisearchException {
@@ -1098,7 +1098,7 @@ public class Index implements Serializable {
      *
      * @return dictionary of a given uid as String
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-dictionary">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-dictionary">API
      *     specification</a>
      */
     public String[] getDictionarySettings() throws MeilisearchException {
@@ -1111,7 +1111,7 @@ public class Index implements Serializable {
      * @param dictionary An array of strings that contains the dictionary.
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-dictionary">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-dictionary">API
      *     specification</a>
      */
     public TaskInfo updateDictionarySettings(String[] dictionary) throws MeilisearchException {
@@ -1123,7 +1123,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-dictionary">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-dictionary">API
      *     specification</a>
      */
     public TaskInfo resetDictionarySettings() throws MeilisearchException {
@@ -1136,7 +1136,7 @@ public class Index implements Serializable {
      * @return separator tokens of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-separator-tokens">API
      *     specification</a>
      */
     public String[] getSeparatorTokensSettings() throws MeilisearchException {
@@ -1150,7 +1150,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-separator-tokens">API
      *     specification</a>
      */
     public TaskInfo updateSeparatorTokensSettings(String[] separatorTokens)
@@ -1164,7 +1164,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-separator-tokens">API
      *     specification</a>
      */
     public TaskInfo resetSeparatorTokensSettings() throws MeilisearchException {
@@ -1177,7 +1177,7 @@ public class Index implements Serializable {
      * @return non-separator tokens of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-non-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-non-separator-tokens">API
      *     specification</a>
      */
     public String[] getNonSeparatorTokensSettings() throws MeilisearchException {
@@ -1191,7 +1191,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-non-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-non-separator-tokens">API
      *     specification</a>
      */
     public TaskInfo updateNonSeparatorTokensSettings(String[] separatorTokens)
@@ -1205,7 +1205,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-non-separator-tokens">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-non-separator-tokens">API
      *     specification</a>
      */
     public TaskInfo resetNonSeparatorTokensSettings() throws MeilisearchException {
@@ -1218,7 +1218,7 @@ public class Index implements Serializable {
      * @return proximity precision level of a given uid as String
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#get-proximity-precision-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-proximity-precision-settings">API
      *     specification</a>
      */
     public String getProximityPrecisionSettings() throws MeilisearchException {
@@ -1232,7 +1232,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-proximity-precision-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-proximity-precision-settings">API
      *     specification</a>
      */
     public TaskInfo updateProximityPrecisionSettings(String proximityPrecision)
@@ -1246,7 +1246,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-proximity-precision-settings">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-proximity-precision-settings">API
      *     specification</a>
      */
     public TaskInfo resetProximityPrecisionSettings() throws MeilisearchException {
@@ -1258,7 +1258,7 @@ public class Index implements Serializable {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats#get-stats">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes#get-stats">API
      *     specification</a>
      */
     public IndexStats getStats() throws MeilisearchException {
@@ -1271,7 +1271,7 @@ public class Index implements Serializable {
      * @param taskId Identifier of the requested index task
      * @return Task instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-one-task">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-one-task">API
      *     specification</a>
      */
     public Task getTask(int taskId) throws MeilisearchException {
@@ -1283,7 +1283,7 @@ public class Index implements Serializable {
      *
      * @return List of tasks in the Meilisearch index
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks">API
      *     specification</a>
      */
     public TasksResults getTasks() throws MeilisearchException {
@@ -1296,7 +1296,7 @@ public class Index implements Serializable {
      * @param param accept by the tasks route
      * @return List of tasks in the Meilisearch index
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-tasks">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks">API
      *     specification</a>
      */
     public TasksResults getTasks(TasksQuery param) throws MeilisearchException {
@@ -1308,7 +1308,7 @@ public class Index implements Serializable {
      *
      * @param taskId Identifier of the requested Task
      * @throws MeilisearchException if an error occurs or if timeout is reached
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#task-status">API
      *     specification</a>
      */
     public void waitForTask(int taskId) throws MeilisearchException {
@@ -1322,7 +1322,7 @@ public class Index implements Serializable {
      * @param timeoutInMs number of milliseconds before throwing an Exception
      * @param intervalInMs number of milliseconds before requesting the status again
      * @throws MeilisearchException if an error occurs or if timeout is reached
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#task-status">API
      *     specification</a>
      */
     public void waitForTask(int taskId, int timeoutInMs, int intervalInMs)
@@ -1347,7 +1347,7 @@ public class Index implements Serializable {
      *
      * @return Integer search cutoff value in milliseconds
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-search-cutoff">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-search-cutoff">API
      *     specification</a>
      */
     public Integer getSearchCutoffMsSettings() throws MeilisearchException {
@@ -1361,7 +1361,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#update-search-cutoff">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-search-cutoff">API
      *     specification</a>
      */
     public TaskInfo updateSearchCutoffMsSettings(Integer milliseconds) throws MeilisearchException {
@@ -1374,7 +1374,7 @@ public class Index implements Serializable {
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
      * @see <a
-     *     href="https://www.meilisearch.com/docs/reference/api/settings#reset-search-cutoff">API
+     *     href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-search-cutoff">API
      *     specification</a>
      */
     public TaskInfo resetSearchCutoffMsSettings() throws MeilisearchException {
@@ -1387,7 +1387,7 @@ public class Index implements Serializable {
      * @param query SimilarDocumentRequest containing parameters for the similar documents search
      * @return SimilarDocumentsResults containing the search results
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/similar">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/similar-documents/get-similar-documents-with-post">API specification</a>
      */
     public SimilarDocumentsResults searchSimilarDocuments(SimilarDocumentRequest query)
             throws MeilisearchException {
@@ -1402,7 +1402,7 @@ public class Index implements Serializable {
      *
      * @return a Map that contains all embedders settings
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#get-embedders">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#get-embedders">API
      *     specification</a>
      */
     public Map<String, Embedder> getEmbeddersSettings() throws MeilisearchException {
@@ -1415,7 +1415,7 @@ public class Index implements Serializable {
      * @param embedders a Map that contains the new embedders settings
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#update-embedders">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#update-embedders">API
      *     specification</a>
      */
     public TaskInfo updateEmbeddersSettings(Map<String, Embedder> embedders)
@@ -1428,7 +1428,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#reset-embedders">API
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#reset-embedders">API
      *     specification</a>
      */
     public TaskInfo resetEmbeddersSettings() throws MeilisearchException {
@@ -1440,7 +1440,7 @@ public class Index implements Serializable {
      *
      * @return TaskInfo instance
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/compact">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/compact-index">API specification</a>
      */
     public TaskInfo compact() throws MeilisearchException {
         return this.config.httpClient.post(

--- a/src/main/java/com/meilisearch/sdk/IndexesHandler.java
+++ b/src/main/java/com/meilisearch/sdk/IndexesHandler.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 /**
  * Class covering the Meilisearch Index API.
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes">API specification</a>
  */
 public class IndexesHandler {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/InstanceHandler.java
@@ -22,7 +22,7 @@ public class InstanceHandler {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/health">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/health/get-health">API specification</a>
      */
     String health() throws MeilisearchException {
         return httpClient.get("/health", String.class);
@@ -33,7 +33,7 @@ public class InstanceHandler {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/health">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/health/get-health">API specification</a>
      */
     boolean isHealthy() throws MeilisearchException {
         try {
@@ -49,7 +49,7 @@ public class InstanceHandler {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes">API specification</a>
      */
     Stats getStats() throws MeilisearchException {
         return httpClient.get("/stats", Stats.class);
@@ -61,7 +61,7 @@ public class InstanceHandler {
      * @param uid Index identifier to the requested
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes">API specification</a>
      */
     IndexStats getIndexStats(String uid) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/stats";
@@ -73,7 +73,7 @@ public class InstanceHandler {
      *
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
-     * @see <a href="https://www.meilisearch.com/docs/reference/api/version">API specification</a>
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/version/get-version">API specification</a>
      */
     String getVersion() throws MeilisearchException {
         return httpClient.get("/version", String.class);

--- a/src/main/java/com/meilisearch/sdk/KeysHandler.java
+++ b/src/main/java/com/meilisearch/sdk/KeysHandler.java
@@ -10,7 +10,7 @@ import com.meilisearch.sdk.model.Results;
 /**
  * Class covering the Meilisearch Key API
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/keys">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys">API specification</a>
  */
 public class KeysHandler {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/Search.java
+++ b/src/main/java/com/meilisearch/sdk/Search.java
@@ -8,7 +8,7 @@ import com.meilisearch.sdk.model.Searchable;
 /**
  * Class used for searching on Meilisearch indexes
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/search">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/search/search-with-post">API specification</a>
  */
 public class Search {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/SettingsHandler.java
+++ b/src/main/java/com/meilisearch/sdk/SettingsHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Class covering the Meilisearch Settings API
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/settings">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings">API specification</a>
  * @see Settings
  */
 public class SettingsHandler {

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -11,7 +11,7 @@ import java.util.Date;
 /**
  * Class covering the Meilisearch Task API
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks">API specification</a>
  */
 public class TasksHandler {
     private final HttpClient httpClient;

--- a/src/main/java/com/meilisearch/sdk/enums/OperationType.java
+++ b/src/main/java/com/meilisearch/sdk/enums/OperationType.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Enum for Operation Type
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#type">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#type">API specification</a>
  */
 public enum OperationType {
     @SerializedName("indexCreation")

--- a/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/CancelTasksQuery.java
@@ -9,7 +9,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of a query parameter for tasks route
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#query-parameters-1">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters-1">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/CreateUpdateWebhookRequest.java
+++ b/src/main/java/com/meilisearch/sdk/model/CreateUpdateWebhookRequest.java
@@ -7,7 +7,7 @@ import lombok.NonNull;
 /**
  * Data structure used in request body while creating or updating a webhook.
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/webhooks">API Specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/webhooks/list-webhooks">API Specification</a>
  */
 public class CreateUpdateWebhookRequest implements Serializable {
     final String url;

--- a/src/main/java/com/meilisearch/sdk/model/CursorResults.java
+++ b/src/main/java/com/meilisearch/sdk/model/CursorResults.java
@@ -6,7 +6,7 @@ import lombok.Data;
 /**
  * Data structure paginated response Currently used in : Batches.
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/batches#response">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#response">API
  *     specification</a>
  */
 @Data

--- a/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DeleteTasksQuery.java
@@ -9,7 +9,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of a query parameter for tasks route
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#query-parameters-2">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters-2">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/DocumentQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentQuery.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 /**
  * Data structure of the query parameters of the documents route when retrieving a document
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#query-parameters-1">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#query-parameters-1">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/DocumentsQuery.java
@@ -10,7 +10,7 @@ import org.json.JSONObject;
  * Data structure of the query parameters or request body params of the documents route when
  * retrieving multiple documents
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/documents#query-parameters">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get#query-parameters">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/FacetSearchResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/FacetSearchResult.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Meilisearch facet search response data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/facet_search#response">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets#response">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/FacetSearchable.java
+++ b/src/main/java/com/meilisearch/sdk/model/FacetSearchable.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 /**
  * Meilisearch facet search response data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/facet_search">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/facet-search/search-in-facets">API specification</a>
  */
 public interface FacetSearchable {
     ArrayList<HashMap<String, Object>> getFacetHits();

--- a/src/main/java/com/meilisearch/sdk/model/FacetSortValue.java
+++ b/src/main/java/com/meilisearch/sdk/model/FacetSortValue.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Enum for Sorting Facet Values
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#faceting-object">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#faceting-object">API
  *     specification</a>
  */
 public enum FacetSortValue {

--- a/src/main/java/com/meilisearch/sdk/model/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStats.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 /**
  * Stats data structure of a Meilisearch Index
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/stats#get-stats-of-an-index">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes#get-stats-of-an-index">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexesQuery.java
@@ -8,7 +8,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of the query parameters when fetching indexes
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes#query-parameters">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes#query-parameters">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/Key.java
+++ b/src/main/java/com/meilisearch/sdk/model/Key.java
@@ -10,7 +10,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of Meilisearch response for a Key
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/keys">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys">API specification</a>
  */
 @Getter
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/KeyUpdate.java
+++ b/src/main/java/com/meilisearch/sdk/model/KeyUpdate.java
@@ -7,7 +7,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure for updating a Key
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/keys">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys">API specification</a>
  */
 @Getter
 public class KeyUpdate {

--- a/src/main/java/com/meilisearch/sdk/model/KeysQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/KeysQuery.java
@@ -8,7 +8,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of the query parameters for the keys routes
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/keys#query-parameters">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#query-parameters">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/LocalizedAttribute.java
+++ b/src/main/java/com/meilisearch/sdk/model/LocalizedAttribute.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 /**
  * LocalizedAttribute setting data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#localized-attributes">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#localized-attributes">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/MultiSearchResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/MultiSearchResult.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Multi search response
  *
- * <p>https://www.meilisearch.com/docs/reference/api/multi_search#response
+ * <p>https://www.meilisearch.com/docs/reference/api/multi-search/perform-a-multi-search#response
  */
 @Getter
 @ToString

--- a/src/main/java/com/meilisearch/sdk/model/SearchResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/SearchResult.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Meilisearch search response data structure for infinite pagination
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/search#response">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/search/search-with-post#response">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/SearchResultPaginated.java
+++ b/src/main/java/com/meilisearch/sdk/model/SearchResultPaginated.java
@@ -9,7 +9,7 @@ import lombok.ToString;
  * Meilisearch search response data structure for limited pagination
  *
  * @see <a
- *     href="https://www.meilisearch.com/docs/learn/front_end/pagination#numbered-page-selectors">
+ *     href="https://www.meilisearch.com/docs/guides/front_end/pagination#numbered-page-selectors">
  *     Numbered Page Selectors</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/Searchable.java
+++ b/src/main/java/com/meilisearch/sdk/model/Searchable.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 /**
  * Meilisearch search common response data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/search">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/search/search-with-post">API specification</a>
  */
 public interface Searchable {
     ArrayList<HashMap<String, Object>> getHits();

--- a/src/main/java/com/meilisearch/sdk/model/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/model/Settings.java
@@ -9,7 +9,7 @@ import lombok.experimental.Accessors;
 /**
  * Meilisearch settings data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/settings">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings">API specification</a>
  */
 @Getter
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/SimilarDocumentsResults.java
+++ b/src/main/java/com/meilisearch/sdk/model/SimilarDocumentsResults.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 /**
  * Meilisearch similar documents results data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/similar#response-200-ok">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/similar-documents/get-similar-documents-with-post#response-200-ok">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/Stats.java
+++ b/src/main/java/com/meilisearch/sdk/model/Stats.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 /**
  * Meilisearch stats data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes">API specification</a>
  */
 @Getter
 public class Stats {

--- a/src/main/java/com/meilisearch/sdk/model/Task.java
+++ b/src/main/java/com/meilisearch/sdk/model/Task.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 /**
  * Data structure of Meilisearch response for a Task
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks">API specification</a>
  */
 @Getter
 public class Task {

--- a/src/main/java/com/meilisearch/sdk/model/TaskInfo.java
+++ b/src/main/java/com/meilisearch/sdk/model/TaskInfo.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 /**
  * Data structure of Meilisearch response for a asynchronous operation
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#summarized-task-object">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#summarized-task-object">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/TaskStatus.java
+++ b/src/main/java/com/meilisearch/sdk/model/TaskStatus.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Enum for Task Status
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#status">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#status">API specification</a>
  */
 public enum TaskStatus {
     @SerializedName("enqueued")

--- a/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/TasksQuery.java
@@ -9,7 +9,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of a query parameter for tasks route
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#query-parameters">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters">API
  *     specification</a>
  */
 @Setter

--- a/src/main/java/com/meilisearch/sdk/model/TasksResults.java
+++ b/src/main/java/com/meilisearch/sdk/model/TasksResults.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 /**
  * Data structure of Meilisearch response for tasks Results
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#response">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#response">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
+++ b/src/main/java/com/meilisearch/sdk/model/TypoTolerance.java
@@ -8,7 +8,7 @@ import lombok.experimental.Accessors;
 /**
  * Typo Tolerance setting data structure
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#typo-tolerance-object">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#typo-tolerance-object">API
  *     specification</a>
  */
 @Getter

--- a/src/main/java/com/meilisearch/sdk/model/Webhook.java
+++ b/src/main/java/com/meilisearch/sdk/model/Webhook.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 /**
  * Webhook data structure.
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/webhooks">API specification</a>
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/webhooks/list-webhooks">API specification</a>
  */
 public class Webhook implements Serializable {
     @Getter protected final UUID uuid;

--- a/src/main/java/com/meilisearch/sdk/model/batch/req/BatchesQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/batch/req/BatchesQuery.java
@@ -8,7 +8,7 @@ import lombok.experimental.Accessors;
 /**
  * Data structure of a query parameter for batches route
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/batches#query-parameters">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#query-parameters">API
  *     specification</a>
  */
 @Data

--- a/src/main/java/com/meilisearch/sdk/model/batch/res/Batch.java
+++ b/src/main/java/com/meilisearch/sdk/model/batch/res/Batch.java
@@ -6,7 +6,7 @@ import lombok.Data;
 /**
  * Data structure of the batch object response
  *
- * @see <a href="https://www.meilisearch.com/docs/reference/api/batches#batch-object">API
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#batch-object">API
  *     specification</a>
  */
 @Data

--- a/src/test/java/com/meilisearch/integration/WebhooksTest.java
+++ b/src/test/java/com/meilisearch/integration/WebhooksTest.java
@@ -41,7 +41,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testCreateWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MASTER_KEY");
+        headers.put("authorization", "MEILISEARCH_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -59,7 +59,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testGetWebhooks() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MASTER_KEY");
+        headers.put("authorization", "MEILISEARCH_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -90,7 +90,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testGetWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MASTER_KEY");
+        headers.put("authorization", "MEILISEARCH_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -110,7 +110,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testUpdateWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MASTER_KEY");
+        headers.put("authorization", "MEILISEARCH_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -134,7 +134,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testDeleteWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MASTER_KEY");
+        headers.put("authorization", "MEILISEARCH_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);

--- a/src/test/java/com/meilisearch/integration/WebhooksTest.java
+++ b/src/test/java/com/meilisearch/integration/WebhooksTest.java
@@ -41,7 +41,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testCreateWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MEILISEARCH_KEY");
+        headers.put("authorization", "MASTER_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -59,7 +59,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testGetWebhooks() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MEILISEARCH_KEY");
+        headers.put("authorization", "MASTER_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -90,7 +90,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testGetWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MEILISEARCH_KEY");
+        headers.put("authorization", "MASTER_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -110,7 +110,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testUpdateWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MEILISEARCH_KEY");
+        headers.put("authorization", "MASTER_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);
@@ -134,7 +134,7 @@ public class WebhooksTest extends AbstractIT {
     @Test
     public void testDeleteWebhook() throws Exception {
         HashMap<String, Object> headers = new HashMap<>();
-        headers.put("authorization", "MEILISEARCH_KEY");
+        headers.put("authorization", "MASTER_KEY");
         headers.put("referer", "http://example.com");
         CreateUpdateWebhookRequest webhookReq1 =
                 new CreateUpdateWebhookRequest("http://webiste.com", headers);


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs