### PR TITLE
Add render template support

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -640,7 +640,6 @@ webhooks_patch_1: |-
   Webhook updated_webhook = this.client.updateWebhook(webhook.getUuid(), webhookReq2);
 webhooks_delete_1: |-
   this.client.deleteWebhook("WEBHOOK_UUID");
-  
 
 post_render_template_1: |-
   Map<String, Boolean> features = new HashMap<>();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -640,3 +640,28 @@ webhooks_patch_1: |-
   Webhook updated_webhook = this.client.updateWebhook(webhook.getUuid(), webhookReq2);
 webhooks_delete_1: |-
   this.client.deleteWebhook("WEBHOOK_UUID");
+  
+
+post_render_template_1: |-
+  Map<String, Boolean> features = new HashMap<>();
+  features.put("renderRoute", true);
+  client.experimentalFeatures(features);
+
+  Map<String, Object> template = new HashMap<>();
+  template.put("kind", "inlineDocumentTemplate");
+  template.put("inline", "Product {{doc.name}} is a {{doc.color}} {{doc.category}}.");
+
+  Map<String, Object> product = new HashMap<>();
+  product.put("name", "Nike Air Max");
+  product.put("color", "Black");
+  product.put("category", "Shoes");
+
+  Map<String, Object> input = new HashMap<>();
+  input.put("kind", "inlineDocument");
+  input.put("inline", product);
+
+  RenderTemplateRequest request = new RenderTemplateRequest()
+      .setTemplate(template)
+      .setInput(input);
+
+  client.renderTemplate(request);

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -482,6 +482,18 @@ public class Client {
         this.config.httpClient.patch("/experimental-features", features, Void.class);
     }
 
