### PR TITLE
Fix Jackson serialization of granular filterable attributes

### DIFF
--- a/src/main/java/com/meilisearch/sdk/model/Settings.java
+++ b/src/main/java/com/meilisearch/sdk/model/Settings.java
@@ -1,5 +1,7 @@
 package com.meilisearch.sdk.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -42,20 +44,24 @@ public class Settings {
     public Settings() {}
 
     /** Granular filterable attributes accessor. */
+    @JsonProperty("filterableAttributes")
     public FilterableAttributesConfig[] getFilterableAttributesConfig() {
         return filterableAttributes;
     }
 
+    @JsonProperty("filterableAttributes")
     public Settings setFilterableAttributesConfig(FilterableAttributesConfig[] configs) {
         this.filterableAttributes = configs;
         return this;
     }
 
     /** Legacy String[] view of filterable attributes. */
+    @JsonIgnore
     public String[] getFilterableAttributes() {
         return FilterableAttributesLegacyAdapter.toLegacyNamesOrThrow(filterableAttributes);
     }
 
+    @JsonIgnore
     public Settings setFilterableAttributes(String[] filterableAttributes) {
         this.filterableAttributes =
                 FilterableAttributesLegacyAdapter.fromLegacyNames(filterableAttributes);

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -166,12 +166,16 @@ class JacksonJsonHandlerTest {
         assertThat(
                 decoded.getFilterableAttributesConfig()[0].getAttributePatterns()[0], is("parent"));
         assertThat(
-                decoded.getFilterableAttributesConfig()[0].getFeatures().getFacetSearch(), is(false));
+                decoded.getFilterableAttributesConfig()[0].getFeatures().getFacetSearch(),
+                is(false));
         assertThat(
                 decoded.getFilterableAttributesConfig()[0].getFeatures().getFilter().getEquality(),
                 is(true));
         assertThat(
-                decoded.getFilterableAttributesConfig()[0].getFeatures().getFilter().getComparison(),
+                decoded.getFilterableAttributesConfig()[0]
+                        .getFeatures()
+                        .getFilter()
+                        .getComparison(),
                 is(false));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -134,4 +134,44 @@ class JacksonJsonHandlerTest {
                 decoded.getFilterableAttributesConfig()[1].getAttributePatterns()[0],
                 is("director"));
     }
+
+    @Test
+    void settingsWithAdvancedGranularFilterableAttributesRoundTripWithCustomMapper()
+            throws Exception {
+        ObjectMapper customMapper = new ObjectMapper();
+        JacksonJsonHandler handlerWithCustomMapper = new JacksonJsonHandler(customMapper);
+
+        FilterableAttributesFeatures features = new FilterableAttributesFeatures();
+        features.setFacetSearch(false);
+        features.setFilter(new FilterableAttributesFilter(true, false));
+
+        FilterableAttributesConfig advanced = new FilterableAttributesConfig();
+        advanced.setAttributePatterns(new String[] {"parent"});
+        advanced.setFeatures(features);
+
+        Settings settings = new Settings();
+        settings.setFilterableAttributesConfig(new FilterableAttributesConfig[] {advanced});
+
+        String json = handlerWithCustomMapper.encode(settings);
+
+        assertThat(
+                json,
+                is(
+                        "{\"filterableAttributes\":[{\"attributePatterns\":[\"parent\"],\"features\":{\"facetSearch\":false,\"filter\":{\"equality\":true,\"comparison\":false}}}]}"));
+
+        Settings decoded = handlerWithCustomMapper.decode(json, Settings.class);
+
+        assertThat(decoded.getFilterableAttributesConfig(), is(notNullValue()));
+        assertThat(decoded.getFilterableAttributesConfig().length, is(1));
+        assertThat(
+                decoded.getFilterableAttributesConfig()[0].getAttributePatterns()[0], is("parent"));
+        assertThat(
+                decoded.getFilterableAttributesConfig()[0].getFeatures().getFacetSearch(), is(false));
+        assertThat(
+                decoded.getFilterableAttributesConfig()[0].getFeatures().getFilter().getEquality(),
+                is(true));
+        assertThat(
+                decoded.getFilterableAttributesConfig()[0].getFeatures().getFilter().getComparison(),
+                is(false));
+    }
 }


### PR DESCRIPTION
## Related issue
Fixes #973

## What does this PR do?

Fixes Jackson serialization when callers use granular `filterableAttributesConfig` values. Jackson previously invoked the legacy `getFilterableAttributes()` accessor, which throws when a configuration contains granular feature settings.

- Maps the granular getter and setter to the API's `filterableAttributes` JSON property.
- Excludes the legacy `String[]` getter and setter from Jackson serialization while retaining them as public SDK methods.
- Adds a regression test covering an advanced configuration with `features.filter` and `facetSearch` settings.

## Validation

- `./gradlew.bat compileTestJava --no-daemon`
- Direct Jackson encode/decode checks for advanced granular and legacy string configurations.
- `git diff --check`

The full test task is blocked locally because the repository's Mockito 4 / JaCoCo 0.8.8 test setup is incompatible with the installed Java 24 runtime; the failure occurs during test initialization before assertions run.

## AI usage

I used Codex to help inspect the affected serialization path and draft the implementation and regression test. I reviewed the code and validated the behavior locally.

## PR checklist

- [x] This PR fixes an existing issue.
- [x] I have read the contributing guidelines.
- [x] The title accurately describes the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization/deserialization for advanced filterable-attribute configurations.
  * Prevented legacy filterable-attribute fields from appearing alongside the newer configuration in JSON output.
  * Ensured facet-search and filter feature settings round-trip accurately through JSON.
* **Tests**
  * Added a round-trip test that validates the exact JSON and verifies decoded advanced filterable-attribute feature and filter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->