### PR TITLE
feat(stats): add indexSize and usedIndexSize to index stats response (#988)

### DIFF
--- a/src/main/java/com/meilisearch/sdk/model/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStats.java
@@ -14,31 +14,14 @@ import lombok.Setter;
 @Getter
 @Setter
 public class IndexStats {
-    @JsonProperty("numberOfDocuments")
     protected long numberOfDocuments;
-
-    @JsonProperty("isIndexing")
     protected boolean isIndexing;
-
-    @JsonProperty("fieldDistribution")
     protected Map<String, Integer> fieldDistribution;
-
-    @JsonProperty("rawDocumentDbSize")
     protected long rawDocumentDbSize;
-
-    @JsonProperty("avgDocumentSize")
     protected long avgDocumentSize;
-
-    @JsonProperty("numberOfEmbeddedDocuments")
     protected long numberOfEmbeddedDocuments;
-
-    @JsonProperty("numberOfEmbeddings")
     protected long numberOfEmbeddings;
-
-    @JsonProperty("indexSize")
     protected long indexSize;
-
-    @JsonProperty("usedIndexSize")
     protected long usedIndexSize;
 
     public IndexStats() {}
@@ -82,5 +65,10 @@ public class IndexStats {
         this.numberOfEmbeddings = numberOfEmbeddings;
         this.indexSize = indexSize;
         this.usedIndexSize = usedIndexSize;
+    }
+
+    @JsonProperty("isIndexing")
+    public boolean isIndexing() {
+        return isIndexing;
     }
 }

--- a/src/main/java/com/meilisearch/sdk/model/IndexStats.java
+++ b/src/main/java/com/meilisearch/sdk/model/IndexStats.java
@@ -1,7 +1,9 @@
 package com.meilisearch.sdk.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Stats data structure of a Meilisearch Index
@@ -10,14 +12,34 @@ import lombok.Getter;
  *     specification</a>
  */
 @Getter
+@Setter
 public class IndexStats {
+    @JsonProperty("numberOfDocuments")
     protected long numberOfDocuments;
+
+    @JsonProperty("isIndexing")
     protected boolean isIndexing;
+
+    @JsonProperty("fieldDistribution")
     protected Map<String, Integer> fieldDistribution;
+
+    @JsonProperty("rawDocumentDbSize")
     protected long rawDocumentDbSize;
+
+    @JsonProperty("avgDocumentSize")
     protected long avgDocumentSize;
+
+    @JsonProperty("numberOfEmbeddedDocuments")
     protected long numberOfEmbeddedDocuments;
+
+    @JsonProperty("numberOfEmbeddings")
     protected long numberOfEmbeddings;
+
+    @JsonProperty("indexSize")
+    protected long indexSize;
+
+    @JsonProperty("usedIndexSize")
+    protected long usedIndexSize;
 
     public IndexStats() {}
 
@@ -29,6 +51,28 @@ public class IndexStats {
             long avgDocumentSize,
             long numberOfEmbeddedDocuments,
             long numberOfEmbeddings) {
+        this(
+                numberOfDocuments,
+                isIndexing,
+                fieldDistribution,
+                rawDocumentDbSize,
+                avgDocumentSize,
+                numberOfEmbeddedDocuments,
+                numberOfEmbeddings,
+                0L,
+                0L);
+    }
+
+    public IndexStats(
+            long numberOfDocuments,
+            boolean isIndexing,
+            Map<String, Integer> fieldDistribution,
+            long rawDocumentDbSize,
+            long avgDocumentSize,
+            long numberOfEmbeddedDocuments,
+            long numberOfEmbeddings,
+            long indexSize,
+            long usedIndexSize) {
         this.numberOfDocuments = numberOfDocuments;
         this.isIndexing = isIndexing;
         this.fieldDistribution = fieldDistribution;
@@ -36,5 +80,7 @@ public class IndexStats {
         this.avgDocumentSize = avgDocumentSize;
         this.numberOfEmbeddedDocuments = numberOfEmbeddedDocuments;
         this.numberOfEmbeddings = numberOfEmbeddings;
+        this.indexSize = indexSize;
+        this.usedIndexSize = usedIndexSize;
     }
 }

--- a/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/GsonJsonHandlerTest.java
@@ -291,6 +291,20 @@ class GsonJsonHandlerTest {
         assertThat(decoded[0].getAttributePatterns(), arrayContaining("director", null, "genres"));
     }
 
+    @Test
+    void decodeIndexStatsWithIndexSizeAndUsedIndexSize() {
+        String json =
+                "{\"numberOfDocuments\":10,\"isIndexing\":false,\"fieldDistribution\":{},\"rawDocumentDbSize\":1024,\"avgDocumentSize\":102,\"numberOfEmbeddedDocuments\":0,\"numberOfEmbeddings\":0,\"indexSize\":2048,\"usedIndexSize\":1500}";
+
+        com.meilisearch.sdk.model.IndexStats indexStats =
+                classToTest.decode(json, com.meilisearch.sdk.model.IndexStats.class);
+
+        assertThat(indexStats, is(notNullValue()));
+        assertThat(indexStats.getNumberOfDocuments(), is(equalTo(10L)));
+        assertThat(indexStats.getIndexSize(), is(equalTo(2048L)));
+        assertThat(indexStats.getUsedIndexSize(), is(equalTo(1500L)));
+    }
+
     @Getter
     private static class Container {
         private Key key;

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -178,4 +178,18 @@ class JacksonJsonHandlerTest {
                         .getComparison(),
                 is(false));
     }
+
+    @Test
+    void decodeIndexStatsWithIndexSizeAndUsedIndexSize() throws Exception {
+        String json =
+                "{\"numberOfDocuments\":10,\"isIndexing\":false,\"fieldDistribution\":{},\"rawDocumentDbSize\":1024,\"avgDocumentSize\":102,\"numberOfEmbeddedDocuments\":0,\"numberOfEmbeddings\":0,\"indexSize\":2048,\"usedIndexSize\":1500}";
+
+        com.meilisearch.sdk.model.IndexStats indexStats =
+                classToTest.decode(json, com.meilisearch.sdk.model.IndexStats.class);
+
+        assertThat(indexStats, is(notNullValue()));
+        assertThat(indexStats.getNumberOfDocuments(), is(equalTo(10L)));
+        assertThat(indexStats.getIndexSize(), is(equalTo(2048L)));
+        assertThat(indexStats.getUsedIndexSize(), is(equalTo(1500L)));
+    }
 }

--- a/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
+++ b/src/test/java/com/meilisearch/sdk/json/JacksonJsonHandlerTest.java
@@ -192,4 +192,18 @@ class JacksonJsonHandlerTest {
         assertThat(indexStats.getIndexSize(), is(equalTo(2048L)));
         assertThat(indexStats.getUsedIndexSize(), is(equalTo(1500L)));
     }
+
+    @Test
+    void serializeIndexStats() throws Exception {
+        com.meilisearch.sdk.model.IndexStats indexStats =
+                new com.meilisearch.sdk.model.IndexStats(
+                        10, false, new java.util.HashMap<>(), 1024, 102, 0, 0, 2048, 1500);
+
+        String json = classToTest.encode(indexStats);
+
+        assertThat(json, org.hamcrest.Matchers.containsString("\"isIndexing\":false"));
+        assertThat(
+                json,
+                org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("\"indexing\"")));
+    }
 }


### PR DESCRIPTION
## Description

Resolves #988.

Updated \IndexStats\ model in \meilisearch-java\ SDK to include:
- \indexSize\: DB size of the index in bytes
- \usedIndexSize\: size of the used pages in the index DB

Added \@JsonProperty\ annotations and unit tests for both \GsonJsonHandlerTest\ and \JacksonJsonHandlerTest\.

## Related Issue

Fixes #988

## Tests

- [x] Unit tests updated & passing (\./gradlew test\)
- [x] Tested deserialization for both Gson & Jackson handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Index statistics now include total index size and used index size.
  * Existing index statistics constructors remain compatible, with new storage values defaulting to zero.

* **Bug Fixes**
  * Improved JSON serialization and deserialization of index statistics, including consistent `isIndexing` status handling.

* **Tests**
  * Added coverage for document, embedding, status, distribution, and storage statistics across supported JSON handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->