### PR TITLE
fix: throw error if route segment is empty or null

### DIFF
--- a/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
+++ b/src/main/java/com/meilisearch/sdk/http/URLBuilder.java
@@ -21,6 +21,9 @@ public class URLBuilder {
     }
 
     public URLBuilder addSubroute(String route) {
+        if (route == null || route.isEmpty()) {
+            throw new IllegalArgumentException("route segment must not be null or empty");
+        }
         routes.append("/");
         routes.append(route);
         return this;

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -39,6 +39,11 @@ public class URLBuilderTest {
                 assertThrows(IllegalArgumentException.class, () -> classToTest.addSubroute(""))
                         .getMessage(),
                 is(equalTo("route segment must not be null or empty")));
+
+        assertThat(
+                assertThrows(IllegalArgumentException.class, () -> classToTest.addSubroute(null))
+                        .getMessage(),
+                is(equalTo("route segment must not be null or empty")));
     }
 
     @Test

--- a/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
+++ b/src/test/java/com/meilisearch/sdk/http/URLBuilderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -30,6 +31,14 @@ public class URLBuilderTest {
                 .addSubroute("route4");
 
         assertThat(classToTest.getRoutes().toString(), is(equalTo("/route1/route2/route3/route4")));
+    }
+
+    @Test
+    void addSubrouteWithNullOrEmptyRoute() {
+        assertThat(
+                assertThrows(IllegalArgumentException.class, () -> classToTest.addSubroute(""))
+                        .getMessage(),
+                is(equalTo("route segment must not be null or empty")));
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #961

## What does this PR do?
- check route segment before appending to url and throw error if null or empty



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of URL path segments to reject null or empty values; prevents creation of invalid paths and returns clearer error messages when segments are missing.

* **Tests**
  * Added unit test coverage for invalid input handling to ensure the new validation and error messaging remain enforced and stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->