### PR TITLE
feat: support distinct in federated search

### DIFF
--- a/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
+++ b/src/main/java/com/meilisearch/sdk/MultiSearchFederation.java
@@ -11,6 +11,7 @@ public class MultiSearchFederation {
     private Integer offset;
     private MergeFacets mergeFacets;
     private Map<String, String[]> facetsByIndex;
+    private String distinct;
 
     public MultiSearchFederation setLimit(Integer limit) {
         this.limit = limit;
@@ -29,6 +30,11 @@ public class MultiSearchFederation {
 
     public MultiSearchFederation setFacetsByIndex(Map<String, String[]> facetsByIndex) {
         this.facetsByIndex = facetsByIndex;
+        return this;
+    }
+
+    public MultiSearchFederation setDistinct(String distinct) {
+        this.distinct = distinct;
         return this;
     }
 

--- a/src/test/java/com/meilisearch/sdk/MultiSearchFederationTest.java
+++ b/src/test/java/com/meilisearch/sdk/MultiSearchFederationTest.java
@@ -1,0 +1,28 @@
+package com.meilisearch.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import org.junit.jupiter.api.Test;
+
+class MultiSearchFederationTest {
+
+    private final GsonJsonHandler jsonHandler = new GsonJsonHandler();
+
+    @Test
+    void serializesDistinctInFederationOptions() throws MeilisearchException {
+        MultiSearchFederation federation = new MultiSearchFederation().setDistinct("movie_id");
+
+        assertThat(jsonHandler.encode(federation), containsString("\"distinct\":\"movie_id\""));
+    }
+
+    @Test
+    void omitsDistinctWhenNotSet() throws MeilisearchException {
+        MultiSearchFederation federation = new MultiSearchFederation().setLimit(10);
+
+        assertThat(jsonHandler.encode(federation), not(containsString("distinct")));
+    }
+}


### PR DESCRIPTION
Adds support for the `distinct` attribute in federated search, introduced in [Meilisearch 1.40.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.40.0). Closes #949.

- `MultiSearchFederation` now carries an optional `distinct` string, serialized into the `federation` object of the multi-search payload (alongside the existing `limit` / `offset` / `mergeFacets` / `facetsByIndex` options).
- Unit tests verifying `distinct` is serialized when set and omitted when not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring `distinct` in federated search requests.
  - Added support for requesting performance details in federated search responses.
  - Both options are optional and can be combined with existing federation settings.

- **Tests**
  - Added coverage confirming configured `distinct` values are included in requests.
  - Added coverage confirming omitted options are not serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->