### PR TITLE
Add getTaskDocuments method (Meilisearch v1.13)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -70,6 +70,8 @@ get_all_tasks_1: |-
   client.getTasks();
 get_task_1: |-
   client.getTask(1);
+get_task_documents_1: |-
+  client.getTaskDocuments(1);
 delete_tasks_1: |-
   DeleteTasksQuery query = new DeleteTasksQuery().setUids(new int[] {1, 2})
   client.deleteTasks(query);

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -300,6 +300,20 @@ public class Client {
     }
 
     /**
+     * Retrieves the documents associated with a task
+     *
+     * @param uid Identifier of the requested task
+     * @return String containing the JSON response with task documents
+     * @throws MeilisearchException if an error occurs
+     * @see <a
+     *     href="https://www.meilisearch.com/docs/reference/api/async-task-management/get-tasks-documents">API
+     *     specification</a>
+     */
+    public String getTaskDocuments(int uid) throws MeilisearchException {
+        return this.tasksHandler.getTaskDocuments(uid);
+    }
+
+    /**
      * Retrieves list of tasks
      *
      * @return TasksResults containing a list of tasks from the Meilisearch API

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -40,6 +40,22 @@ public class TasksHandler {
     }
 
     /**
+     * Retrieves the documents associated with a task
+     *
+     * @param taskUid Identifier of the requested Task
+     * @return String containing the JSON response with task documents
+     * @throws MeilisearchException if client request causes an error
+     */
+    String getTaskDocuments(int taskUid) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder();
+        urlb.addSubroute("tasks")
+            .addSubroute(Integer.toString(taskUid))
+            .addSubroute("documents");
+        String urlPath = urlb.getURL();
+        return httpClient.get(urlPath, String.class);
+    }
+
+    /**
      * Retrieves all tasks from the client
      *
      * @return TasksResults containing a list of task instance


### PR DESCRIPTION
## Summary

Adds `getTaskDocuments` to retrieve documents associated with a task, corresponding to `GET /tasks/{taskUid}/documents` introduced in Meilisearch 1.13.

## Changes

- `src/main/java/com/meilisearch/sdk/TasksHandler.java`: Added `getTaskDocuments(int taskUid)` method using URLBuilder to construct `/tasks/{uid}/documents` path
- `src/main/java/com/meilisearch/sdk/Client.java`: Added public `getTaskDocuments(int uid)` wrapper with Javadoc and API reference link
- `.code-samples.meilisearch.yaml`: Added `get_task_documents_1` code sample

## Testing

Follows the same pattern as `getTask` - constructs URL with URLBuilder, calls `httpClient.get`. Returns raw JSON string for flexibility with document types.

Closes #948

This contribution was developed with AI assistance (Claude Code).