### PR TITLE
Return the finished Task from waitForTask and add a Client timeout overload

### DIFF
--- a/src/main/java/com/meilisearch/sdk/Client.java
+++ b/src/main/java/com/meilisearch/sdk/Client.java
@@ -356,10 +356,29 @@ public class Client {
      * Waits for a task to be processed
      *
      * @param uid Identifier of the requested Task
+     * @return Task in its final state (succeeded, failed or canceled)
      * @throws MeilisearchException if an error occurs or if timeout is reached
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
+     *     specification</a>
      */
-    public void waitForTask(int uid) throws MeilisearchException {
-        this.tasksHandler.waitForTask(uid);
+    public Task waitForTask(int uid) throws MeilisearchException {
+        return this.tasksHandler.waitForTask(uid);
+    }
+
+    /**
+     * Waits for a task to be processed
+     *
+     * @param uid Identifier of the requested Task
+     * @param timeoutInMs number of milliseconds before throwing an Exception
+     * @param intervalInMs number of milliseconds before requesting the status again
+     * @return Task in its final state (succeeded, failed or canceled)
+     * @throws MeilisearchException if an error occurs or if timeout is reached
+     * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
+     *     specification</a>
+     */
+    public Task waitForTask(int uid, int timeoutInMs, int intervalInMs)
+            throws MeilisearchException {
+        return this.tasksHandler.waitForTask(uid, timeoutInMs, intervalInMs);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/Index.java
+++ b/src/main/java/com/meilisearch/sdk/Index.java
@@ -1307,12 +1307,13 @@ public class Index implements Serializable {
      * Waits for a task to be processed
      *
      * @param taskId Identifier of the requested Task
+     * @return Task in its final state (succeeded, failed or canceled)
      * @throws MeilisearchException if an error occurs or if timeout is reached
      * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
      *     specification</a>
      */
-    public void waitForTask(int taskId) throws MeilisearchException {
-        this.tasksHandler.waitForTask(taskId, 5000, 50);
+    public Task waitForTask(int taskId) throws MeilisearchException {
+        return this.tasksHandler.waitForTask(taskId);
     }
 
     /**
@@ -1321,13 +1322,14 @@ public class Index implements Serializable {
      * @param taskId ID of the index update
      * @param timeoutInMs number of milliseconds before throwing an Exception
      * @param intervalInMs number of milliseconds before requesting the status again
+     * @return Task in its final state (succeeded, failed or canceled)
      * @throws MeilisearchException if an error occurs or if timeout is reached
      * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks#task-status">API
      *     specification</a>
      */
-    public void waitForTask(int taskId, int timeoutInMs, int intervalInMs)
+    public Task waitForTask(int taskId, int timeoutInMs, int intervalInMs)
             throws MeilisearchException {
-        this.tasksHandler.waitForTask(taskId, timeoutInMs, intervalInMs);
+        return this.tasksHandler.waitForTask(taskId, timeoutInMs, intervalInMs);
     }
 
     /**

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -150,7 +150,8 @@ public class TasksHandler {
             if (status != TaskStatus.ENQUEUED && status != TaskStatus.PROCESSING) {
                 return task;
             }
-            if (System.currentTimeMillis() >= deadline) {
+            long remainingMs = deadline - System.currentTimeMillis();
+            if (remainingMs <= 0) {
                 throw new MeilisearchTimeoutException(
                         "Task "
                                 + taskUid
@@ -161,7 +162,8 @@ public class TasksHandler {
                                 + ")");
             }
             try {
-                Thread.sleep(intervalInMs);
+                // never sleep past the deadline, even when intervalInMs exceeds timeoutInMs
+                Thread.sleep(Math.min(intervalInMs, remainingMs));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new MeilisearchTimeoutException(e);

--- a/src/main/java/com/meilisearch/sdk/TasksHandler.java
+++ b/src/main/java/com/meilisearch/sdk/TasksHandler.java
@@ -6,7 +6,6 @@ import com.meilisearch.sdk.http.URLBuilder;
 import com.meilisearch.sdk.model.*;
 import com.meilisearch.sdk.model.batch.req.BatchesQuery;
 import com.meilisearch.sdk.model.batch.res.Batch;
-import java.util.Date;
 
 /**
  * Class covering the Meilisearch Task API
@@ -14,6 +13,9 @@ import java.util.Date;
  * @see <a href="https://www.meilisearch.com/docs/reference/api/tasks">API specification</a>
  */
 public class TasksHandler {
+    static final int DEFAULT_WAIT_TIMEOUT_MS = 5000;
+    static final int DEFAULT_WAIT_INTERVAL_MS = 50;
+
     private final HttpClient httpClient;
 
     /**
@@ -124,10 +126,11 @@ public class TasksHandler {
      * Waits for a task to be processed
      *
      * @param taskUid Identifier of the Task
+     * @return Task in its final state (succeeded, failed or canceled)
      * @throws MeilisearchException if timeout is reached
      */
-    void waitForTask(int taskUid) throws MeilisearchException {
-        this.waitForTask(taskUid, 5000, 50);
+    Task waitForTask(int taskUid) throws MeilisearchException {
+        return this.waitForTask(taskUid, DEFAULT_WAIT_TIMEOUT_MS, DEFAULT_WAIT_INTERVAL_MS);
     }
 
     /**
@@ -136,28 +139,33 @@ public class TasksHandler {
      * @param taskUid Identifier of the Task
      * @param timeoutInMs number of milliseconds before throwing an Exception
      * @param intervalInMs number of milliseconds before requesting the status again
+     * @return Task in its final state (succeeded, failed or canceled)
      * @throws MeilisearchException if timeout is reached
      */
-    void waitForTask(int taskUid, int timeoutInMs, int intervalInMs) throws MeilisearchException {
-        Task task;
-        TaskStatus status = null;
-        long startTime = new Date().getTime();
-        long elapsedTime = 0;
-
-        while (status == null
-                || (status.equals(TaskStatus.ENQUEUED) || status.equals(TaskStatus.PROCESSING))) {
-            if (elapsedTime >= timeoutInMs) {
-                throw new MeilisearchTimeoutException();
+    Task waitForTask(int taskUid, int timeoutInMs, int intervalInMs) throws MeilisearchException {
+        long deadline = System.currentTimeMillis() + timeoutInMs;
+        while (true) {
+            Task task = this.getTask(taskUid);
+            TaskStatus status = task.getStatus();
+            if (status != TaskStatus.ENQUEUED && status != TaskStatus.PROCESSING) {
+                return task;
             }
-            task = this.getTask(taskUid);
-            status = task.getStatus();
+            if (System.currentTimeMillis() >= deadline) {
+                throw new MeilisearchTimeoutException(
+                        "Task "
+                                + taskUid
+                                + " not finished after "
+                                + timeoutInMs
+                                + "ms (last status: "
+                                + status
+                                + ")");
+            }
             try {
                 Thread.sleep(intervalInMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new MeilisearchTimeoutException();
+                throw new MeilisearchTimeoutException(e);
             }
-            elapsedTime = new Date().getTime() - startTime;
         }
     }
 

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -2,6 +2,7 @@ package com.meilisearch.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -14,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.meilisearch.integration.classes.AbstractIT;
 import com.meilisearch.integration.classes.TestData;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.exceptions.MeilisearchTimeoutException;
 import com.meilisearch.sdk.model.*;
 import com.meilisearch.sdk.utils.Movie;
 import java.time.Instant;
@@ -340,9 +342,58 @@ public class TasksTest extends AbstractIT {
         Index index = client.index(indexUid);
 
         TaskInfo task = index.addDocuments(this.testData.getRaw());
-        index.waitForTask(task.getTaskUid());
 
-        assertThrows(Exception.class, () -> index.waitForTask(task.getTaskUid(), 0, 50));
+        MeilisearchTimeoutException e =
+                assertThrows(
+                        MeilisearchTimeoutException.class,
+                        () -> index.waitForTask(task.getTaskUid(), 0, 50));
+        assertThat(e.getMessage(), containsString("Task " + task.getTaskUid()));
+        assertThat(e.getMessage(), containsString("0ms"));
+
+        index.waitForTask(task.getTaskUid());
+    }
+
+    /** Test waitForTask returns the finished task */
+    @Test
+    public void testWaitForTaskReturnsTask() throws Exception {
+        String indexUid = "WaitForTaskReturnsTask";
+        TaskInfo response = client.createIndex(indexUid);
+
+        Task task = client.waitForTask(response.getTaskUid());
+
+        assertThat(task.getUid(), is(equalTo(response.getTaskUid())));
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.SUCCEEDED)));
+        assertThat(task.getFinishedAt(), is(notNullValue()));
+
+        client.deleteIndex(indexUid);
+    }
+
+    /** Test waitForTask returns a failed task instead of throwing */
+    @Test
+    public void testWaitForTaskReturnsFailedTask() throws Exception {
+        String indexUid = "WaitForTaskReturnsFailedTask";
+        client.waitForTask(client.createIndex(indexUid).getTaskUid());
+
+        TaskInfo response = client.createIndex(indexUid);
+        Task task = client.waitForTask(response.getTaskUid());
+
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.FAILED)));
+        assertThat(task.getError().getCode(), is(equalTo("index_already_exists")));
+
+        client.deleteIndex(indexUid);
+    }
+
+    /** Test Client.waitForTask with timeoutInMs and intervalInMs */
+    @Test
+    public void testClientWaitForTaskTimeoutInMs() throws Exception {
+        String indexUid = "ClientWaitForTaskTimeoutInMs";
+        TaskInfo response = client.createIndex(indexUid);
+
+        Task task = client.waitForTask(response.getTaskUid(), 10000, 50);
+
+        assertThat(task.getStatus(), is(equalTo(TaskStatus.SUCCEEDED)));
+
+        client.deleteIndex(indexUid);
     }
 
     /** Test Tasks with Jackson Json Handler */

--- a/src/test/java/com/meilisearch/integration/TasksTest.java
+++ b/src/test/java/com/meilisearch/integration/TasksTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -349,6 +350,25 @@ public class TasksTest extends AbstractIT {
                         () -> index.waitForTask(task.getTaskUid(), 0, 50));
         assertThat(e.getMessage(), containsString("Task " + task.getTaskUid()));
         assertThat(e.getMessage(), containsString("0ms"));
+
+        index.waitForTask(task.getTaskUid());
+    }
+
+    /** Test waitForTask does not sleep past the timeout when intervalInMs exceeds it */
+    @Test
+    public void testWaitForTaskIntervalLongerThanTimeout() throws Exception {
+        String indexUid = "WaitForTaskIntervalLongerThanTimeout";
+        Index index = client.index(indexUid);
+        TaskInfo task = index.addDocuments(this.testData.getRaw());
+
+        long start = System.currentTimeMillis();
+        try {
+            index.waitForTask(task.getTaskUid(), 100, 10000);
+        } catch (MeilisearchTimeoutException ignored) {
+            // either outcome is fine, only the elapsed time matters
+        }
+
+        assertThat(System.currentTimeMillis() - start, is(lessThan(5000L)));
 
         index.waitForTask(task.getTaskUid());
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #991

## What does this PR do?
- `waitForTask` on `Client`, `Index` and `TasksHandler` now returns the `Task` in its final state (`succeeded`, `failed` or `canceled`) instead of `void`, matching the other official Meilisearch SDKs ([js](https://github.com/meilisearch/meilisearch-js/blob/a4e0707cf7de8e76d3c958dbcd615e9653c6d447/src/task.ts#L112-L136), [python](https://github.com/meilisearch/meilisearch-python/blob/80a562f5ec590cfb8bfc3d4a1d74bf1f7f8d4b86/meilisearch/client.py#L993-L998), [go](https://github.com/meilisearch/meilisearch-go/blob/75f1af413cbf6b7786c8934808770e102753a774/meilisearch.go#L490), [rust](https://github.com/meilisearch/meilisearch-rust/blob/14008e4aa0777872131fd01ed7e5ef2d2ef8663a/src/tasks.rs#L312-L317), [dotnet](https://github.com/meilisearch/meilisearch-dotnet/blob/ea0e4c84a723db0cdebfbc8621e4a277dc3b2dd0/src/Meilisearch/MeilisearchClient.cs#L261)). Callers can inspect `getStatus()` / `getError()` without a second `getTask` round trip.
- Adds `Client.waitForTask(int uid, int timeoutInMs, int intervalInMs)`. `Index` already had this overload; `Client` was stuck with the hard-coded 5000ms / 50ms.
- `MeilisearchTimeoutException` now carries a message: `Task <uid> not finished after <timeout>ms (last status: <status>)`. An interrupted wait keeps the interrupt flag and wraps the `InterruptedException` as the cause instead of throwing a bare exception.
- The polling loop returns as soon as a terminal status is observed instead of sleeping one more interval first.
- `failed` / `canceled` tasks are returned, not thrown, on purpose: this is what the SDKs linked above do and it keeps existing callers that wait on an intentionally failing task working.

Tests added in `TasksTest`: returned task for a succeeded task, returned task for a failed task (`index_already_exists`), the new `Client` overload, and the timeout message.

## Compatibility note
`void` to `Task` is source compatible (existing call sites that ignore the result still compile) but not binary compatible for consumers compiled against an older jar; they need a recompile.

`testWaitForTaskTimoutInMs` was adjusted: it used to wait on an already-finished task with a 0ms timeout and expect an exception. A finished task is now returned immediately, so the test waits on a freshly enqueued task instead.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task-waiting methods now return the completed task, including its status and details.
  * Added configurable timeout and polling intervals when waiting for tasks.
  * Client- and index-level task waiting now provide consistent results.

* **Bug Fixes**
  * Timeout errors now provide clearer information, including the task identifier and timeout duration.
  * Waiting no longer exceeds the configured timeout when the polling interval is longer than the remaining wait time.

* **Tests**
  * Added coverage for successful and failed tasks, configurable timeouts, and timeout messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->