### PR TITLE
Add exhaustive facet count to facet search requests

### DIFF
--- a/src/main/java/com/meilisearch/sdk/FacetSearchRequest.java
+++ b/src/main/java/com/meilisearch/sdk/FacetSearchRequest.java
@@ -23,6 +23,7 @@ public class FacetSearchRequest {
     private String q;
     private MatchingStrategy matchingStrategy;
     private String[] attributesToSearchOn;
+    private Boolean exhaustiveFacetCount;
     private String[] filter;
     private String[][] filterArray;
 
@@ -68,6 +69,7 @@ public class FacetSearchRequest {
                                         ? null
                                         : this.matchingStrategy.toString())
                         .putOpt("attributesToSearchOn", this.attributesToSearchOn)
+                        .putOpt("exhaustiveFacetCount", this.exhaustiveFacetCount)
                         .putOpt("filter", this.filter)
                         .putOpt("filter", this.filterArray);
 

--- a/src/test/java/com/meilisearch/sdk/FacetSearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/FacetSearchRequestTest.java
@@ -25,6 +25,17 @@ class FacetSearchRequestTest {
     }
 
     @Test
+    void serializesExhaustiveFacetCountWhenFalse() {
+        FacetSearchRequest request =
+                new FacetSearchRequest("genres").setExhaustiveFacetCount(false);
+
+        JSONObject json = new JSONObject(request.toString());
+
+        assertThat(json.has("exhaustiveFacetCount"), is(true));
+        assertThat(json.getBoolean("exhaustiveFacetCount"), is(false));
+    }
+
+    @Test
     void buildsWithExhaustiveFacetCount() {
         FacetSearchRequest request =
                 FacetSearchRequest.builder().facetName("genres").exhaustiveFacetCount(true).build();

--- a/src/test/java/com/meilisearch/sdk/FacetSearchRequestTest.java
+++ b/src/test/java/com/meilisearch/sdk/FacetSearchRequestTest.java
@@ -1,0 +1,34 @@
+package com.meilisearch.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class FacetSearchRequestTest {
+    @Test
+    void omitsExhaustiveFacetCountByDefault() {
+        JSONObject json = new JSONObject(new FacetSearchRequest("genres").toString());
+
+        assertThat(json.has("exhaustiveFacetCount"), is(false));
+    }
+
+    @Test
+    void serializesExhaustiveFacetCount() {
+        FacetSearchRequest request = new FacetSearchRequest("genres").setExhaustiveFacetCount(true);
+
+        JSONObject json = new JSONObject(request.toString());
+
+        assertThat(json.getBoolean("exhaustiveFacetCount"), is(true));
+    }
+
+    @Test
+    void buildsWithExhaustiveFacetCount() {
+        FacetSearchRequest request =
+                FacetSearchRequest.builder().facetName("genres").exhaustiveFacetCount(true).build();
+
+        assertThat(request.getExhaustiveFacetCount(), is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
## Summary

- add the optional `exhaustiveFacetCount` field to `FacetSearchRequest`
- include the field in facet-search JSON only when callers set it
- cover default omission, setter serialization, and builder access
- cover explicit `false`, which must serialize rather than be omitted

Closes #843

## Testing

- `./gradlew test` — 117 tests, 0 failures, including JaCoCo coverage verification
- `bash ./scripts/lint.sh` — passed, spotless reports no changes
- `./gradlew integrationTest` — completed with `NO-SOURCE`; no integration tests ran through that task

Run on Temurin 17, matching `sourceCompatibility` and CI. Three `SettingsHandlerTest` cases need a
Meilisearch instance on `localhost:7700`; they pass with one running and fail with a connection
error without it.

## Review follow-up

`exhaustiveFacetCount` is a boxed `Boolean`, so `null` means "omit" while `false` must still be
sent. The original tests only covered `true`, which would let a "falsy means omit" regression pass
unnoticed. `serializesExhaustiveFacetCountWhenFalse` closes that gap by asserting the key is
present and its value is `false`.

## AI assistance

AI assistance was used materially throughout. Codex helped inspect the repository and draft the
initial implementation and tests; Claude Code added the explicit-`false` regression test and ran
the verification listed above. The full diff was reviewed before submission. I can't attribute
every line to one tool or the other, so both are named rather than guessed at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting exhaustive facet counts during facet searches.
  * The option can be configured through setters or the request builder and is included in requests when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
