### PR TITLE
Add getTaskDocuments method

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -70,6 +70,8 @@ get_all_tasks_1: |-
   client.getTasks();
 get_task_1: |-
   client.getTask(1);
+get_task_documents_1: |-
+  client.getTaskDocuments(1);
 delete_tasks_1: |-
   DeleteTasksQuery query = new DeleteTasksQuery().setUids(new int[] {1, 2})
   client.deleteTasks(query);

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -300,6 +300,18 @@ public class Client {
     }
 
     /**
+     * Retrieves the documents associated with the specified task
+     *
+     * @param uid Identifier of the requested Task
+     * @return Results containing the documents associated with the task
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#get-task-documents">API specification</a>
+     */
+    public Results getTaskDocuments(int uid) throws MeilisearchException {
+        return this.tasksHandler.getTaskDocuments(uid);
+    }
+
+    /**
      * Retrieves list of tasks
      *
      * @return TasksResults containing a list of tasks from the Meilisearch API

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -40,6 +40,20 @@ public class TasksHandler {
     }
 
     /**
+     * Retrieves the documents associated with the specified task
+     *
+     * @param taskUid Identifier of the requested Task
+     * @return Results containing the documents associated with the task
+     * @throws MeilisearchException if client request causes an error
+     */
+    Results getTaskDocuments(int taskUid) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("tasks").addSubroute(Integer.toString(taskUid)).addSubroute("documents");
+        String urlPath = urlb.getURL();
+        return httpClient.get(urlPath, Results.class);
+    }
+
+    /**
      * Retrieves all tasks from the client
      *
      * @return TasksResults containing a list of task instance


### PR DESCRIPTION
## Summary

Adds `getTaskDocuments` to the Java SDK. Meilisearch v1.13 introduced `GET /tasks/{taskUid}/documents` but the SDK had no way to call it.

## Changes

- `TasksHandler.java`: New `getTaskDocuments(int taskUid)` method. Uses the same URLBuilder pattern as `getTask` with an additional `/documents` subroute.
- `Client.java`: Exposes `getTaskDocuments(int uid)` delegating to the tasks handler.
- `.code-samples.meilisearch.yaml`: Adds `get_task_documents_1` code sample.

## Testing

Follows the same pattern as existing task methods. Integration tests require a running Meilisearch instance.

Fixes #948

This contribution was developed with AI assistance (Claude Code + Codex CLI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve documents associated with a specific task by task ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->