### PR TITLE
Add stats size format options

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -331,9 +331,15 @@ update_search_cutoff_1: |-
 reset_search_cutoff_1: |-
   client.index("movies").resetSearchCutoffMsSettings();
 get_index_stats_1: |-
-  client.index("movies").getStats();
+  StatsQuery statsQuery = new StatsQuery()
+    .setShowInternalDatabaseSizes(true)
+    .setSizeFormat("human");
+  client.index("movies").getStats(statsQuery);
 get_indexes_stats_1: |-
-  client.getStats();
+  StatsQuery statsQuery = new StatsQuery()
+    .setShowInternalDatabaseSizes(true)
+    .setSizeFormat("human");
+  client.getStats(statsQuery);
 get_health_1: |-
   client.health();
 get_version_1: |-

--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -275,6 +275,19 @@ public class Client {
     }
 
     /**
+     * Gets extended information and metrics about indexes and the Meilisearch database
+     *
+     * @param params query parameters accepted by the stats route
+     * @return StatsWithSizeFormat instance from Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats#stats-object">API
+     *     specification</a>
+     */
+    public StatsWithSizeFormat getStats(StatsQuery params) throws MeilisearchException {
+        return this.instanceHandler.getStats(params);
+    }
+
+    /**
      * Gets the version of Meilisearch instance
      *
      * @return Meilisearch API response

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -1266,6 +1266,19 @@ public class Index implements Serializable {
     }
 
     /**
+     * Gets extended information and metrics about indexes and the Meilisearch database
+     *
+     * @param params query parameters accepted by the stats route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats#get-stats">API
+     *     specification</a>
+     */
+    public IndexStatsWithSizeFormat getStats(StatsQuery params) throws MeilisearchException {
+        return this.instanceHandler.getIndexStats(this.uid, params);
+    }
+
+    /**
      * Retrieves an index tasks by its uid
      *
      * @param taskId Identifier of the requested index task

--- a/src/main/java/com/meilisearch/sdk/InstanceHandler.java
+++ b/src/main/java/com/meilisearch/sdk/InstanceHandler.java
@@ -1,8 +1,12 @@
 package com.meilisearch.sdk;
 
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.IndexStats;
+import com.meilisearch.sdk.model.IndexStatsWithSizeFormat;
 import com.meilisearch.sdk.model.Stats;
+import com.meilisearch.sdk.model.StatsQuery;
+import com.meilisearch.sdk.model.StatsWithSizeFormat;
 
 /** Class providing information on the Meilisearch instance */
 public class InstanceHandler {
@@ -58,6 +62,22 @@ public class InstanceHandler {
     /**
      * Gets extended information and metrics about indexes and the Meilisearch database
      *
+     * @param params query parameters accepted by the stats route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+     */
+    StatsWithSizeFormat getStats(StatsQuery params) throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder("/stats");
+        if (params != null) {
+            urlb.addQuery(params.toQuery());
+        }
+        return httpClient.get(urlb.getURL(), StatsWithSizeFormat.class);
+    }
+
+    /**
+     * Gets extended information and metrics about indexes and the Meilisearch database
+     *
      * @param uid Index identifier to the requested
      * @return Meilisearch API response
      * @throws MeilisearchException if an error occurs
@@ -66,6 +86,24 @@ public class InstanceHandler {
     IndexStats getIndexStats(String uid) throws MeilisearchException {
         String requestQuery = "/indexes/" + uid + "/stats";
         return httpClient.<IndexStats>get(requestQuery, IndexStats.class);
+    }
+
+    /**
+     * Gets extended information and metrics about an index and the Meilisearch database
+     *
+     * @param uid Index identifier to the requested
+     * @param params query parameters accepted by the stats route
+     * @return Meilisearch API response
+     * @throws MeilisearchException if an error occurs
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+     */
+    IndexStatsWithSizeFormat getIndexStats(String uid, StatsQuery params)
+            throws MeilisearchException {
+        URLBuilder urlb = new URLBuilder("/indexes").addSubroute(uid).addSubroute("stats");
+        if (params != null) {
+            urlb.addQuery(params.toQuery());
+        }
+        return httpClient.get(urlb.getURL(), IndexStatsWithSizeFormat.class);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/model/IndexStatsWithSizeFormat.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStatsWithSizeFormat.java
@@ -1,0 +1,47 @@
+package com.meilisearch.sdk.model;
+
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * Stats data structure of a Meilisearch Index when database sizes may be raw bytes or human-readable
+ * strings.
+ *
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/indexes/get-stats-of-index">API
+ *     specification</a>
+ */
+@Getter
+public class IndexStatsWithSizeFormat {
+    protected long numberOfDocuments;
+    protected boolean isIndexing;
+    protected Map<String, Integer> fieldDistribution;
+    protected Object rawDocumentDbSize;
+    protected Object avgDocumentSize;
+    protected Object maxDocumentSize;
+    protected Long numberOfEmbeddedDocuments;
+    protected Long numberOfEmbeddings;
+    protected Map<String, Object> internalDatabaseSizes;
+
+    public IndexStatsWithSizeFormat() {}
+
+    public IndexStatsWithSizeFormat(
+            long numberOfDocuments,
+            boolean isIndexing,
+            Map<String, Integer> fieldDistribution,
+            Object rawDocumentDbSize,
+            Object avgDocumentSize,
+            Object maxDocumentSize,
+            Long numberOfEmbeddedDocuments,
+            Long numberOfEmbeddings,
+            Map<String, Object> internalDatabaseSizes) {
+        this.numberOfDocuments = numberOfDocuments;
+        this.isIndexing = isIndexing;
+        this.fieldDistribution = fieldDistribution;
+        this.rawDocumentDbSize = rawDocumentDbSize;
+        this.avgDocumentSize = avgDocumentSize;
+        this.maxDocumentSize = maxDocumentSize;
+        this.numberOfEmbeddedDocuments = numberOfEmbeddedDocuments;
+        this.numberOfEmbeddings = numberOfEmbeddings;
+        this.internalDatabaseSizes = internalDatabaseSizes;
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/model/StatsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/StatsQuery.java
@@ -1,0 +1,31 @@
+package com.meilisearch.sdk.model;
+
+import com.meilisearch.sdk.http.URLBuilder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data structure of the query parameters for the stats routes.
+ *
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+ */
+@Setter
+@Getter
+@Accessors(chain = true)
+public class StatsQuery {
+    private Boolean showInternalDatabaseSizes;
+    private String sizeFormat;
+
+    public StatsQuery() {}
+
+    public String toQuery() {
+        URLBuilder urlb =
+                new URLBuilder()
+                        .addParameter(
+                                "showInternalDatabaseSizes",
+                                this.getShowInternalDatabaseSizes())
+                        .addParameter("sizeFormat", this.getSizeFormat());
+        return urlb.getURL();
+    }
+}

--- a/src/main/java/com/meilisearch/sdk/model/StatsQuery.java
+++ b/src/main/java/com/meilisearch/sdk/model/StatsQuery.java
@@ -24,8 +24,10 @@ public class StatsQuery {
                 new URLBuilder()
                         .addParameter(
                                 "showInternalDatabaseSizes",
-                                this.getShowInternalDatabaseSizes())
-                        .addParameter("sizeFormat", this.getSizeFormat());
+                                this.getShowInternalDatabaseSizes());
+        if (this.getSizeFormat() != null && !this.getSizeFormat().isEmpty()) {
+            urlb.addParameter("sizeFormat", this.getSizeFormat());
+        }
         return urlb.getURL();
     }
 }

--- a/src/main/java/com/meilisearch/sdk/model/StatsWithSizeFormat.java
+++ b/src/main/java/com/meilisearch/sdk/model/StatsWithSizeFormat.java
@@ -1,0 +1,31 @@
+package com.meilisearch.sdk.model;
+
+import java.util.Date;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * Meilisearch stats data structure when database sizes may be raw bytes or human-readable strings.
+ *
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/stats">API specification</a>
+ */
+@Getter
+public class StatsWithSizeFormat {
+    protected Object databaseSize;
+    protected Date lastUpdate;
+    protected Map<String, IndexStatsWithSizeFormat> indexes;
+    protected Object usedDatabaseSize;
+
+    public StatsWithSizeFormat(
+            Object databaseSize,
+            Date lastUpdate,
+            Map<String, IndexStatsWithSizeFormat> indexes,
+            Object usedDatabaseSize) {
+        this.databaseSize = databaseSize;
+        this.lastUpdate = lastUpdate;
+        this.indexes = indexes;
+        this.usedDatabaseSize = usedDatabaseSize;
+    }
+
+    public StatsWithSizeFormat() {}
+}

--- a/src/test/java/com/meilisearch/sdk/StatsTest.java
+++ b/src/test/java/com/meilisearch/sdk/StatsTest.java
@@ -1,0 +1,121 @@
+package com.meilisearch.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.meilisearch.sdk.model.IndexStatsWithSizeFormat;
+import com.meilisearch.sdk.model.StatsQuery;
+import com.meilisearch.sdk.model.StatsWithSizeFormat;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StatsTest {
+
+    private MockWebServer server;
+    private Client client;
+
+    @BeforeEach
+    void setup() throws Exception {
+        server = new MockWebServer();
+        server.start();
+
+        client = new Client(new Config(server.url("/").toString(), "masterKey"));
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void getStatsWithQueryParameters() throws Exception {
+        String json =
+                """
+            {
+              "databaseSize": "1.2 KiB",
+              "usedDatabaseSize": "1 KiB",
+              "lastUpdate": "2019-11-20T09:40:33.711324Z",
+              "indexes": {
+                "movies": {
+                  "numberOfDocuments": 10,
+                  "rawDocumentDbSize": "100 B",
+                  "maxDocumentSize": "16 B",
+                  "avgDocumentSize": "10 B",
+                  "isIndexing": true,
+                  "fieldDistribution": {
+                    "genre": 10
+                  },
+                  "internalDatabaseSizes": {
+                    "documents": "100 B"
+                  }
+                }
+              }
+            }
+            """;
+        StatsQuery query =
+                new StatsQuery().setShowInternalDatabaseSizes(true).setSizeFormat("human");
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(json));
+
+        StatsWithSizeFormat stats = client.getStats(query);
+
+        assertThat(
+                server.takeRequest().getPath(),
+                is("//stats?showInternalDatabaseSizes=true&sizeFormat=human"));
+        assertThat(stats.getDatabaseSize(), is("1.2 KiB"));
+        assertThat(stats.getUsedDatabaseSize(), is("1 KiB"));
+        assertThat(stats.getIndexes().get("movies").getRawDocumentDbSize(), is("100 B"));
+        assertThat(
+                stats.getIndexes().get("movies").getInternalDatabaseSizes().get("documents"),
+                is("100 B"));
+    }
+
+    @Test
+    void getIndexStatsWithQueryParameters() throws Exception {
+        String json =
+                """
+            {
+              "numberOfDocuments": 10,
+              "rawDocumentDbSize": "100 B",
+              "maxDocumentSize": "16 B",
+              "avgDocumentSize": "10 B",
+              "numberOfEmbeddings": 2,
+              "numberOfEmbeddedDocuments": 1,
+              "isIndexing": false,
+              "fieldDistribution": {
+                "genre": 10
+              },
+              "internalDatabaseSizes": {
+                "documents": "100 B"
+              }
+            }
+            """;
+        StatsQuery query =
+                new StatsQuery().setShowInternalDatabaseSizes(true).setSizeFormat("human");
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(json));
+
+        IndexStatsWithSizeFormat stats = client.index("movies").getStats(query);
+
+        assertThat(
+                server.takeRequest().getPath(),
+                is("//indexes/movies/stats?showInternalDatabaseSizes=true&sizeFormat=human"));
+        assertThat(stats.getRawDocumentDbSize(), is("100 B"));
+        assertThat(stats.getAvgDocumentSize(), is("10 B"));
+        assertThat(stats.getMaxDocumentSize(), is("16 B"));
+        assertThat(stats.getInternalDatabaseSizes().get("documents"), is("100 B"));
+        assertThat(stats.getNumberOfEmbeddings(), is(2L));
+        assertThat(stats.getNumberOfEmbeddedDocuments(), is(1L));
+    }
+
+    @Test
+    void statsQuerySerializesParameters() {
+        StatsQuery query =
+                new StatsQuery().setShowInternalDatabaseSizes(true).setSizeFormat("raw");
+
+        assertThat(query.toQuery(), is("?showInternalDatabaseSizes=true&sizeFormat=raw"));
+    }
+}

--- a/src/test/java/com/meilisearch/sdk/StatsTest.java
+++ b/src/test/java/com/meilisearch/sdk/StatsTest.java
@@ -112,10 +112,94 @@ class StatsTest {
     }
 
     @Test
+    void getStatsWithRawSizeResponse() throws Exception {
+        String json =
+                """
+            {
+              "databaseSize": 1200,
+              "usedDatabaseSize": 1000,
+              "lastUpdate": "2019-11-20T09:40:33.711324Z",
+              "indexes": {
+                "movies": {
+                  "numberOfDocuments": 10,
+                  "rawDocumentDbSize": 100,
+                  "maxDocumentSize": 16,
+                  "avgDocumentSize": 10,
+                  "isIndexing": true,
+                  "fieldDistribution": {
+                    "genre": 10
+                  },
+                  "internalDatabaseSizes": {
+                    "documents": 100
+                  }
+                }
+              }
+            }
+            """;
+        StatsQuery query = new StatsQuery().setShowInternalDatabaseSizes(true);
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(json));
+
+        StatsWithSizeFormat stats = client.getStats(query);
+
+        assertThat(
+                server.takeRequest().getPath(),
+                is("//stats?showInternalDatabaseSizes=true"));
+        assertThat(stats.getDatabaseSize(), is(1200.0));
+        assertThat(stats.getUsedDatabaseSize(), is(1000.0));
+        assertThat(stats.getIndexes().get("movies").getRawDocumentDbSize(), is(100.0));
+        assertThat(
+                stats.getIndexes().get("movies").getInternalDatabaseSizes().get("documents"),
+                is(100.0));
+    }
+
+    @Test
+    void getIndexStatsWithRawSizeResponse() throws Exception {
+        String json =
+                """
+            {
+              "numberOfDocuments": 10,
+              "rawDocumentDbSize": 100,
+              "maxDocumentSize": 16,
+              "avgDocumentSize": 10,
+              "numberOfEmbeddings": 2,
+              "numberOfEmbeddedDocuments": 1,
+              "isIndexing": false,
+              "fieldDistribution": {
+                "genre": 10
+              },
+              "internalDatabaseSizes": {
+                "documents": 100
+              }
+            }
+            """;
+        StatsQuery query = new StatsQuery().setShowInternalDatabaseSizes(true);
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(json));
+
+        IndexStatsWithSizeFormat stats = client.index("movies").getStats(query);
+
+        assertThat(
+                server.takeRequest().getPath(),
+                is("//indexes/movies/stats?showInternalDatabaseSizes=true"));
+        assertThat(stats.getRawDocumentDbSize(), is(100.0));
+        assertThat(stats.getAvgDocumentSize(), is(10.0));
+        assertThat(stats.getMaxDocumentSize(), is(16.0));
+        assertThat(stats.getInternalDatabaseSizes().get("documents"), is(100.0));
+        assertThat(stats.getNumberOfEmbeddings(), is(2L));
+        assertThat(stats.getNumberOfEmbeddedDocuments(), is(1L));
+    }
+
+    @Test
     void statsQuerySerializesParameters() {
         StatsQuery query =
                 new StatsQuery().setShowInternalDatabaseSizes(true).setSizeFormat("raw");
 
         assertThat(query.toQuery(), is("?showInternalDatabaseSizes=true&sizeFormat=raw"));
+        assertThat(new StatsQuery().toQuery(), is(""));
+        assertThat(
+                new StatsQuery().setShowInternalDatabaseSizes(true).toQuery(),
+                is("?showInternalDatabaseSizes=true"));
+        assertThat(new StatsQuery().setSizeFormat("human").toQuery(), is("?sizeFormat=human"));
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #966

## What does this PR do?
- Adds `StatsQuery` support for the `showInternalDatabaseSizes` and `sizeFormat` query parameters.
- Adds parameterized stats methods for global stats and index stats.
- Adds response models that support raw numeric sizes and human-readable size strings.
- Represents `internalDatabaseSizes` as a flexible map.
- Updates tests for the new stats query parameters and response handling.
- Updates `.code-samples.meilisearch.yaml` for `get_index_stats_1` and `get_indexes_stats_1`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
  - Used ChatGPT/Codex to inspect the SDK structure, implement the stats query/model changes, add focused tests, and prepare this PR description.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## Tests
- `.\gradlew.bat testClasses`
- `.\gradlew.bat test --tests com.meilisearch.sdk.StatsTest --init-script <disable-jacoco> -x jacocoTestReport -x jacocoTestCoverageVerification --rerun-tasks`

Thank you so much for contributing to Meilisearch!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stats requests can now include options for internal database sizes and human-readable size formatting.
  * Added overloads to retrieve enhanced stats at both the app-wide and index levels.
* **Bug Fixes**
  * Updated Java stats examples to use the query-based approach for size formatting and internal size visibility.
* **Tests**
  * Added coverage for stats query serialization and parsing of both human-formatted and raw numeric size responses for global and index stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->