### PR TITLE
Use labels array in release drafter config

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -17,7 +17,7 @@ categories:
   - title: '🔒 Security'
     label: 'security'
   - title: '⚙️ Maintenance/misc'
-    label:
+    labels:
       - 'dependencies'
       - 'maintenance'
       - 'documentation'


### PR DESCRIPTION
# Pull Request

## Related issue
Release Drafter v7 requires `label` to be a string; multi-label categories must use `labels`.

## What does this PR do?
- Fix config

## AI disclosure
Cursor with `grok-4.5-high`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release draft categorization by supporting multiple labels for maintenance and miscellaneous changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->