### PR TITLE
feat: add personalized search (experimental)

### DIFF
--- a/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/IndexSearchRequest.java
@@ -2,6 +2,7 @@ package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.model.Hybrid;
 import com.meilisearch.sdk.model.MatchingStrategy;
+import com.meilisearch.sdk.model.Personalize;
 import lombok.*;
 import lombok.experimental.Accessors;
 import org.json.JSONObject;
@@ -41,6 +42,7 @@ public class IndexSearchRequest {
     protected String distinct;
     protected Hybrid hybrid;
     protected Boolean retrieveVectors;
+    protected Personalize personalize;
 
     /**
      * Constructor for MultiSearchRequest for building search queries with the default values:
@@ -111,7 +113,10 @@ public class IndexSearchRequest {
                         .putOpt("locales", this.locales)
                         .putOpt("distinct", this.distinct)
                         .putOpt("retrieveVectors", this.retrieveVectors)
-                        .putOpt("hybrid", this.hybrid != null ? this.hybrid.toJSONObject() : null);
+                        .putOpt("hybrid", this.hybrid != null ? this.hybrid.toJSONObject() : null)
+                        .putOpt(
+                                "personalize",
+                                this.personalize != null ? this.personalize.toJSONObject() : null);
 
         return jsonObject.toString();
     }

--- a/src/main/java/com/meilisearch/sdk/SearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/SearchRequest.java
@@ -2,6 +2,7 @@ package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.model.Hybrid;
 import com.meilisearch.sdk.model.MatchingStrategy;
+import com.meilisearch.sdk.model.Personalize;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +47,7 @@ public class SearchRequest {
     protected Hybrid hybrid;
     protected Double[] vector;
     protected Boolean retrieveVectors;
+    protected Personalize personalize;
     /**
      * Constructor for SearchRequest for building search queries with the default values: offset: 0,
      * limit: 20, attributesToRetrieve: ["*"], attributesToCrop: null, cropLength: 200,
@@ -114,6 +116,10 @@ public class SearchRequest {
 
         if (this.hybrid != null) {
             jsonObject.put("hybrid", this.hybrid.toJSONObject());
+        }
+
+        if (this.personalize != null) {
+            jsonObject.put("personalize", this.personalize.toJSONObject());
         }
 
         return jsonObject.toString();

--- a/src/main/java/com/meilisearch/sdk/model/Personalize.java
+++ b/src/main/java/com/meilisearch/sdk/model/Personalize.java
@@ -1,0 +1,43 @@
+package com.meilisearch.sdk.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.json.JSONObject;
+
+/** Personalization configuration for personalized search (experimental) */
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@Setter
+@Accessors(chain = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Personalize {
+    /** Natural-language description of the user's context used to personalize the search */
+    private String userContext;
+
+    /**
+     * Method that returns the JSON representation of the Personalize object
+     *
+     * @return JSONObject representation of the Personalize object
+     */
+    public JSONObject toJSONObject() {
+        return new JSONObject().putOpt("userContext", this.userContext);
+    }
+
+    /**
+     * Method that returns the JSON String of the Personalize object
+     *
+     * @return JSON String of the Personalize object
+     */
+    @Override
+    public String toString() {
+        return toJSONObject().toString();
+    }
+}

--- a/src/test/java/com/meilisearch/sdk/IndexSearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/IndexSearchRequestTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import com.meilisearch.sdk.model.Hybrid;
+import com.meilisearch.sdk.model.Personalize;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 class IndexSearchRequestTest {
@@ -53,5 +55,28 @@ class IndexSearchRequestTest {
 
         String expected = "{\"q\":\"This is a Test\",\"hybrid\":{\"embedder\":\"default\"}}";
         assertThat(classToTest.toString(), is(equalTo(expected)));
+    }
+
+    @Test
+    void toStringWithPersonalizeUsingBuilder() {
+        IndexSearchRequest classToTest =
+                IndexSearchRequest.builder()
+                        .q("This is a Test")
+                        .personalize(
+                                Personalize.builder()
+                                        .userContext("The user prefers sci-fi movies")
+                                        .build())
+                        .build();
+
+        JSONObject json = new JSONObject(classToTest.toString());
+        assertThat(json.getString("q"), is(equalTo("This is a Test")));
+        assertThat(
+                json.getJSONObject("personalize").getString("userContext"),
+                is(equalTo("The user prefers sci-fi movies")));
+
+        // Verify getters
+        assertThat(
+                classToTest.getPersonalize().getUserContext(),
+                is(equalTo("The user prefers sci-fi movies")));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/SearchRequestTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import com.meilisearch.sdk.model.Hybrid;
 import com.meilisearch.sdk.model.MatchingStrategy;
+import com.meilisearch.sdk.model.Personalize;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -418,5 +419,28 @@ class SearchRequestTest {
         String result = searchRequest.toString();
         JSONObject json = new JSONObject(result);
         assertThat(json.getBoolean("retrieveVectors"), is(true));
+    }
+
+    @Test
+    void toStringWithPersonalizeUsingBuilder() {
+        SearchRequest classToTest =
+                SearchRequest.builder()
+                        .q("This is a Test")
+                        .personalize(
+                                Personalize.builder()
+                                        .userContext("The user prefers sci-fi movies")
+                                        .build())
+                        .build();
+
+        JSONObject json = new JSONObject(classToTest.toString());
+        assertThat(json.getString("q"), is(equalTo("This is a Test")));
+        assertThat(
+                json.getJSONObject("personalize").getString("userContext"),
+                is(equalTo("The user prefers sci-fi movies")));
+
+        // Verify getters
+        assertThat(
+                classToTest.getPersonalize().getUserContext(),
+                is(equalTo("The user prefers sci-fi movies")));
     }
 }


### PR DESCRIPTION
Adds support for the `personalize` search parameter introduced in Meilisearch 1.47.0. Closes #970.

- New `Personalize` model (`model/Personalize.java`) with a `userContext` field, mirroring the existing `Hybrid` model (lombok builder + `toJSONObject()`).
- `SearchRequest` and `IndexSearchRequest` now accept an optional `personalize` object and serialize it into the request body. `IndexSearchRequest` covers federated / multi-search, which 1.47.0 also supports per the issue note.
- Unit tests in `SearchRequestTest` and `IndexSearchRequestTest` covering the serialization and getters.

Usage:

    SearchRequest.builder()
        .q("...")
        .personalize(Personalize.builder().userContext("The user prefers ...").build())
        .build();

Note: the SDK performs search over POST (`Search` / `Index.search`), so there is no separate GET search path in the client to update — `personalize` is added to the POST request body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the optional `personalize` search parameter.
  * Search requests can now include a personalization context, such as a user context, through the builder API.
  * Personalization is supported for both standard and index-based search requests.
  * Personalization details are included in serialized search requests when provided.

* **Tests**
  * Added coverage confirming personalization context is correctly included and accessible in search requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->