### PR TITLE
Add support for `distinct` in federated search requests

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -9,6 +9,7 @@ public class MultiSearchFederation {
 
     private Integer limit;
     private Integer offset;
+    private String distinct;
     private MergeFacets mergeFacets;
     private Map<String, String[]> facetsByIndex;
 
@@ -19,6 +20,11 @@ public class MultiSearchFederation {
 
     public MultiSearchFederation setOffset(Integer offset) {
         this.offset = offset;
+        return this;
+    }
+
+    public MultiSearchFederation setDistinct(String distinct) {
+        this.distinct = distinct;
         return this;
     }
 
@@ -40,7 +46,10 @@ public class MultiSearchFederation {
     @Override
     public String toString() {
         JSONObject jsonObject =
-                new JSONObject().put("limit", this.limit).put("offset", this.offset);
+                new JSONObject()
+                        .put("limit", this.limit)
+                        .put("offset", this.offset)
+                        .put("distinct", this.distinct);
         return jsonObject.toString();
     }
 }

--- a/src/test/java/com/meilisearch/integration/SearchTest.java
+++ b/src/test/java/com/meilisearch/integration/SearchTest.java
@@ -853,6 +853,40 @@ public class SearchTest extends AbstractIT {
         }
     }
 
+    /*
+     * Test the federation parameter with distinct in multi search method
+     */
+    @Test
+    public void testFederationWithDistinct() throws Exception {
+        HashSet<String> indexUids = new HashSet<>();
+        indexUids.add("MultiSearch1");
+        indexUids.add("MultiSearch2");
+        for (String indexUid : indexUids) {
+            Index index = client.index(indexUid);
+
+            TestData<Movie> testData = this.getTestData(MOVIES_INDEX, Movie.class);
+            TaskInfo task = index.addDocuments(testData.getRaw());
+
+            index.waitForTask(task.getTaskUid());
+        }
+
+        MultiSearchRequest search = new MultiSearchRequest();
+        search.addQuery(new IndexSearchRequest("MultiSearch1").setQuery("batman"));
+        search.addQuery(new IndexSearchRequest("MultiSearch2").setQuery("batman"));
+
+        MultiSearchFederation federation = new MultiSearchFederation();
+        federation.setDistinct("title");
+        MultiSearchResult results = client.multiSearch(search, federation);
+
+        ArrayList<HashMap<String, Object>> hits = results.getHits();
+        // With distinct on "title", each title value appears at most once
+        HashSet<Object> titles = new HashSet<>();
+        for (HashMap<String, Object> hit : hits) {
+            titles.add(hit.get("title"));
+        }
+        assertThat(titles.size(), is(hits.size()));
+    }
+
     /** Test multisearch with ranking score threshold */
     @Test
     public void testMultiSearchWithRankingScoreThreshold() throws Exception {


### PR DESCRIPTION
## Summary
Adds `distinct` field to `MultiSearchFederation` for Meilisearch v1.40 federated search.

## Why this matters
Meilisearch v1.40 introduced `distinct` in federated search requests. The Java SDK was missing this field. Users couldn't deduplicate federated results by attribute.

## Changes
- Added `distinct` String field with setter to `MultiSearchFederation` in `src/main/java/com/meilisearch/sdk/MultiSearchFederation.java`
- Updated `toString()` to include `distinct` in JSON output
- Added `testFederationWithDistinct` integration test in `src/test/java/com/meilisearch/integration/SearchTest.java`

## Testing
- Test follows the existing `testFederation` pattern
- Sets `distinct` on the federation object and verifies unique values in results

Closes #949

**AI disclosure:** This contribution was developed with AI assistance (Codex CLI for initial implementation, Claude Code for review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct field support for multi-search federation. Users can now configure deduplication when performing federated searches across multiple indexes by specifying a field value for uniqueness. This feature eliminates duplicate results in combined searches, enabling more precise and controlled result sets when querying multiple data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->