+    /**
+     * Renders a template using the experimental render-template route.
+     *
+     * @param request Render template request body
+     * @return Rendered template result
+     * @throws MeilisearchException if an error occurs
+     */
+    public RenderTemplateResult renderTemplate(RenderTemplateRequest request)
+            throws MeilisearchException {
+        return this.config.httpClient.post("/render-template", request, RenderTemplateResult.class);
+    }
+
     public String generateTenantToken(String apiKeyUid, Map<String, Object> searchRules)
             throws MeilisearchException {
         return this.generateTenantToken(apiKeyUid, searchRules, new TenantTokenOptions());

--- a/src/main/java/com/meilisearch/sdk/RenderTemplateRequest.java
+++ b/src/main/java/com/meilisearch/sdk/RenderTemplateRequest.java
@@ -1,0 +1,30 @@
+package com.meilisearch.sdk;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.json.JSONObject;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@Setter
+@Accessors(chain = true)
+public class RenderTemplateRequest {
+    private Map<String, Object> template;
+    private Map<String, Object> input;
+
+    public RenderTemplateRequest() {}
+
+    @Override
+    public String toString() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("template", this.template);
+        jsonObject.putOpt("input", this.input);
+        return jsonObject.toString();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/model/RenderTemplateResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/RenderTemplateResult.java
@@ -1,13 +1,15 @@
 package com.meilisearch.sdk.model;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
+@Setter
 @ToString
 public class RenderTemplateResult {
-    Object template;
-    Object rendered;
+    private Object template;
+    private Object rendered;
 
     public RenderTemplateResult() {}
 }

--- a/src/main/java/com/meilisearch/sdk/model/RenderTemplateResult.java
+++ b/src/main/java/com/meilisearch/sdk/model/RenderTemplateResult.java
@@ -1,0 +1,13 @@
+package com.meilisearch.sdk.model;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class RenderTemplateResult {
+    Object template;
+    Object rendered;
+
+    public RenderTemplateResult() {}
+}

--- a/src/test/java/com/meilisearch/sdk/RenderTemplateRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/RenderTemplateRequestTest.java
@@ -4,6 +4,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import com.meilisearch.sdk.http.request.BasicRequest;
+import com.meilisearch.sdk.http.request.HttpMethod;
+import com.meilisearch.sdk.http.request.HttpRequest;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -67,6 +72,63 @@ class RenderTemplateRequestTest {
         assertThat(
                 json.getJSONObject("template").getString("inline"),
                 is(equalTo("Hello {{doc.name}}")));
+    }
+
+    @Test
+    void requestSerializerWithTemplateAndInput() {
+        Map<String, Object> template = new HashMap<>();
+        template.put("kind", "inlineDocumentTemplate");
+        template.put("inline", "Product {{doc.name}} is a {{doc.color}} {{doc.category}}.");
+
+        Map<String, Object> product = new HashMap<>();
+        product.put("name", "Nike Air Max");
+        product.put("color", "Black");
+        product.put("category", "Shoes");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("kind", "inlineDocument");
+        input.put("inline", product);
+
+        RenderTemplateRequest request =
+                new RenderTemplateRequest().setTemplate(template).setInput(input);
+
+        BasicRequest basicRequest = new BasicRequest(new GsonJsonHandler());
+        HttpRequest httpRequest =
+                basicRequest.create(
+                        HttpMethod.POST, "/render-template", Collections.emptyMap(), request);
+
+        JSONObject json = new JSONObject(httpRequest.getContent());
+
+        assertThat(httpRequest.getMethod(), is(equalTo(HttpMethod.POST)));
+        assertThat(httpRequest.getPath(), is(equalTo("/render-template")));
+        assertThat(
+                json.getJSONObject("template").getString("kind"),
+                is(equalTo("inlineDocumentTemplate")));
+        assertThat(json.getJSONObject("input").getString("kind"), is(equalTo("inlineDocument")));
+        assertThat(
+                json.getJSONObject("input").getJSONObject("inline").getString("name"),
+                is(equalTo("Nike Air Max")));
+    }
+
+    @Test
+    void requestSerializerWithoutInput() {
+        Map<String, Object> template = new HashMap<>();
+        template.put("kind", "inlineDocumentTemplate");
+        template.put("inline", "Hello {{doc.name}}");
+
+        RenderTemplateRequest request = new RenderTemplateRequest().setTemplate(template);
+
+        BasicRequest basicRequest = new BasicRequest(new GsonJsonHandler());
+        HttpRequest httpRequest =
+                basicRequest.create(
+                        HttpMethod.POST, "/render-template", Collections.emptyMap(), request);
+
+        JSONObject json = new JSONObject(httpRequest.getContent());
+
+        assertThat(httpRequest.getMethod(), is(equalTo(HttpMethod.POST)));
+        assertThat(httpRequest.getPath(), is(equalTo("/render-template")));
+        assertThat(json.has("template"), is(true));
+        assertThat(json.has("input"), is(false));
     }
 
     @Test

--- a/src/test/java/com/meilisearch/sdk/RenderTemplateRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/RenderTemplateRequestTest.java
@@ -1,0 +1,86 @@
+package com.meilisearch.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class RenderTemplateRequestTest {
+    @Test
+    void toStringWithTemplateAndInput() {
+        Map<String, Object> template = new HashMap<>();
+        template.put("kind", "inlineDocumentTemplate");
+        template.put("inline", "Product {{doc.name}} is a {{doc.color}} {{doc.category}}.");
+
+        Map<String, Object> product = new HashMap<>();
+        product.put("name", "Nike Air Max");
+        product.put("color", "Black");
+        product.put("category", "Shoes");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("kind", "inlineDocument");
+        input.put("inline", product);
+
+        RenderTemplateRequest request =
+                new RenderTemplateRequest().setTemplate(template).setInput(input);
+
+        JSONObject json = new JSONObject(request.toString());
+
+        assertThat(
+                json.getJSONObject("template").getString("kind"),
+                is(equalTo("inlineDocumentTemplate")));
+        assertThat(
+                json.getJSONObject("template").getString("inline"),
+                is(equalTo("Product {{doc.name}} is a {{doc.color}} {{doc.category}}.")));
+
+        assertThat(json.getJSONObject("input").getString("kind"), is(equalTo("inlineDocument")));
+        assertThat(
+                json.getJSONObject("input").getJSONObject("inline").getString("name"),
+                is(equalTo("Nike Air Max")));
+        assertThat(
+                json.getJSONObject("input").getJSONObject("inline").getString("color"),
+                is(equalTo("Black")));
+        assertThat(
+                json.getJSONObject("input").getJSONObject("inline").getString("category"),
+                is(equalTo("Shoes")));
+    }
+
+    @Test
+    void toStringWithoutInput() {
+        Map<String, Object> template = new HashMap<>();
+        template.put("kind", "inlineDocumentTemplate");
+        template.put("inline", "Hello {{doc.name}}");
+
+        RenderTemplateRequest request = new RenderTemplateRequest().setTemplate(template);
+
+        JSONObject json = new JSONObject(request.toString());
+
+        assertThat(json.has("template"), is(true));
+        assertThat(json.has("input"), is(false));
+        assertThat(
+                json.getJSONObject("template").getString("kind"),
+                is(equalTo("inlineDocumentTemplate")));
+        assertThat(
+                json.getJSONObject("template").getString("inline"),
+                is(equalTo("Hello {{doc.name}}")));
+    }
+
+    @Test
+    void gettersAndSetters() {
+        Map<String, Object> template = new HashMap<>();
+        template.put("kind", "inlineDocumentTemplate");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("kind", "inlineDocument");
+
+        RenderTemplateRequest request =
+                RenderTemplateRequest.builder().template(template).input(input).build();
+
+        assertThat(request.getTemplate(), is(equalTo(template)));
+        assertThat(request.getInput(), is(equalTo(input)));
+    }
+}

--- a/src/test/java/com/meilisearch/sdk/model/RenderTemplateResultTest.java
+++ b/src/test/java/com/meilisearch/sdk/model/RenderTemplateResultTest.java
@@ -1,0 +1,22 @@
+package com.meilisearch.sdk.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import org.junit.jupiter.api.Test;
+
+class RenderTemplateResultTest {
+    @Test
+    void deserializesWithJacksonJsonHandler() throws Exception {
+        RenderTemplateResult result =
+                new JacksonJsonHandler()
+                        .decode(
+                                "{\"template\":\"Hello {{doc.name}}\",\"rendered\":\"Hello Movindu\"}",
+                                RenderTemplateResult.class);
+
+        assertThat(result.getTemplate(), is(equalTo("Hello {{doc.name}}")));
+        assertThat(result.getRendered(), is(equalTo("Hello Movindu")));
+    }
+}

--- a/src/test/java/com/meilisearch/sdk/model/RenderTemplateResultTest.java
+++ b/src/test/java/com/meilisearch/sdk/model/RenderTemplateResultTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import com.meilisearch.sdk.json.JacksonJsonHandler;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class RenderTemplateResultTest {
@@ -18,5 +20,29 @@ class RenderTemplateResultTest {
 
         assertThat(result.getTemplate(), is(equalTo("Hello {{doc.name}}")));
         assertThat(result.getRendered(), is(equalTo("Hello Movindu")));
+    }
+
+    @Test
+    void deserializesStructuredRenderedValueWithJacksonJsonHandler() throws Exception {
+        RenderTemplateResult result =
+                new JacksonJsonHandler()
+                        .decode(
+                                "{"
+                                        + "\"template\":\"{{ doc }}\","
+                                        + "\"rendered\":{"
+                                        + "\"title\":\"Ariel\","
+                                        + "\"tags\":[\"movie\",\"classic\"]"
+                                        + "}"
+                                        + "}",
+                                RenderTemplateResult.class);
+
+        assertThat(result.getTemplate(), is(equalTo("{{ doc }}")));
+
+        Map<?, ?> rendered = (Map<?, ?>) result.getRendered();
+        assertThat(rendered.get("title"), is(equalTo("Ariel")));
+
+        List<?> tags = (List<?>) rendered.get("tags");
+        assertThat(tags.get(0), is(equalTo("movie")));
+        assertThat(tags.get(1), is(equalTo("classic")));
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #974

## What does this PR do?

Adds Java SDK support for the experimental `/render-template` route.

- Added `RenderTemplateRequest` to serialize the render template request body
- Added `RenderTemplateResult` to represent the API response
- Added `Client#renderTemplate` to call `POST /render-template`
- Added request serialization tests for render template requests with and without input
- Added a code sample in `.code-samples.meilisearch.yaml`

## How I tested

- Ran `./gradlew.bat spotlessApply`
- Ran `./gradlew.bat compileJava`
- Ran `./gradlew.bat test --tests "com.meilisearch.sdk.RenderTemplateRequestTest" -x jacocoTestCoverageVerification`
- Ran `bash ./scripts/lint.sh`
- Ran `./gradlew.bat clean build`

Note: `clean build` fails locally only on `SettingsHandlerTest` with `java.net.ConnectException` because a local Meilisearch instance is not running.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Java SDK support for experimental template rendering, including a new `renderTemplate` API to request a template + input and receive rendered output.
  * Introduced new request/response models for template rendering.
* **Documentation**
  * Added a new Java documentation code sample showing how to enable and use the experimental render route.
* **Tests**
  * Added/expanded unit tests for request serialization, HTTP payload generation, builder/accessors, and response deserialization (including structured rendered JSON).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->