### PR TITLE
Add filter condition to Dynamic Search Rules

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -672,9 +672,9 @@ list_dynamic_search_rules_1: |-
 get_dynamic_search_rule_1: |-
   DynamicSearchRule rule = client.getDynamicSearchRule("black-friday");
 patch_dynamic_search_rule_1: |-
-  List<Map<String, Object>> conditions = List.of(
-      Map.of("scope", "query", "isEmpty", true),
-      Map.of("scope", "time", "start", "2025-11-28T00:00:00Z", "end", "2025-11-28T23:59:59Z"));
+  Map<String, Object> conditions = Map.of(
+      "query", Map.of("isEmpty", true),
+      "time", Map.of("start", "2025-11-28T00:00:00Z", "end", "2025-11-28T23:59:59Z"));
 
   List<Map<String, Object>> actions = List.of(
       Map.of(

--- a/src/main/java/com/meilisearch/sdk/model/DynamicSearchRule.java
+++ b/src/main/java/com/meilisearch/sdk/model/DynamicSearchRule.java
@@ -19,8 +19,9 @@ public class DynamicSearchRule implements Serializable {
     protected String description;
     protected int priority;
     protected boolean active;
-    protected List<Map<String, Object>> conditions;
+    protected Map<String, Object> conditions;
     protected List<Map<String, Object>> actions;
+    protected String lastUpdatedAt;
 
     public DynamicSearchRule() {}
 
@@ -29,7 +30,7 @@ public class DynamicSearchRule implements Serializable {
             String description,
             int priority,
             boolean active,
-            List<Map<String, Object>> conditions,
+            Map<String, Object> conditions,
             List<Map<String, Object>> actions) {
         this.uid = uid;
         this.description = description;

--- a/src/main/java/com/meilisearch/sdk/model/DynamicSearchRule.java
+++ b/src/main/java/com/meilisearch/sdk/model/DynamicSearchRule.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 public class DynamicSearchRule implements Serializable {
     protected String uid;
     protected String description;
-    protected int priority;
+    protected int precedence;
     protected boolean active;
     protected Map<String, Object> conditions;
     protected List<Map<String, Object>> actions;
@@ -28,13 +28,13 @@ public class DynamicSearchRule implements Serializable {
     public DynamicSearchRule(
             String uid,
             String description,
-            int priority,
+            int precedence,
             boolean active,
             Map<String, Object> conditions,
             List<Map<String, Object>> actions) {
         this.uid = uid;
         this.description = description;
-        this.priority = priority;
+        this.precedence = precedence;
         this.active = active;
         this.conditions = conditions;
         this.actions = actions;

--- a/src/test/java/com/meilisearch/integration/DynamicSearchRulesTest.java
+++ b/src/test/java/com/meilisearch/integration/DynamicSearchRulesTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.model.DynamicSearchRule;
 import com.meilisearch.sdk.model.DynamicSearchRulesQuery;
 import com.meilisearch.sdk.model.Results;
@@ -13,6 +14,7 @@ import com.meilisearch.sdk.model.TaskInfo;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -33,14 +35,17 @@ public class DynamicSearchRulesTest extends AbstractIT {
     }
 
     private DynamicSearchRule buildTestRule(String uid) {
-        Map<String, Object> queryCondition = Map.of("scope", "query", "isEmpty", true);
+        Map<String, Object> queryCondition = Map.of("query", Map.of("isEmpty", true));
         Map<String, Object> action =
                 Map.of(
                         "selector", Map.of("indexUid", "products"),
                         "action", Map.of("type", "pin", "position", 1));
 
-        return new DynamicSearchRule(
-                uid, "Test rule", 5, true, List.of(queryCondition), List.of(action));
+        return new DynamicSearchRule(uid, "Test rule", 5, true, queryCondition, List.of(action));
+    }
+
+    private Map<String, Object> buildFilterCondition(String color) {
+        return Map.of("filter", Map.of("values", Map.of("color", color, "category", "shirt")));
     }
 
     @Test
@@ -55,6 +60,42 @@ public class DynamicSearchRulesTest extends AbstractIT {
         assertThat(fetched.getDescription(), equalTo("Test rule"));
         assertThat(fetched.getPriority(), equalTo(5));
         assertThat(fetched.isActive(), equalTo(true));
+        assertThat(fetched.getLastUpdatedAt(), notNullValue());
+    }
+
+    @Test
+    public void testCreateAndUpdateDynamicSearchRuleWithFilterCondition()
+            throws MeilisearchException {
+        DynamicSearchRule rule = buildTestRule("test-filter");
+        rule.setConditions(buildFilterCondition("red"));
+
+        TaskInfo createTask = client.updateDynamicSearchRule("test-filter", rule);
+        client.waitForTask(createTask.getTaskUid());
+
+        DynamicSearchRule created = client.getDynamicSearchRule("test-filter");
+        JSONObject createdConditions =
+                new JSONObject(new GsonJsonHandler().encode(created.getConditions()));
+        assertThat(
+                createdConditions
+                        .getJSONObject("filter")
+                        .getJSONObject("values")
+                        .getString("color"),
+                equalTo("red"));
+
+        rule.setConditions(buildFilterCondition("blue"));
+        TaskInfo updateTask = client.updateDynamicSearchRule("test-filter", rule);
+        client.waitForTask(updateTask.getTaskUid());
+
+        DynamicSearchRule updated = client.getDynamicSearchRule("test-filter");
+        JSONObject updatedConditions =
+                new JSONObject(new GsonJsonHandler().encode(updated.getConditions()));
+        assertThat(
+                updatedConditions
+                        .getJSONObject("filter")
+                        .getJSONObject("values")
+                        .getString("color"),
+                equalTo("blue"));
+        assertThat(updated.getLastUpdatedAt(), notNullValue());
     }
 
     @Test
@@ -79,6 +120,7 @@ public class DynamicSearchRulesTest extends AbstractIT {
                 client.listDynamicSearchRules(new DynamicSearchRulesQuery());
 
         assertThat(results.getResults().length >= 2, equalTo(true));
+        assertThat(results.getResults()[0].getLastUpdatedAt(), notNullValue());
     }
 
     @Test

--- a/src/test/java/com/meilisearch/integration/DynamicSearchRulesTest.java
+++ b/src/test/java/com/meilisearch/integration/DynamicSearchRulesTest.java
@@ -58,7 +58,7 @@ public class DynamicSearchRulesTest extends AbstractIT {
         DynamicSearchRule fetched = client.getDynamicSearchRule("test-rule");
         assertThat(fetched.getUid(), equalTo("test-rule"));
         assertThat(fetched.getDescription(), equalTo("Test rule"));
-        assertThat(fetched.getPriority(), equalTo(5));
+        assertThat(fetched.getPrecedence(), equalTo(5));
         assertThat(fetched.isActive(), equalTo(true));
         assertThat(fetched.getLastUpdatedAt(), notNullValue());
     }

--- a/src/test/java/com/meilisearch/sdk/model/DynamicSearchRuleTest.java
+++ b/src/test/java/com/meilisearch/sdk/model/DynamicSearchRuleTest.java
@@ -45,13 +45,14 @@ class DynamicSearchRuleTest {
         String lastUpdatedAt = "2026-07-28T08:30:00Z";
         String response =
                 "{\"uid\":\"test-filter\",\"description\":\"Filter rule\","
-                        + "\"priority\":1,\"active\":true,\"conditions\":{},\"actions\":[],"
+                        + "\"precedence\":1,\"active\":true,\"conditions\":{},\"actions\":[],"
                         + "\"lastUpdatedAt\":\""
                         + lastUpdatedAt
                         + "\"}";
 
         DynamicSearchRule rule = jsonHandler.decode(response, DynamicSearchRule.class);
 
+        assertThat(rule.getPrecedence(), is(equalTo(1)));
         assertThat(rule.getLastUpdatedAt(), is(equalTo(lastUpdatedAt)));
     }
 }

--- a/src/test/java/com/meilisearch/sdk/model/DynamicSearchRuleTest.java
+++ b/src/test/java/com/meilisearch/sdk/model/DynamicSearchRuleTest.java
@@ -1,0 +1,57 @@
+package com.meilisearch.sdk.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class DynamicSearchRuleTest {
+    private final GsonJsonHandler jsonHandler = new GsonJsonHandler();
+
+    @Test
+    void serializesFilterConditionValues() {
+        Map<String, Object> conditions =
+                Map.of(
+                        "filter",
+                        Map.of(
+                                "values",
+                                Map.of(
+                                        "color", "red",
+                                        "category", "shirt")));
+        Map<String, Object> action =
+                Map.of(
+                        "selector", Map.of("indexUid", "products", "id", "123"),
+                        "action", Map.of("type", "pin", "position", 1));
+
+        DynamicSearchRule rule =
+                new DynamicSearchRule(
+                        "test-filter", "Filter rule", 1, true, conditions, List.of(action));
+
+        JSONObject json = new JSONObject(jsonHandler.encode(rule));
+        JSONObject values =
+                json.getJSONObject("conditions").getJSONObject("filter").getJSONObject("values");
+
+        assertThat(values.getString("color"), is(equalTo("red")));
+        assertThat(values.getString("category"), is(equalTo("shirt")));
+    }
+
+    @Test
+    void deserializesLastUpdatedAt() {
+        String lastUpdatedAt = "2026-07-28T08:30:00Z";
+        String response =
+                "{\"uid\":\"test-filter\",\"description\":\"Filter rule\","
+                        + "\"priority\":1,\"active\":true,\"conditions\":{},\"actions\":[],"
+                        + "\"lastUpdatedAt\":\""
+                        + lastUpdatedAt
+                        + "\"}";
+
+        DynamicSearchRule rule = jsonHandler.decode(response, DynamicSearchRule.class);
+
+        assertThat(rule.getLastUpdatedAt(), is(equalTo(lastUpdatedAt)));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #986

## What does this PR do?
- Update `DynamicSearchRule.conditions` type from `List<Map<String, Object>>` to `Map<String, Object>` to align with Meilisearch v1.50.0 API changes
- Add support for `filter` condition in dynamic search rules (Meilisearch v1.51.0)
- Add `lastUpdatedAt` field to `DynamicSearchRule`
- Update integration tests to cover filter condition create/update flows
- Add unit tests for filter condition serialization and `lastUpdatedAt` deserialization

**AI usage disclosure:** Test cases in `DynamicSearchRulesTest.java` and `DynamicSearchRuleTest.java` were generated with Codex and then manually reviewed and adjusted.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic search rules now support structured `conditions`, including nested query/time and filter values.
  * Exposes a rule’s `lastUpdatedAt` timestamp.
* **Improvements**
  * Dynamic search rules now preserve condition payloads correctly across create, update, retrieve, and list.
  * JSON serialization/deserialization was enhanced to match the new `conditions` structure.
  * Renamed `priority` to `precedence`.
  * Updated dynamic rule examples to the new `conditions` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->