### PR TITLE
Add distinct option to MultiSearchFederation (Meilisearch v1.40)

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -9,6 +9,7 @@ public class MultiSearchFederation {
 
     private Integer limit;
     private Integer offset;
+    private String distinct;
     private MergeFacets mergeFacets;
     private Map<String, String[]> facetsByIndex;
 
@@ -19,6 +20,11 @@ public class MultiSearchFederation {
 
     public MultiSearchFederation setOffset(Integer offset) {
         this.offset = offset;
+        return this;
+    }
+
+    public MultiSearchFederation setDistinct(String distinct) {
+        this.distinct = distinct;
         return this;
     }
 
@@ -40,7 +46,10 @@ public class MultiSearchFederation {
     @Override
     public String toString() {
         JSONObject jsonObject =
-                new JSONObject().put("limit", this.limit).put("offset", this.offset);
+                new JSONObject()
+                        .put("limit", this.limit)
+                        .put("offset", this.offset)
+                        .put("distinct", this.distinct);
         return jsonObject.toString();
     }
 }


### PR DESCRIPTION
## Summary

Adds optional `distinct` field to `MultiSearchFederation` for deduplicating federated search results by a specified attribute. Introduced in Meilisearch v1.40.

## Changes

`src/main/java/com/meilisearch/sdk/MultiSearchFederation.java`: Added `distinct` String field with setter, getter (via Lombok `@Getter`), and JSON serialization.

## Testing

Follows the same pattern as existing `limit` and `offset` fields. The `@Getter` annotation auto-generates the accessor.

Closes #949

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `distinct` parameter in multi-search federation operations, enabling users to control result uniqueness when federating multiple search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->